### PR TITLE
Fix CI formatting and clippy checks

### DIFF
--- a/src/ai/loader.rs
+++ b/src/ai/loader.rs
@@ -1,5 +1,5 @@
 use super::review::*;
-use sha2::{Sha256, Digest};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
@@ -85,31 +85,25 @@ pub fn load_ai_state(repo_root: &str, current_diff_hash: &str) -> AiState {
         // TODO(risk:minor): Deserialization errors are silently swallowed (`Err(_) => {}`).
         // A malformed sidecar will appear as if the file doesn't exist; there is no
         // user-visible indication that a parse failure occurred.
-        match serde_json::from_str::<ErReview>(&content) {
-            Ok(review) => {
-                state.is_stale = review.diff_hash != current_diff_hash;
-                state.review = Some(review);
-            }
-            Err(_) => {}
+        if let Ok(review) = serde_json::from_str::<ErReview>(&content) {
+            state.is_stale = review.diff_hash != current_diff_hash;
+            state.review = Some(review);
         }
     }
 
     // Load .er-order.json
     let order_path = Path::new(repo_root).join(".er-order.json");
     if let Ok(content) = std::fs::read_to_string(&order_path) {
-        match serde_json::from_str::<ErOrder>(&content) {
-            Ok(order) => {
-                // Check staleness against review hash or independently
-                if !state.is_stale && order.diff_hash != current_diff_hash {
-                    state.is_stale = true;
-                }
-                // TODO(risk:medium): `ErOrder.order` is an unbounded Vec<OrderEntry> from
-                // untrusted JSON with no size cap. A crafted file could list tens of
-                // thousands of paths, consuming memory and making any O(n) scan over them
-                // (e.g. file-tree display ordering) noticeably slow.
-                state.order = Some(order);
+        if let Ok(order) = serde_json::from_str::<ErOrder>(&content) {
+            // Check staleness against review hash or independently
+            if !state.is_stale && order.diff_hash != current_diff_hash {
+                state.is_stale = true;
             }
-            Err(_) => {}
+            // TODO(risk:medium): `ErOrder.order` is an unbounded Vec<OrderEntry> from
+            // untrusted JSON with no size cap. A crafted file could list tens of
+            // thousands of paths, consuming memory and making any O(n) scan over them
+            // (e.g. file-tree display ordering) noticeably slow.
+            state.order = Some(order);
         }
     }
 
@@ -127,48 +121,39 @@ pub fn load_ai_state(repo_root: &str, current_diff_hash: &str) -> AiState {
     // Load .er-checklist.json
     let checklist_path = Path::new(repo_root).join(".er-checklist.json");
     if let Ok(content) = std::fs::read_to_string(&checklist_path) {
-        match serde_json::from_str::<ErChecklist>(&content) {
-            Ok(checklist) => {
-                if !state.is_stale && checklist.diff_hash != current_diff_hash {
-                    state.is_stale = true;
-                }
-                state.checklist = Some(checklist);
+        if let Ok(checklist) = serde_json::from_str::<ErChecklist>(&content) {
+            if !state.is_stale && checklist.diff_hash != current_diff_hash {
+                state.is_stale = true;
             }
-            Err(_) => {}
+            state.checklist = Some(checklist);
         }
     }
 
     // Load .er-questions.json (personal review questions)
     let questions_path = Path::new(repo_root).join(".er-questions.json");
     if let Ok(content) = std::fs::read_to_string(&questions_path) {
-        match serde_json::from_str::<ErQuestions>(&content) {
-            Ok(mut questions) => {
-                // Per-comment staleness: mark all stale if diff changed
-                if questions.diff_hash != current_diff_hash {
-                    for q in &mut questions.questions {
-                        q.stale = true;
-                    }
+        if let Ok(mut questions) = serde_json::from_str::<ErQuestions>(&content) {
+            // Per-comment staleness: mark all stale if diff changed
+            if questions.diff_hash != current_diff_hash {
+                for q in &mut questions.questions {
+                    q.stale = true;
                 }
-                state.questions = Some(questions);
             }
-            Err(_) => {}
+            state.questions = Some(questions);
         }
     }
 
     // Load .er-github-comments.json (GitHub PR comments)
     let gh_comments_path = Path::new(repo_root).join(".er-github-comments.json");
     if let Ok(content) = std::fs::read_to_string(&gh_comments_path) {
-        match serde_json::from_str::<ErGitHubComments>(&content) {
-            Ok(mut gh_comments) => {
-                // Per-comment staleness
-                if gh_comments.diff_hash != current_diff_hash {
-                    for c in &mut gh_comments.comments {
-                        c.stale = true;
-                    }
+        if let Ok(mut gh_comments) = serde_json::from_str::<ErGitHubComments>(&content) {
+            // Per-comment staleness
+            if gh_comments.diff_hash != current_diff_hash {
+                for c in &mut gh_comments.comments {
+                    c.stale = true;
                 }
-                state.github_comments = Some(gh_comments);
             }
-            Err(_) => {}
+            state.github_comments = Some(gh_comments);
         }
     }
 
@@ -181,16 +166,44 @@ pub fn load_ai_state(repo_root: &str, current_diff_hash: &str) -> AiState {
     if state.questions.is_none() && state.github_comments.is_none() {
         let feedback_path = Path::new(repo_root).join(".er-feedback.json");
         if let Ok(content) = std::fs::read_to_string(&feedback_path) {
-            match serde_json::from_str::<ErFeedback>(&content) {
-                Ok(feedback) => {
-                    state.feedback = Some(feedback);
-                }
-                Err(_) => {}
+            if let Ok(feedback) = serde_json::from_str::<ErFeedback>(&content) {
+                state.feedback = Some(feedback);
             }
         }
     }
 
     state
+}
+
+/// Get the mtime of the most recently modified .er-* file
+// TODO(risk:medium): TOCTOU race: mtime is read here, but the actual file read happens
+// later in `load_ai_state`. Between these two calls another process (e.g. a concurrent
+// AI skill run) can overwrite the file, so the mtime poll can indicate "no change" while
+// `load_ai_state` reads a newer version, or vice-versa (it shows "changed" but by the
+// time `load_ai_state` runs the file is already overwritten again with identical content).
+// The impact is a missed or spurious reload — incorrect data displayed until the next tick.
+pub fn latest_er_mtime(repo_root: &str) -> Option<std::time::SystemTime> {
+    let root = Path::new(repo_root);
+    let files = [
+        ".er-review.json",
+        ".er-order.json",
+        ".er-summary.md",
+        ".er-checklist.json",
+        ".er-feedback.json",
+        ".er-questions.json",
+        ".er-github-comments.json",
+    ];
+
+    files
+        .iter()
+        .filter_map(|name| {
+            let path = root.join(name);
+            // TODO(risk:minor): `metadata().modified()` can fail on filesystems that do not
+            // support mtime (e.g. FAT32, some network mounts). The `ok()?` silently drops
+            // these files from the max calculation, meaning their updates are never detected.
+            std::fs::metadata(&path).ok()?.modified().ok()
+        })
+        .max()
 }
 
 #[cfg(test)]
@@ -271,38 +284,4 @@ mod tests {
         let h2 = compute_per_file_hashes(diff_v2);
         assert_ne!(h1["x.rs"], h2["x.rs"]);
     }
-}
-
-/// Get the mtime of the most recently modified .er-* file
-// TODO(risk:medium): TOCTOU race: mtime is read here, but the actual file read happens
-// later in `load_ai_state`. Between these two calls another process (e.g. a concurrent
-// AI skill run) can overwrite the file, so the mtime poll can indicate "no change" while
-// `load_ai_state` reads a newer version, or vice-versa (it shows "changed" but by the
-// time `load_ai_state` runs the file is already overwritten again with identical content).
-// The impact is a missed or spurious reload — incorrect data displayed until the next tick.
-pub fn latest_er_mtime(repo_root: &str) -> Option<std::time::SystemTime> {
-    let root = Path::new(repo_root);
-    let files = [
-        ".er-review.json",
-        ".er-order.json",
-        ".er-summary.md",
-        ".er-checklist.json",
-        ".er-feedback.json",
-        ".er-questions.json",
-        ".er-github-comments.json",
-    ];
-
-    files
-        .iter()
-        .filter_map(|name| {
-            let path = root.join(name);
-            // TODO(risk:minor): `metadata().modified()` can fail on filesystems that do not
-            // support mtime (e.g. FAT32, some network mounts). The `ok()?` silently drops
-            // these files from the max calculation, meaning their updates are never detected.
-            std::fs::metadata(&path)
-                .ok()?
-                .modified()
-                .ok()
-        })
-        .max()
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,7 +1,7 @@
-mod review;
 mod loader;
 mod relocate;
+mod review;
 
-pub use review::*;
 pub use loader::*;
 pub use relocate::*;
+pub use review::*;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,8 @@
 pub mod filter;
 mod state;
 
-pub use state::{App, ConfirmAction, DiffMode, DirEntry, InputMode, OverlayData, SplitSide, TabState};
-pub(crate) use state::chrono_now;
 pub use crate::git::Worktree;
+pub(crate) use state::chrono_now;
+pub use state::{
+    App, ConfirmAction, DiffMode, DirEntry, InputMode, OverlayData, SplitSide, TabState,
+};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ErConfig {
     #[serde(default)]
     pub features: FeatureFlags,
@@ -120,18 +120,6 @@ fn default_agent_args() -> Vec<String> {
     vec!["--print".into(), "-p".into(), "{prompt}".into()]
 }
 
-impl Default for ErConfig {
-    fn default() -> Self {
-        Self {
-            features: FeatureFlags::default(),
-            agent: AgentConfig::default(),
-            display: DisplayConfig::default(),
-            watched: WatchedConfig::default(),
-            hints: HintConfig::default(),
-        }
-    }
-}
-
 impl Default for FeatureFlags {
     fn default() -> Self {
         Self {
@@ -169,8 +157,8 @@ impl Default for DisplayConfig {
 /// Merging is deep: individual fields within sections (e.g. `[features]`) override independently.
 pub fn load_config(repo_root: &str) -> ErConfig {
     let local_path = format!("{repo_root}/.er-config.toml");
-    let global_path = dirs::config_dir()
-        .map(|d| d.join("er/config.toml").to_string_lossy().to_string());
+    let global_path =
+        dirs::config_dir().map(|d| d.join("er/config.toml").to_string_lossy().to_string());
 
     let global_table = global_path
         .and_then(|p| std::fs::read_to_string(p).ok())

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,23 +1,17 @@
 mod diff;
 mod status;
 
+#[allow(unused_imports)]
 pub use diff::{
-    DiffFile, DiffFileHeader, DiffHunk, DiffLine, LineType,
-    parse_diff, parse_diff_headers, parse_file_at_offset, header_to_stub,
-    compact_files, compact_files_match, expand_compacted_file, CompactionConfig,
-    LAZY_PARSE_THRESHOLD,
+    compact_files, compact_files_match, expand_compacted_file, header_to_stub, parse_diff,
+    parse_diff_headers, parse_file_at_offset, CompactionConfig, DiffFile, DiffFileHeader, DiffHunk,
+    DiffLine, LineType, LAZY_PARSE_THRESHOLD,
 };
 pub use status::{
-    FileStatus, Worktree, CommitInfo, WatchedFile,
-    detect_base_branch_in,
-    get_repo_root,
-    get_repo_root_in,
-    get_current_branch_in,
-    git_diff_raw, git_diff_raw_file,
-    list_worktrees,
-    git_stage_file, git_unstage_file, git_stage_all, git_commit,
-    git_log_branch, git_diff_commit,
-    discover_watched_files, verify_gitignored, save_snapshot,
-    read_watched_file_content, diff_watched_file_snapshot,
-    is_merge_in_progress, git_diff_conflicts, unmerged_files,
+    detect_base_branch_in, diff_watched_file_snapshot, discover_watched_files,
+    get_current_branch_in, get_repo_root, get_repo_root_in, git_commit, git_diff_commit,
+    git_diff_conflicts, git_diff_raw, git_diff_raw_file, git_log_branch, git_stage_all,
+    git_stage_file, git_unstage_file, is_merge_in_progress, list_worktrees,
+    read_watched_file_content, save_snapshot, unmerged_files, verify_gitignored, CommitInfo,
+    FileStatus, WatchedFile, Worktree,
 };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,5 @@
-mod file_tree;
 mod diff_view;
+mod file_tree;
 pub mod highlight;
 mod overlay;
 pub mod panel;
@@ -10,8 +10,8 @@ mod utils;
 
 use crate::app::{App, OverlayData};
 use highlight::Highlighter;
-use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::Frame;
 
 /// Render the entire UI
 pub fn draw(f: &mut Frame, app: &App, hl: &mut Highlighter) {
@@ -26,8 +26,8 @@ pub fn draw(f: &mut Frame, app: &App, hl: &mut Highlighter) {
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(top_height),   // top bar (dynamic rows)
-            Constraint::Min(1),              // main content
+            Constraint::Length(top_height),    // top bar (dynamic rows)
+            Constraint::Min(1),                // main content
             Constraint::Length(bottom_height), // bottom bar (dynamic rows)
         ])
         .split(f.area());
@@ -54,10 +54,7 @@ pub fn draw(f: &mut Frame, app: &App, hl: &mut Highlighter) {
         // 2-col layout: file_tree + diff
         let main_area = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(32),
-                Constraint::Min(1),
-            ])
+            .constraints([Constraint::Length(32), Constraint::Min(1)])
             .split(outer[1]);
         file_tree::render(f, main_area[0], app);
         if app.split_diff_active(&app.config) {

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -5,34 +5,40 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{DirEntry, OverlayData, Worktree};
 use super::styles;
+use crate::app::{DirEntry, OverlayData, Worktree};
 
 /// Render the active overlay on top of the main UI
 /// Note: Settings overlay is rendered separately in ui/mod.rs since it needs App access.
 pub fn render_overlay(f: &mut Frame, area: Rect, overlay: &OverlayData) {
     match overlay {
-        OverlayData::WorktreePicker { worktrees, selected } => {
+        OverlayData::WorktreePicker {
+            worktrees,
+            selected,
+        } => {
             render_worktree_picker(f, area, worktrees, *selected);
         }
-        OverlayData::DirectoryBrowser { current_path, entries, selected } => {
+        OverlayData::DirectoryBrowser {
+            current_path,
+            entries,
+            selected,
+        } => {
             render_directory_browser(f, area, current_path, entries, *selected);
         }
         OverlayData::Settings { .. } => {
             // Handled in ui/mod.rs draw()
         }
-        OverlayData::FilterHistory { history, selected, preset_count } => {
+        OverlayData::FilterHistory {
+            history,
+            selected,
+            preset_count,
+        } => {
             render_filter_history(f, area, history, *selected, *preset_count);
         }
     }
 }
 
-fn render_worktree_picker(
-    f: &mut Frame,
-    area: Rect,
-    worktrees: &[Worktree],
-    selected: usize,
-) {
+fn render_worktree_picker(f: &mut Frame, area: Rect, worktrees: &[Worktree], selected: usize) {
     let popup_height = (worktrees.len() as u16 + 2).min(area.height.saturating_sub(6));
     let popup_width = 70u16.min(area.width.saturating_sub(6));
     let popup = centered_rect(popup_width, popup_height, area);
@@ -48,10 +54,7 @@ fn render_worktree_picker(
             let marker = if is_sel { "▶ " } else { "  " };
 
             let line = Line::from(vec![
-                Span::styled(
-                    marker,
-                    ratatui::style::Style::default().fg(styles::CYAN),
-                ),
+                Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
                 Span::styled(
                     format!("{:<20}", wt.branch),
                     if is_sel {
@@ -60,10 +63,7 @@ fn render_worktree_picker(
                         ratatui::style::Style::default().fg(styles::TEXT)
                     },
                 ),
-                Span::styled(
-                    &wt.path,
-                    ratatui::style::Style::default().fg(styles::DIM),
-                ),
+                Span::styled(&wt.path, ratatui::style::Style::default().fg(styles::DIM)),
             ]);
 
             let style = if is_sel {
@@ -96,7 +96,9 @@ fn render_directory_browser(
     entries: &[DirEntry],
     selected: usize,
 ) {
-    let popup_height = (entries.len() as u16 + 2).min(area.height.saturating_sub(6)).max(5);
+    let popup_height = (entries.len() as u16 + 2)
+        .min(area.height.saturating_sub(6))
+        .max(5);
     let popup_width = 70u16.min(area.width.saturating_sub(6));
     let popup = centered_rect(popup_width, popup_height, area);
 
@@ -129,9 +131,7 @@ fn render_directory_browser(
             let is_sel = idx == selected;
             let marker = if is_sel { "▶ " } else { "  " };
 
-            let icon = if entry.is_git_repo {
-                " "
-            } else if entry.is_dir {
+            let icon = if entry.is_git_repo || entry.is_dir {
                 " "
             } else {
                 "  "
@@ -146,16 +146,16 @@ fn render_directory_browser(
             };
 
             let mut spans = vec![
-                Span::styled(
-                    marker,
-                    ratatui::style::Style::default().fg(styles::CYAN),
-                ),
+                Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
                 Span::styled(icon, name_style),
-                Span::styled(&entry.name, if is_sel {
-                    ratatui::style::Style::default().fg(styles::BRIGHT)
-                } else {
-                    name_style
-                }),
+                Span::styled(
+                    &entry.name,
+                    if is_sel {
+                        ratatui::style::Style::default().fg(styles::BRIGHT)
+                    } else {
+                        name_style
+                    },
+                ),
             ];
 
             if entry.is_git_repo {
@@ -217,7 +217,9 @@ fn render_filter_history(
 
     let separator_lines = if !history.is_empty() { 1 } else { 0 };
     let total_rows = preset_count + separator_lines + history.len();
-    let popup_height = (total_rows as u16 + 2).min(area.height.saturating_sub(6)).max(4);
+    let popup_height = (total_rows as u16 + 2)
+        .min(area.height.saturating_sub(6))
+        .max(4);
     let popup_width = 60u16.min(area.width.saturating_sub(6));
     let popup = centered_rect(popup_width, popup_height, area);
 
@@ -231,16 +233,17 @@ fn render_filter_history(
         let marker = if is_sel { "▶ " } else { "  " };
 
         let line = Line::from(vec![
-            Span::styled(
-                marker,
-                ratatui::style::Style::default().fg(styles::CYAN),
-            ),
+            Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
             Span::styled(
                 format!("{:<10}", preset.name),
                 if is_sel {
-                    ratatui::style::Style::default().fg(styles::BRIGHT).add_modifier(ratatui::style::Modifier::BOLD)
+                    ratatui::style::Style::default()
+                        .fg(styles::BRIGHT)
+                        .add_modifier(ratatui::style::Modifier::BOLD)
                 } else {
-                    ratatui::style::Style::default().fg(styles::BLUE).add_modifier(ratatui::style::Modifier::BOLD)
+                    ratatui::style::Style::default()
+                        .fg(styles::BLUE)
+                        .add_modifier(ratatui::style::Modifier::BOLD)
                 },
             ),
             Span::styled(
@@ -260,10 +263,13 @@ fn render_filter_history(
 
     // Separator + history section
     if !history.is_empty() {
-        items.push(ListItem::new(Line::from(Span::styled(
-            "── history ──",
-            ratatui::style::Style::default().fg(styles::MUTED),
-        ))).style(ratatui::style::Style::default().bg(styles::PANEL)));
+        items.push(
+            ListItem::new(Line::from(Span::styled(
+                "── history ──",
+                ratatui::style::Style::default().fg(styles::MUTED),
+            )))
+            .style(ratatui::style::Style::default().bg(styles::PANEL)),
+        );
 
         for (idx, expr) in history.iter().enumerate() {
             let abs_idx = preset_count + idx;
@@ -271,10 +277,7 @@ fn render_filter_history(
             let marker = if is_sel { "▶ " } else { "  " };
 
             let line = Line::from(vec![
-                Span::styled(
-                    marker,
-                    ratatui::style::Style::default().fg(styles::YELLOW),
-                ),
+                Span::styled(marker, ratatui::style::Style::default().fg(styles::YELLOW)),
                 Span::styled(
                     expr.as_str(),
                     if is_sel {

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -6,10 +6,10 @@ use ratatui::{
     Frame,
 };
 
-use crate::ai::{CommentRef, CommentType, PanelContent, ReviewFocus, RiskLevel};
-use crate::app::App;
 use super::styles;
 use super::utils::word_wrap;
+use crate::ai::{CommentRef, CommentType, PanelContent, ReviewFocus, RiskLevel};
+use crate::app::App;
 
 // PR check conclusion display helpers
 fn check_icon(conclusion: Option<&str>) -> (&'static str, ratatui::style::Color) {
@@ -51,7 +51,9 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
     let has_pr = tab.pr_data.is_some();
 
     let file_style = if content == PanelContent::FileDetail {
-        Style::default().fg(styles::PURPLE).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(styles::PURPLE)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(styles::DIM)
     };
@@ -64,7 +66,9 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
 
     if has_ai {
         let ai_style = if content == PanelContent::AiSummary {
-            Style::default().fg(styles::PURPLE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(styles::PURPLE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(styles::DIM)
         };
@@ -75,7 +79,9 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
 
     if has_pr {
         let pr_style = if content == PanelContent::PrOverview {
-            Style::default().fg(styles::PURPLE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(styles::PURPLE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(styles::DIM)
         };
@@ -86,7 +92,9 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
 
     if tab.symbol_refs.is_some() {
         let refs_style = if content == PanelContent::SymbolRefs {
-            Style::default().fg(styles::PURPLE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(styles::PURPLE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(styles::DIM)
         };
@@ -153,7 +161,9 @@ fn render_file_detail<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
     // File path header
     lines.push(Line::from(vec![Span::styled(
         format!(" {}", path),
-        Style::default().fg(styles::TEXT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(styles::TEXT)
+            .add_modifier(Modifier::BOLD),
     )]));
     lines.push(Line::from(""));
 
@@ -282,18 +292,12 @@ fn render_file_detail<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
         let author = comment.author();
 
         let mut header_spans = vec![
-            Span::styled(
-                format!(" {} ", bullet),
-                Style::default().fg(accent),
-            ),
+            Span::styled(format!(" {} ", bullet), Style::default().fg(accent)),
             Span::styled(
                 author.to_string(),
                 Style::default().fg(accent).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                format!("  {}", target),
-                Style::default().fg(styles::DIM),
-            ),
+            Span::styled(format!("  {}", target), Style::default().fg(styles::DIM)),
         ];
 
         if comment.is_stale() {
@@ -309,10 +313,7 @@ fn render_file_detail<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
                 Style::default().fg(styles::GREEN),
             ));
         } else if comment.comment_type() == CommentType::GitHubComment {
-            header_spans.push(Span::styled(
-                "  ↑ local",
-                Style::default().fg(styles::DIM),
-            ));
+            header_spans.push(Span::styled("  ↑ local", Style::default().fg(styles::DIM)));
         }
 
         // Reply indicator
@@ -472,7 +473,11 @@ fn render_ai_summary<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate::
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("{}{} ", prefix, fr.risk.symbol()),
-                    if is_selected { risk_style.bg(bg) } else { risk_style },
+                    if is_selected {
+                        risk_style.bg(bg)
+                    } else {
+                        risk_style
+                    },
                 ),
                 Span::styled(*path, path_style),
             ]));
@@ -502,7 +507,9 @@ fn render_ai_summary<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate::
             .fg(styles::CYAN)
             .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
     } else {
-        Style::default().fg(styles::CYAN).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(styles::CYAN)
+            .add_modifier(Modifier::BOLD)
     };
     lines.push(Line::from(vec![Span::styled(
         " ─── Review Checklist ───",
@@ -607,11 +614,15 @@ fn render_pr_overview<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
     lines.push(Line::from(vec![
         Span::styled(
             format!(" #{} ", pr.number),
-            Style::default().fg(styles::CYAN).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(styles::CYAN)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             pr.state.to_lowercase(),
-            Style::default().fg(state_color).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(state_color)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("  @{}", pr.author),
@@ -625,7 +636,9 @@ fn render_pr_overview<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
     for wrapped in word_wrap(&pr.title, max_w) {
         lines.push(Line::from(vec![Span::styled(
             format!(" {}", wrapped),
-            Style::default().fg(styles::BRIGHT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(styles::BRIGHT)
+                .add_modifier(Modifier::BOLD),
         )]));
     }
     lines.push(Line::from(""));
@@ -689,19 +702,20 @@ fn render_pr_overview<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
             // string yielding just "…". Enforce a minimum panel width at the layout level
             // to make this branch unreachable.
             let check_name = if check.name.chars().count() > max_w.saturating_sub(12) {
-                format!("{}…", check.name.chars().take(max_w.saturating_sub(13)).collect::<String>())
+                format!(
+                    "{}…",
+                    check
+                        .name
+                        .chars()
+                        .take(max_w.saturating_sub(13))
+                        .collect::<String>()
+                )
             } else {
                 check.name.clone()
             };
             lines.push(Line::from(vec![
-                Span::styled(
-                    format!(" {} ", icon),
-                    Style::default().fg(color),
-                ),
-                Span::styled(
-                    check_name,
-                    Style::default().fg(styles::TEXT),
-                ),
+                Span::styled(format!(" {} ", icon), Style::default().fg(color)),
+                Span::styled(check_name, Style::default().fg(styles::TEXT)),
                 Span::styled(
                     format!("  {}", status_text),
                     Style::default().fg(styles::MUTED),
@@ -719,18 +733,22 @@ fn render_pr_overview<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
         )]));
         lines.push(Line::from(""));
         // Deduplicate: keep latest review state per reviewer
-        let mut seen: std::collections::HashMap<&str, &crate::github::ReviewerStatus> = std::collections::HashMap::new();
+        let mut seen: std::collections::HashMap<&str, &crate::github::ReviewerStatus> =
+            std::collections::HashMap::new();
         for r in &pr.reviewers {
             seen.insert(&r.login, r);
         }
-        let mut sorted_reviewers: Vec<&crate::github::ReviewerStatus> = seen.values().copied().collect();
+        let mut sorted_reviewers: Vec<&crate::github::ReviewerStatus> =
+            seen.values().copied().collect();
         sorted_reviewers.sort_by(|a, b| a.login.cmp(&b.login));
         for reviewer in sorted_reviewers {
             let (label, color) = review_state_style(&reviewer.state);
             lines.push(Line::from(vec![
                 Span::styled(
                     format!(" @{}  ", reviewer.login),
-                    Style::default().fg(styles::TEXT).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(styles::TEXT)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(label, Style::default().fg(color)),
             ]));
@@ -758,7 +776,9 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
         Span::styled(" Symbol: ", Style::default().fg(styles::DIM)),
         Span::styled(
             &*state.symbol,
-            Style::default().fg(styles::BLUE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(styles::BLUE)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
     lines.push(Line::from(""));
@@ -770,7 +790,9 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
     if !state.in_diff.is_empty() {
         lines.push(Line::from(vec![Span::styled(
             format!(" In this diff ({})", state.in_diff.len()),
-            Style::default().fg(styles::CYAN).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(styles::CYAN)
+                .add_modifier(Modifier::BOLD),
         )]));
 
         for entry in &state.in_diff {
@@ -778,7 +800,13 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
             let loc = format!(" {}:{}", entry.file, entry.line_num);
             let content = entry.line_content.trim();
             let truncated = if content.chars().count() > max_w {
-                format!("{}…", content.chars().take(max_w.saturating_sub(1)).collect::<String>())
+                format!(
+                    "{}…",
+                    content
+                        .chars()
+                        .take(max_w.saturating_sub(1))
+                        .collect::<String>()
+                )
             } else {
                 content.to_string()
             };
@@ -789,7 +817,10 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
                 Style::default().fg(styles::TEXT)
             };
             let loc_style = if is_selected {
-                Style::default().fg(styles::BLUE).bg(styles::PANEL).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(styles::BLUE)
+                    .bg(styles::PANEL)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(styles::BLUE)
             };
@@ -809,7 +840,9 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
     if !state.external.is_empty() {
         lines.push(Line::from(vec![Span::styled(
             format!(" Other files ({})", state.external.len()),
-            Style::default().fg(styles::DIM).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(styles::DIM)
+                .add_modifier(Modifier::BOLD),
         )]));
 
         for entry in &state.external {
@@ -817,7 +850,13 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
             let loc = format!(" {}:{}", entry.file, entry.line_num);
             let content = entry.line_content.trim();
             let truncated = if content.chars().count() > max_w {
-                format!("{}…", content.chars().take(max_w.saturating_sub(1)).collect::<String>())
+                format!(
+                    "{}…",
+                    content
+                        .chars()
+                        .take(max_w.saturating_sub(1))
+                        .collect::<String>()
+                )
             } else {
                 content.to_string()
             };
@@ -828,7 +867,10 @@ fn render_symbol_refs<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a crate:
                 Style::default().fg(styles::DIM)
             };
             let loc_style = if is_selected {
-                Style::default().fg(styles::MUTED).bg(styles::PANEL).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(styles::MUTED)
+                    .bg(styles::PANEL)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(styles::MUTED)
             };

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5,9 +5,9 @@ use ratatui::{
     Frame,
 };
 
+use super::styles;
 use crate::app::App;
 use crate::config::{self, SettingsItem};
-use super::styles;
 
 /// Render the settings overlay
 pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
@@ -35,17 +35,14 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
 
         match item {
             SettingsItem::SectionHeader(title) => {
-                let line = Line::from(vec![
-                    Span::styled(
-                        format!("  {}", title),
-                        ratatui::style::Style::default()
-                            .fg(styles::CYAN)
-                            .add_modifier(ratatui::style::Modifier::BOLD),
-                    ),
-                ]);
+                let line = Line::from(vec![Span::styled(
+                    format!("  {}", title),
+                    ratatui::style::Style::default()
+                        .fg(styles::CYAN)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                )]);
                 list_items.push(
-                    ListItem::new(line)
-                        .style(ratatui::style::Style::default().bg(styles::PANEL)),
+                    ListItem::new(line).style(ratatui::style::Style::default().bg(styles::PANEL)),
                 );
             }
             SettingsItem::BoolToggle { label, get, .. } => {
@@ -54,10 +51,7 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
                 let checkbox = if value { "[x]" } else { "[ ]" };
 
                 let line = Line::from(vec![
-                    Span::styled(
-                        marker,
-                        ratatui::style::Style::default().fg(styles::CYAN),
-                    ),
+                    Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
                     Span::styled(
                         format!("{} ", checkbox),
                         ratatui::style::Style::default().fg(if value {
@@ -89,10 +83,7 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
                 let marker = if is_sel { "▸ " } else { "  " };
 
                 let line = Line::from(vec![
-                    Span::styled(
-                        marker,
-                        ratatui::style::Style::default().fg(styles::CYAN),
-                    ),
+                    Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
                     Span::styled(
                         label.as_str(),
                         if is_sel {
@@ -120,10 +111,7 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
                 let marker = if is_sel { "▸ " } else { "  " };
 
                 let line = Line::from(vec![
-                    Span::styled(
-                        marker,
-                        ratatui::style::Style::default().fg(styles::CYAN),
-                    ),
+                    Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN)),
                     Span::styled(
                         label.as_str(),
                         ratatui::style::Style::default().fg(styles::DIM),
@@ -153,10 +141,7 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
                 .fg(styles::TEXT)
                 .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        Span::styled(
-            " nav  ",
-            ratatui::style::Style::default().fg(styles::DIM),
-        ),
+        Span::styled(" nav  ", ratatui::style::Style::default().fg(styles::DIM)),
         Span::styled(
             "Space/Enter",
             ratatui::style::Style::default()
@@ -173,29 +158,20 @@ pub fn render_settings(f: &mut Frame, area: Rect, app: &App, selected: usize) {
                 .fg(styles::TEXT)
                 .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        Span::styled(
-            " save  ",
-            ratatui::style::Style::default().fg(styles::DIM),
-        ),
+        Span::styled(" save  ", ratatui::style::Style::default().fg(styles::DIM)),
         Span::styled(
             "Esc",
             ratatui::style::Style::default()
                 .fg(styles::TEXT)
                 .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        Span::styled(
-            " cancel",
-            ratatui::style::Style::default().fg(styles::DIM),
-        ),
+        Span::styled(" cancel", ratatui::style::Style::default().fg(styles::DIM)),
     ]);
     list_items.push(
-        ListItem::new(Line::from(""))
-            .style(ratatui::style::Style::default().bg(styles::PANEL)),
+        ListItem::new(Line::from("")).style(ratatui::style::Style::default().bg(styles::PANEL)),
     );
-    list_items.push(
-        ListItem::new(help_line)
-            .style(ratatui::style::Style::default().bg(styles::PANEL)),
-    );
+    list_items
+        .push(ListItem::new(help_line).style(ratatui::style::Style::default().bg(styles::PANEL)));
 
     let block = Block::default()
         .title(Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -5,9 +5,9 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, DiffMode, InputMode, ConfirmAction};
-use crate::ai::PanelContent;
 use super::styles;
+use crate::ai::PanelContent;
+use crate::app::{App, ConfirmAction, DiffMode, InputMode};
 
 /// Compute the display width of a list of spans
 fn spans_width(spans: &[Span]) -> usize {
@@ -140,27 +140,48 @@ pub fn render_top_bar(f: &mut Frame, area: Rect, app: &App) {
     let mut modes: Vec<Span> = vec![Span::raw(" ")];
     if app.config.features.view_branch {
         modes.push(Span::styled(" 1 ", mode_style(DiffMode::Branch, tab.mode)));
-        modes.push(Span::styled(" BRANCH ", mode_style(DiffMode::Branch, tab.mode)));
+        modes.push(Span::styled(
+            " BRANCH ",
+            mode_style(DiffMode::Branch, tab.mode),
+        ));
         modes.push(Span::raw(" "));
     }
     if app.config.features.view_unstaged {
-        modes.push(Span::styled(" 2 ", mode_style(DiffMode::Unstaged, tab.mode)));
-        modes.push(Span::styled(" UNSTAGED ", mode_style(DiffMode::Unstaged, tab.mode)));
+        modes.push(Span::styled(
+            " 2 ",
+            mode_style(DiffMode::Unstaged, tab.mode),
+        ));
+        modes.push(Span::styled(
+            " UNSTAGED ",
+            mode_style(DiffMode::Unstaged, tab.mode),
+        ));
         modes.push(Span::raw(" "));
     }
     if app.config.features.view_staged {
         modes.push(Span::styled(" 3 ", mode_style(DiffMode::Staged, tab.mode)));
-        modes.push(Span::styled(" STAGED ", mode_style(DiffMode::Staged, tab.mode)));
+        modes.push(Span::styled(
+            " STAGED ",
+            mode_style(DiffMode::Staged, tab.mode),
+        ));
         modes.push(Span::raw(" "));
     }
     if app.config.features.view_history {
         modes.push(Span::styled(" 4 ", mode_style(DiffMode::History, tab.mode)));
-        modes.push(Span::styled(" HISTORY ", mode_style(DiffMode::History, tab.mode)));
+        modes.push(Span::styled(
+            " HISTORY ",
+            mode_style(DiffMode::History, tab.mode),
+        ));
     }
     if app.config.features.view_conflicts {
         modes.push(Span::raw(" "));
-        modes.push(Span::styled(" 5 ", mode_style(DiffMode::Conflicts, tab.mode)));
-        modes.push(Span::styled(" CONFLICTS ", mode_style(DiffMode::Conflicts, tab.mode)));
+        modes.push(Span::styled(
+            " 5 ",
+            mode_style(DiffMode::Conflicts, tab.mode),
+        ));
+        modes.push(Span::styled(
+            " CONFLICTS ",
+            mode_style(DiffMode::Conflicts, tab.mode),
+        ));
     }
     if tab.sort_by_mtime {
         modes.push(Span::raw(" "));
@@ -180,7 +201,11 @@ pub fn render_top_bar(f: &mut Frame, area: Rect, app: &App) {
         if tab.ai.is_stale {
             let stale_count = tab.ai.stale_files.len();
             let stale_label = if stale_count > 0 {
-                format!("⚠ {} file{} changed", stale_count, if stale_count == 1 { "" } else { "s" })
+                format!(
+                    "⚠ {} file{} changed",
+                    stale_count,
+                    if stale_count == 1 { "" } else { "s" }
+                )
             } else {
                 "⚠ AI stale".to_string()
             };
@@ -346,7 +371,10 @@ struct Hint {
 
 impl Hint {
     fn new(key: &str, label: &str) -> Self {
-        Self { key: key.to_string(), label: label.to_string() }
+        Self {
+            key: key.to_string(),
+            label: label.to_string(),
+        }
     }
     fn width(&self) -> usize {
         self.key.len() + self.label.len()
@@ -398,7 +426,9 @@ fn build_history_hints(app: &App) -> Vec<Hint> {
     // Show current file in commit if navigating
     if let Some(ref history) = tab.history {
         if !history.commit_files.is_empty() {
-            let file_name = history.commit_files.get(history.selected_file)
+            let file_name = history
+                .commit_files
+                .get(history.selected_file)
                 .map(|f| f.path.rsplit('/').next().unwrap_or(&f.path))
                 .unwrap_or("");
             if !file_name.is_empty() {
@@ -467,12 +497,10 @@ fn build_hints(app: &App) -> Vec<Hint> {
         }
 
         // Staging hints
-        if h.staging {
-            if tab.mode == DiffMode::Unstaged || tab.mode == DiffMode::Staged {
-                hints.push(Hint::new("s", " stage "));
-            }
-            // Staging not applicable in Conflicts mode
+        if h.staging && (tab.mode == DiffMode::Unstaged || tab.mode == DiffMode::Staged) {
+            hints.push(Hint::new("s", " stage "));
         }
+        // Staging not applicable in Conflicts mode
 
         // Comment hints
         if h.comments {
@@ -598,10 +626,7 @@ fn pack_hint_lines(hints: &[Hint], width: usize) -> Vec<Line<'static>> {
             current_spans.push(Span::raw(" "));
         }
         if !hint.key.is_empty() {
-            current_spans.push(Span::styled(
-                hint.key.clone(),
-                styles::key_hint_style(),
-            ));
+            current_spans.push(Span::styled(hint.key.clone(), styles::key_hint_style()));
         }
         current_spans.push(Span::styled(
             hint.label.clone(),
@@ -633,7 +658,11 @@ fn pack_hint_lines(hints: &[Hint], width: usize) -> Vec<Line<'static>> {
 /// Calculate how many rows the bottom bar needs
 pub fn bottom_bar_height(app: &App, width: u16) -> u16 {
     match &app.input_mode {
-        InputMode::Search | InputMode::Comment | InputMode::Confirm(_) | InputMode::Filter | InputMode::Commit => 1,
+        InputMode::Search
+        | InputMode::Comment
+        | InputMode::Confirm(_)
+        | InputMode::Filter
+        | InputMode::Commit => 1,
         InputMode::Normal => {
             let hints = build_hints(app);
             let lines = pack_hint_lines(&hints, width as usize);
@@ -653,10 +682,13 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
                 ConfirmAction::DeleteComment { .. } => "Delete comment? (y/n)",
             };
             let spans = vec![
-                Span::styled(" ⚠ ", ratatui::style::Style::default()
-                    .fg(styles::BG)
-                    .bg(styles::YELLOW)
-                    .add_modifier(ratatui::style::Modifier::BOLD)),
+                Span::styled(
+                    " ⚠ ",
+                    ratatui::style::Style::default()
+                        .fg(styles::BG)
+                        .bg(styles::YELLOW)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                ),
                 Span::styled(
                     format!(" {} ", prompt),
                     ratatui::style::Style::default().fg(styles::YELLOW),
@@ -670,7 +702,14 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
             let is_reply = tab.comment_reply_to.is_some();
             let is_finding_reply = tab.comment_finding_ref.is_some();
             let (label, accent) = if is_reply {
-                ("reply", if is_question { styles::YELLOW } else { styles::CYAN })
+                (
+                    "reply",
+                    if is_question {
+                        styles::YELLOW
+                    } else {
+                        styles::CYAN
+                    },
+                )
             } else if is_finding_reply {
                 ("response", styles::CYAN)
             } else if is_question {
@@ -678,29 +717,33 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
             } else {
                 ("comment", styles::CYAN)
             };
-            let file_short = tab.comment_file.rsplit('/').next().unwrap_or(&tab.comment_file);
+            let file_short = tab
+                .comment_file
+                .rsplit('/')
+                .next()
+                .unwrap_or(&tab.comment_file);
             let target_label = if let Some(ln) = tab.comment_line_num {
                 format!("{}:L{}", file_short, ln)
             } else {
                 format!("{}:h{}", file_short, tab.comment_hunk + 1)
             };
             let spans = vec![
-                Span::styled(format!(" {} ", label), ratatui::style::Style::default()
-                    .fg(styles::BG)
-                    .bg(accent)
-                    .add_modifier(ratatui::style::Modifier::BOLD)),
+                Span::styled(
+                    format!(" {} ", label),
+                    ratatui::style::Style::default()
+                        .fg(styles::BG)
+                        .bg(accent)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                ),
                 Span::styled(
                     format!(" {} ", target_label),
                     ratatui::style::Style::default().fg(styles::DIM),
                 ),
                 Span::styled(
-                    format!("{}", tab.comment_input),
+                    tab.comment_input.to_string(),
                     ratatui::style::Style::default().fg(styles::TEXT),
                 ),
-                Span::styled(
-                    "█",
-                    ratatui::style::Style::default().fg(accent),
-                ),
+                Span::styled("█", ratatui::style::Style::default().fg(accent)),
                 Span::styled("  ", ratatui::style::Style::default()),
                 Span::styled("Enter", styles::key_hint_style()),
                 Span::styled(" send  ", ratatui::style::Style::default().fg(styles::DIM)),
@@ -712,18 +755,18 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
         }
         InputMode::Filter => {
             let spans = vec![
-                Span::styled(" filter ", ratatui::style::Style::default()
-                    .fg(styles::BG)
-                    .bg(styles::YELLOW)
-                    .add_modifier(ratatui::style::Modifier::BOLD)),
+                Span::styled(
+                    " filter ",
+                    ratatui::style::Style::default()
+                        .fg(styles::BG)
+                        .bg(styles::YELLOW)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                ),
                 Span::styled(
                     format!(" {}", tab.filter_input),
                     ratatui::style::Style::default().fg(styles::TEXT),
                 ),
-                Span::styled(
-                    "█",
-                    ratatui::style::Style::default().fg(styles::YELLOW),
-                ),
+                Span::styled("█", ratatui::style::Style::default().fg(styles::YELLOW)),
                 Span::styled("  ", ratatui::style::Style::default()),
                 Span::styled("Enter", styles::key_hint_style()),
                 Span::styled(" apply  ", ratatui::style::Style::default().fg(styles::DIM)),
@@ -740,13 +783,13 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
                     format!(" {}", tab.search_query),
                     ratatui::style::Style::default().fg(styles::TEXT),
                 ),
-                Span::styled(
-                    "█",
-                    ratatui::style::Style::default().fg(styles::BLUE),
-                ),
+                Span::styled("█", ratatui::style::Style::default().fg(styles::BLUE)),
                 Span::styled("  ", ratatui::style::Style::default()),
                 Span::styled("Enter", styles::key_hint_style()),
-                Span::styled(" confirm  ", ratatui::style::Style::default().fg(styles::DIM)),
+                Span::styled(
+                    " confirm  ",
+                    ratatui::style::Style::default().fg(styles::DIM),
+                ),
                 Span::styled("Esc", styles::key_hint_style()),
                 Span::styled(" cancel", ratatui::style::Style::default().fg(styles::DIM)),
             ];
@@ -755,21 +798,24 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
         }
         InputMode::Commit => {
             let spans = vec![
-                Span::styled(" commit ", ratatui::style::Style::default()
-                    .fg(styles::BG)
-                    .bg(styles::GREEN)
-                    .add_modifier(ratatui::style::Modifier::BOLD)),
+                Span::styled(
+                    " commit ",
+                    ratatui::style::Style::default()
+                        .fg(styles::BG)
+                        .bg(styles::GREEN)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                ),
                 Span::styled(
                     format!(" {}", tab.commit_input),
                     ratatui::style::Style::default().fg(styles::TEXT),
                 ),
-                Span::styled(
-                    "█",
-                    ratatui::style::Style::default().fg(styles::GREEN),
-                ),
+                Span::styled("█", ratatui::style::Style::default().fg(styles::GREEN)),
                 Span::styled("  ", ratatui::style::Style::default()),
                 Span::styled("Enter", styles::key_hint_style()),
-                Span::styled(" commit  ", ratatui::style::Style::default().fg(styles::DIM)),
+                Span::styled(
+                    " commit  ",
+                    ratatui::style::Style::default().fg(styles::DIM),
+                ),
                 Span::styled("Esc", styles::key_hint_style()),
                 Span::styled(" cancel", ratatui::style::Style::default().fg(styles::DIM)),
             ];
@@ -790,11 +836,11 @@ pub fn render_bottom_bar(f: &mut Frame, area: Rect, app: &App) {
                 .split(area);
 
             // TODO(risk:medium): rows is split from area with exactly `row_count` slots, one per
-    // hint line. If pack_hint_lines returns more lines than row_count (which can happen if
-    // bottom_bar_height and render_bottom_bar compute hint packing differently due to a
-    // race on terminal resize), rows[i] will panic with an out-of-bounds index. Clamp the
-    // enumeration to rows.len().
-    for (i, line) in lines.into_iter().enumerate() {
+            // hint line. If pack_hint_lines returns more lines than row_count (which can happen if
+            // bottom_bar_height and render_bottom_bar compute hint packing differently due to a
+            // race on terminal resize), rows[i] will panic with an out-of-bounds index. Clamp the
+            // enumeration to rows.len().
+            for (i, line) in lines.into_iter().enumerate() {
                 let bar = Paragraph::new(line).style(panel_bg);
                 f.render_widget(bar, rows[i]);
             }
@@ -822,14 +868,8 @@ pub fn render_watch_notification(f: &mut Frame, area: Rect, message: &str) {
     };
 
     let notif = Paragraph::new(Line::from(vec![
-        Span::styled(
-            " ● ",
-            ratatui::style::Style::default().fg(styles::GREEN),
-        ),
-        Span::styled(
-            message,
-            ratatui::style::Style::default().fg(styles::TEXT),
-        ),
+        Span::styled(" ● ", ratatui::style::Style::default().fg(styles::GREEN)),
+        Span::styled(message, ratatui::style::Style::default().fg(styles::TEXT)),
         Span::raw(" "),
     ]))
     .style(

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -36,7 +36,6 @@ pub(crate) fn word_wrap(text: &str, max_width: usize) -> Vec<String> {
                 if !current.is_empty() {
                     result.push(current);
                     current = String::new();
-                    is_first_segment = false;
                 }
                 // Break the word into max_width chunks
                 let mut chars = word.chars().peekable();

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -20,14 +20,13 @@ pub struct FileWatcher {
 impl FileWatcher {
     /// Start watching a directory. Changed file events are sent to the provided sender.
     /// Events are debounced by `debounce_ms` milliseconds.
-    pub fn new(
-        root: &Path,
-        debounce_ms: u64,
-        tx: mpsc::Sender<WatchEvent>,
-    ) -> Result<Self> {
+    pub fn new(root: &Path, debounce_ms: u64, tx: mpsc::Sender<WatchEvent>) -> Result<Self> {
         let mut debouncer = new_debouncer(
             Duration::from_millis(debounce_ms),
-            move |result: std::result::Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+            move |result: std::result::Result<
+                Vec<notify_debouncer_mini::DebouncedEvent>,
+                notify::Error,
+            >| {
                 // TODO(risk:minor): Watcher errors (`Err` branch) are silently discarded.
                 // If the OS watch limit is hit (inotify: ENOSPC, kqueue: open file limit)
                 // the watcher will stop delivering events with no indication to the user —


### PR DESCRIPTION
Apply rustfmt formatting across all source files and resolve all clippy
warnings: replace match-with-single-arm with if-let, use is_some_and
instead of map_or(false), collapse nested if statements, use
strip_prefix instead of manual slicing, replace match with matches!
macro, fix unused imports/assignments, and add targeted allow attributes
for type_complexity and field_reassign_with_default in tests.

https://claude.ai/code/session_01RjKPZAbxdqx4bC2QJTawqh