### PR TITLE
Improve file watcher debouncing and error handling for state persistence

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -623,6 +623,7 @@ pub struct FileTreeCache {
     show_unreviewed_only: bool,
     file_count: usize,
     reviewed_count: usize,
+    filter_expr: String,
 }
 
 /// Lightweight memory tracking
@@ -1121,8 +1122,22 @@ impl TabState {
     pub fn reload_ai_state(&mut self) {
         let prev_stale_files = std::mem::take(&mut self.ai.stale_files);
         self.ai = ai::load_ai_state(&self.repo_root, &self.branch_diff_hash);
-        // Finding IDs may change after review reload — clear stale reference
-        self.focused_finding_id = None;
+        // Only clear focused finding if it no longer exists in the reloaded data
+        if let Some(ref fid) = self.focused_finding_id {
+            let still_exists = self
+                .ai
+                .review
+                .as_ref()
+                .map(|r| {
+                    r.files
+                        .values()
+                        .any(|fr| fr.findings.iter().any(|f| f.id == *fid))
+                })
+                .unwrap_or(false);
+            if !still_exists {
+                self.focused_finding_id = None;
+            }
+        }
         // Preserve per-file staleness across .er-* file reloads (recomputed in refresh_diff)
         if self.ai.is_stale {
             self.ai.stale_files = prev_stale_files;
@@ -1296,17 +1311,15 @@ impl TabState {
             false
         };
 
-        // TODO(risk:medium): write errors are silently discarded here (let _ = ...). If the disk is full
-        // or the directory is read-only, the relocation update is lost without any user notification.
-        // The next refresh will re-relocate the same comments, but any intermediate "relocated" state is
-        // dropped, and the user has no idea the write failed.
         // Write back to disk if anything changed
         if questions_changed {
             if let Some(ref qs) = self.ai.questions {
                 let path = format!("{}/.er/questions.json", repo_root);
                 if let Ok(json) = serde_json::to_string_pretty(qs) {
                     let tmp = format!("{}.tmp", path);
-                    let _ = std::fs::write(&tmp, json).and_then(|_| std::fs::rename(&tmp, &path));
+                    if let Err(e) = std::fs::write(&tmp, json).and_then(|_| std::fs::rename(&tmp, &path)) {
+                        eprintln!("er: failed to write relocated questions: {}", e);
+                    }
                 }
             }
         }
@@ -1315,7 +1328,9 @@ impl TabState {
                 let path = format!("{}/.er/github-comments.json", repo_root);
                 if let Ok(json) = serde_json::to_string_pretty(gc) {
                     let tmp = format!("{}.tmp", path);
-                    let _ = std::fs::write(&tmp, json).and_then(|_| std::fs::rename(&tmp, &path));
+                    if let Err(e) = std::fs::write(&tmp, json).and_then(|_| std::fs::rename(&tmp, &path)) {
+                        eprintln!("er: failed to write relocated comments: {}", e);
+                    }
                 }
             }
         }
@@ -2356,6 +2371,7 @@ impl TabState {
                     || cache.show_unreviewed_only != self.show_unreviewed_only
                     || cache.file_count != self.files.len()
                     || cache.reviewed_count != reviewed_count
+                    || cache.filter_expr != self.filter_expr
             }
             None => true,
         };
@@ -2372,6 +2388,7 @@ impl TabState {
                 show_unreviewed_only: self.show_unreviewed_only,
                 file_count: self.files.len(),
                 reviewed_count,
+                filter_expr: self.filter_expr.clone(),
             });
             visible
         } else {
@@ -3132,6 +3149,9 @@ impl TabState {
         // Restore view preferences
         self.show_unreviewed_only = session.show_unreviewed_only;
         self.sort_by_mtime = session.sort_by_mtime;
+
+        // Rebuild hunk offsets for the restored file selection
+        self.rebuild_hunk_offsets();
 
         // Restore comment draft if non-empty
         if !session.comment_draft.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ fn run_app<B: Backend<Error: Send + Sync + 'static>>(
     // Debounce state for file watcher refreshes
     let mut pending_refresh = false;
     let mut refresh_deadline = Instant::now();
+    let mut refresh_max_deadline = Instant::now();
     let mut pending_file_count = 0usize;
 
     // Session auto-save: debounced at ~2 seconds
@@ -213,12 +214,16 @@ fn run_app<B: Backend<Error: Send + Sync + 'static>>(
         // Drain all pending events each tick to avoid accumulation under rapid changes.
         while let Ok(WatchEvent::FilesChanged(paths)) = watch_rx.try_recv() {
             pending_file_count += paths.len();
+            if !pending_refresh {
+                // First event in this batch — set both soft and hard deadlines
+                refresh_max_deadline = Instant::now() + Duration::from_millis(2000);
+            }
             pending_refresh = true;
             refresh_deadline = Instant::now() + Duration::from_millis(200);
         }
 
-        // Execute debounced refresh when deadline passes
-        if pending_refresh && Instant::now() >= refresh_deadline {
+        // Execute debounced refresh when soft deadline passes OR hard deadline reached
+        if pending_refresh && (Instant::now() >= refresh_deadline || Instant::now() >= refresh_max_deadline) {
             pending_refresh = false;
             let count = pending_file_count;
             pending_file_count = 0;


### PR DESCRIPTION
## Summary
This PR improves the robustness of the application by enhancing file watcher debouncing logic, adding proper error reporting for disk write failures, and fixing state restoration to preserve hunk offset calculations.

## Key Changes

- **File watcher debouncing**: Implemented a dual-deadline system with both a soft deadline (200ms) and hard deadline (2000ms) to prevent excessive refresh delays during rapid file changes while ensuring timely updates
- **Error handling for disk writes**: Replaced silent error discarding with explicit error logging for relocated questions and comments, improving visibility into persistence failures
- **Finding focus preservation**: Modified `reload_ai_state()` to only clear focused finding IDs if they no longer exist in reloaded data, preserving user focus when possible
- **State restoration**: Added `rebuild_hunk_offsets()` call during session restoration to ensure hunk offset calculations are properly recomputed for restored file selections
- **Cache invalidation**: Added `filter_expr` field to `FileTreeCache` to properly track filter expression changes and invalidate cache when needed

## Implementation Details

- The file watcher now tracks both `refresh_deadline` (soft, 200ms) and `refresh_max_deadline` (hard, 2000ms) to balance responsiveness with batching efficiency
- Disk write errors are now reported to stderr with context about what operation failed
- Finding focus is preserved across AI state reloads by checking if the focused finding still exists in the reloaded data before clearing it
- Cache validation now includes filter expression comparison to ensure filtered file lists are properly regenerated when filters change

https://claude.ai/code/session_01P3o3RhdDmHuhET5cPQY3iU