### PR TITLE
feat: reduce diff bg saturation, add backwards theme cycling

### DIFF
--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -4234,6 +4234,43 @@ impl App {
         }
     }
 
+    /// Cycle the currently selected config hub item backwards (Left arrow)
+    pub fn config_hub_activate_prev(&mut self) {
+        let idx = match &self.overlay {
+            Some(OverlayData::ConfigHub {
+                selected,
+                editing: None,
+                ..
+            }) => *selected,
+            _ => return,
+        };
+        let items = config::config_hub_items(&self.config);
+        let Some(item) = items.into_iter().nth(idx) else {
+            return;
+        };
+        match item {
+            config::ConfigItem::StringCycle {
+                options, get, set, ..
+            } => {
+                let current = get(&self.config);
+                let pos = options.iter().position(|&o| o == current).unwrap_or(0);
+                let prev = options[(pos + options.len() - 1) % options.len()];
+                set(&mut self.config, prev.to_string());
+                crate::ui::themes::set_theme_by_name(&self.config.display.theme);
+                self.config_hub_rebuild_items();
+            }
+            config::ConfigItem::NumberEdit {
+                get, set, min, max, ..
+            } => {
+                let current = get(&self.config);
+                let prev = if current <= min { max } else { current - 1 };
+                set(&mut self.config, prev);
+                self.config_hub_rebuild_items();
+            }
+            _ => {}
+        }
+    }
+
     /// Apply the editing buffer to the config and close the inline edit
     pub fn config_hub_confirm_edit(&mut self) {
         let (item_idx, buffer) = match &self.overlay {

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -4,7 +4,6 @@ pub(super) mod quiz;
 pub(super) mod wizard;
 
 use crate::ai::{self, AiState, CommentType, InlineLayers, PanelContent, ReviewFocus};
-use tui_textarea::TextArea;
 use crate::config::{self, ErConfig, WatchedConfig};
 use crate::git::{
     self, CommitInfo, CompactionConfig, DiffFile, DiffFileHeader, WatchedFile, Worktree,
@@ -17,6 +16,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[allow(unused_imports)]
 use std::time::Instant;
+use tui_textarea::TextArea;
 
 static COMMENT_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -245,8 +245,7 @@ pub enum AiActionKind {
     Summary,
 }
 
-impl AiActionKind {
-}
+impl AiActionKind {}
 
 /// Which modal hub is open
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2927,13 +2926,11 @@ impl App {
             .config
             .ai_hub
             .resolve_provider_id(self.current_ai_provider.as_deref());
-        let model = provider
-            .as_deref()
-            .and_then(|provider_id| {
-                self.config
-                    .ai_hub
-                    .resolve_model_id(provider_id, self.current_ai_model.as_deref())
-            });
+        let model = provider.as_deref().and_then(|provider_id| {
+            self.config
+                .ai_hub
+                .resolve_model_id(provider_id, self.current_ai_model.as_deref())
+        });
         self.current_ai_provider = provider;
         self.current_ai_model = model;
     }
@@ -2995,7 +2992,11 @@ impl App {
                 let model_summary = if provider.models.is_empty() {
                     "no model presets".to_string()
                 } else {
-                    format!("{} model{}", provider.models.len(), if provider.models.len() == 1 { "" } else { "s" })
+                    format!(
+                        "{} model{}",
+                        provider.models.len(),
+                        if provider.models.len() == 1 { "" } else { "s" }
+                    )
                 };
                 Some(HubItem {
                     label,
@@ -7361,10 +7362,7 @@ mod tests {
     #[test]
     fn comment_text_multi_line_joins_with_newline() {
         let mut tab = TabState::new_for_test(vec![]);
-        tab.comment_textarea = TextArea::new(vec![
-            "line one".to_string(),
-            "line two".to_string(),
-        ]);
+        tab.comment_textarea = TextArea::new(vec!["line one".to_string(), "line two".to_string()]);
         assert_eq!(tab.comment_text(), "line one\nline two");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,18 +269,20 @@ impl AiHubConfig {
             .or_else(|| self.providers.keys().next().cloned())
     }
 
-    pub fn resolve_model_id(
-        &self,
-        provider_id: &str,
-        preferred: Option<&str>,
-    ) -> Option<String> {
+    pub fn resolve_model_id(&self, provider_id: &str, preferred: Option<&str>) -> Option<String> {
         let provider = self.providers.get(provider_id)?;
         if provider.models.is_empty() {
             return None;
         }
 
         preferred
-            .and_then(|id| provider.models.iter().any(|m| m.id == id).then(|| id.to_string()))
+            .and_then(|id| {
+                provider
+                    .models
+                    .iter()
+                    .any(|m| m.id == id)
+                    .then(|| id.to_string())
+            })
             .or_else(|| {
                 self.default_model.as_deref().and_then(|id| {
                     provider

--- a/src/github.rs
+++ b/src/github.rs
@@ -1099,11 +1099,7 @@ pub fn gh_pr_review_threads(
 }
 
 /// Fetch review thread resolution status for a remote PR (no local clone needed).
-pub fn gh_pr_review_threads_remote(
-    owner: &str,
-    repo: &str,
-    pr: u64,
-) -> Result<HashMap<u64, bool>> {
+pub fn gh_pr_review_threads_remote(owner: &str, repo: &str, pr: u64) -> Result<HashMap<u64, bool>> {
     let query = format!(
         r#"query {{ repository(owner: "{}", name: "{}") {{ pullRequest(number: {}) {{ reviewThreads(first: 100) {{ nodes {{ isResolved comments(first: 100) {{ nodes {{ databaseId }} }} }} }} }} }} }}"#,
         owner, repo, pr

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -97,7 +97,10 @@ pub fn handle_overlay_input(app: &mut App, key: KeyEvent) -> Result<()> {
             match key.code {
                 KeyCode::Char('j') | KeyCode::Down => app.overlay_next(),
                 KeyCode::Char('k') | KeyCode::Up => app.overlay_prev(),
-                KeyCode::Enter | KeyCode::Char(' ') => app.config_hub_activate(),
+                KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Right => {
+                    app.config_hub_activate()
+                }
+                KeyCode::Left => app.config_hub_activate_prev(),
                 KeyCode::Char('d') => app.config_hub_delete_selected(),
                 KeyCode::Char('s') => app.config_hub_save_local(),
                 KeyCode::Char('S') => app.config_hub_save_global(),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,7 +1,7 @@
 use crate::app;
 use crate::app::{
-    cleanup_question_answers, cleanup_questions, cleanup_reviews, AiActionKind, App,
-    ConfirmAction, DiffMode, HubAction, InputMode,
+    cleanup_question_answers, cleanup_questions, cleanup_reviews, AiActionKind, App, ConfirmAction,
+    DiffMode, HubAction, InputMode,
 };
 use crate::{git, github};
 use anyhow::Result;
@@ -97,9 +97,7 @@ pub fn handle_overlay_input(app: &mut App, key: KeyEvent) -> Result<()> {
             match key.code {
                 KeyCode::Char('j') | KeyCode::Down => app.overlay_next(),
                 KeyCode::Char('k') | KeyCode::Up => app.overlay_prev(),
-                KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Right => {
-                    app.config_hub_activate()
-                }
+                KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Right => app.config_hub_activate(),
                 KeyCode::Left => app.config_hub_activate_prev(),
                 KeyCode::Char('d') => app.config_hub_delete_selected(),
                 KeyCode::Char('s') => app.config_hub_save_local(),
@@ -749,9 +747,9 @@ pub(super) fn build_agent_quiz_prompt(app: &mut App) -> Option<String> {
     let mode = tab.mode;
     let base = tab.base_branch.clone();
     match mode {
-        DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged | DiffMode::Wizard => {
-            Some(crate::ai::prompts::build_quiz_prompt(&base, mode.git_mode()))
-        }
+        DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged | DiffMode::Wizard => Some(
+            crate::ai::prompts::build_quiz_prompt(&base, mode.git_mode()),
+        ),
         _ => {
             app.notify("Quiz generation not available in this mode");
             None
@@ -809,12 +807,9 @@ pub(super) fn build_agent_wizard_prompt(app: &mut App) -> Option<String> {
     let mode = tab.mode;
     let base = tab.base_branch.clone();
     match mode {
-        DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged | DiffMode::Wizard => {
-            Some(crate::ai::prompts::build_wizard_prompt(
-                &base,
-                mode.git_mode(),
-            ))
-        }
+        DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged | DiffMode::Wizard => Some(
+            crate::ai::prompts::build_wizard_prompt(&base, mode.git_mode()),
+        ),
         _ => {
             app.notify("Wizard generation not available in this mode");
             None
@@ -880,11 +875,9 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
 
     // Fetch review thread resolution status
     let resolved_map = if is_remote {
-        github::gh_pr_review_threads_remote(&owner, &repo_name, pr_number)
-            .unwrap_or_default()
+        github::gh_pr_review_threads_remote(&owner, &repo_name, pr_number).unwrap_or_default()
     } else {
-        github::gh_pr_review_threads(&owner, &repo_name, pr_number, &repo_root)
-            .unwrap_or_default()
+        github::gh_pr_review_threads(&owner, &repo_name, pr_number, &repo_root).unwrap_or_default()
     };
 
     // Load existing github-comments.json (uses cache dir in remote mode)

--- a/src/ui/themes.rs
+++ b/src/ui/themes.rs
@@ -126,9 +126,9 @@ pub fn ocean_depth() -> Theme {
         purple: Color::Rgb(167, 139, 250),
         orange: Color::Rgb(251, 146, 60),
 
-        add_bg: Color::Rgb(16, 36, 28),
+        add_bg: Color::Rgb(14, 27, 23),
         add_text: Color::Rgb(74, 222, 128),
-        del_bg: Color::Rgb(42, 16, 22),
+        del_bg: Color::Rgb(31, 14, 20),
         del_text: Color::Rgb(248, 113, 113),
         hunk_bg: Color::Rgb(22, 22, 42),
 
@@ -175,9 +175,9 @@ pub fn moonlight() -> Theme {
         purple: Color::Rgb(160, 140, 210),
         orange: Color::Rgb(210, 140, 80),
 
-        add_bg: Color::Rgb(18, 34, 26),
+        add_bg: Color::Rgb(17, 27, 23),
         add_text: Color::Rgb(100, 195, 130),
-        del_bg: Color::Rgb(38, 18, 22),
+        del_bg: Color::Rgb(30, 17, 21),
         del_text: Color::Rgb(210, 120, 120),
         hunk_bg: Color::Rgb(24, 24, 40),
 
@@ -223,9 +223,9 @@ pub fn daybreak() -> Theme {
         purple: Color::Rgb(124, 58, 237),
         orange: Color::Rgb(194, 88, 14),
 
-        add_bg: Color::Rgb(220, 252, 231),
+        add_bg: Color::Rgb(230, 251, 238),
         add_text: Color::Rgb(22, 163, 74),
-        del_bg: Color::Rgb(254, 226, 226),
+        del_bg: Color::Rgb(253, 234, 235),
         del_text: Color::Rgb(220, 38, 38),
         hunk_bg: Color::Rgb(226, 232, 248),
 
@@ -271,9 +271,9 @@ pub fn high_contrast() -> Theme {
         purple: Color::Rgb(190, 130, 255),
         orange: Color::Rgb(255, 140, 0),
 
-        add_bg: Color::Rgb(0, 40, 20),
+        add_bg: Color::Rgb(0, 26, 13),
         add_text: Color::Rgb(0, 255, 80),
-        del_bg: Color::Rgb(50, 0, 0),
+        del_bg: Color::Rgb(33, 0, 0),
         del_text: Color::Rgb(255, 50, 50),
         hunk_bg: Color::Rgb(0, 0, 40),
 
@@ -324,9 +324,9 @@ pub fn tokyo_night() -> Theme {
         purple: Color::Rgb(187, 154, 247), // #bb9af7
         orange: Color::Rgb(255, 158, 100), // #ff9e64
 
-        add_bg: Color::Rgb(36, 62, 74),      // #243e4a (diff.add)
+        add_bg: Color::Rgb(33, 50, 61),      // #243e4a toned down
         add_text: Color::Rgb(158, 206, 106), // #9ece6a (green)
-        del_bg: Color::Rgb(74, 39, 47),      // #4a272f (diff.delete)
+        del_bg: Color::Rgb(57, 35, 44),      // #4a272f toned down
         del_text: Color::Rgb(247, 118, 142), // #f7768e (red)
         hunk_bg: Color::Rgb(31, 34, 49),     // #1f2231 (diff.change)
 
@@ -374,9 +374,9 @@ pub fn tokyo_night_storm() -> Theme {
         purple: Color::Rgb(187, 154, 247), // #bb9af7
         orange: Color::Rgb(255, 158, 100), // #ff9e64
 
-        add_bg: Color::Rgb(43, 72, 90),      // #2b485a (diff.add)
+        add_bg: Color::Rgb(41, 61, 79),      // #2b485a toned down
         add_text: Color::Rgb(158, 206, 106), // #9ece6a (green)
-        del_bg: Color::Rgb(82, 49, 63),      // #52313f (diff.delete)
+        del_bg: Color::Rgb(66, 46, 62),      // #52313f toned down
         del_text: Color::Rgb(247, 118, 142), // #f7768e (red)
         hunk_bg: Color::Rgb(39, 45, 67),     // #272d43 (diff.change)
 
@@ -424,9 +424,9 @@ pub fn tokyo_night_moon() -> Theme {
         purple: Color::Rgb(192, 153, 255), // #c099ff
         orange: Color::Rgb(255, 150, 108), // #ff966c
 
-        add_bg: Color::Rgb(42, 69, 86),      // #2a4556 (diff.add)
+        add_bg: Color::Rgb(39, 57, 75),      // #2a4556 toned down
         add_text: Color::Rgb(195, 232, 141), // #c3e88d (green)
-        del_bg: Color::Rgb(75, 42, 61),      // #4b2a3d (diff.delete)
+        del_bg: Color::Rgb(61, 40, 59),      // #4b2a3d toned down
         del_text: Color::Rgb(255, 117, 127), // #ff757f (red)
         hunk_bg: Color::Rgb(37, 42, 63),     // #252a3f (diff.change)
 
@@ -474,9 +474,9 @@ pub fn tokyo_night_day() -> Theme {
         purple: Color::Rgb(152, 84, 241), // #9854f1
         orange: Color::Rgb(177, 92, 0),   // #b15c00
 
-        add_bg: Color::Rgb(183, 206, 213),  // #b7ced5 (diff.add)
+        add_bg: Color::Rgb(198, 213, 219),  // #b7ced5 toned down
         add_text: Color::Rgb(88, 117, 57),  // #587539 (green)
-        del_bg: Color::Rgb(218, 186, 190),  // #dababe (diff.delete)
+        del_bg: Color::Rgb(220, 200, 204),  // #dababe toned down
         del_text: Color::Rgb(245, 42, 101), // #f52a65 (red)
         hunk_bg: Color::Rgb(213, 217, 228), // #d5d9e4 (diff.change)
 
@@ -591,9 +591,9 @@ mod tests {
         assert_eq!(t.red, Color::Rgb(248, 113, 113));
         assert_eq!(t.purple, Color::Rgb(167, 139, 250));
         assert_eq!(t.orange, Color::Rgb(251, 146, 60));
-        assert_eq!(t.add_bg, Color::Rgb(16, 36, 28));
+        assert_eq!(t.add_bg, Color::Rgb(14, 27, 23));
         assert_eq!(t.add_text, Color::Rgb(74, 222, 128));
-        assert_eq!(t.del_bg, Color::Rgb(42, 16, 22));
+        assert_eq!(t.del_bg, Color::Rgb(31, 14, 20));
         assert_eq!(t.del_text, Color::Rgb(248, 113, 113));
         assert_eq!(t.hunk_bg, Color::Rgb(22, 22, 42));
         assert_eq!(t.line_cursor_bg, Color::Rgb(36, 28, 52));


### PR DESCRIPTION
## In plain terms

**The problem:** Diff line backgrounds (green for adds, red for deletes) were visually dominant — they formed solid colored bands that competed with the syntax-highlighted code text, making individual token colors hard to read.

**Why it matters:** The whole point of syntax highlighting is to help you scan code quickly. When the background overpowers the foreground, you lose that signal.

**The fix:** Reduced add/delete background saturation ~35% across all 8 themes so the green/red tint is a subtle indicator rather than the dominant visual element. Also added Left/Right arrow navigation in Config Hub so you can cycle backwards through theme options (and any other cyclic setting) without having to loop all the way around.

**TL;DR:** Diff backgrounds are quieter, text colors pop more, and you can go backwards in the theme selector with the Left arrow.

---

## Changes

- **`src/ui/themes.rs`** — Reduced `add_bg`/`del_bg` saturation in all 8 theme constructors and updated the corresponding unit test
- **`src/input/mod.rs`** — Added `Left` → backwards cycle, `Right` → forwards cycle in Config Hub (non-editing state)
- **`src/app/state/mod.rs`** — Added `config_hub_activate_prev()` method mirroring `config_hub_activate()` with reversed wrap-around logic