### PR TITLE
feat: nested verification commands for mono-repo packages

### DIFF
--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -3586,66 +3586,74 @@ impl App {
 
     /// Open a package-specific verify hub showing that package's configured commands.
     pub fn open_package_commands_hub(&mut self, package_id: String) {
-        let pkg = match self.config.packages.items.get(&package_id) {
-            Some(p) => p.clone(),
+        let not_configured = "set in [packages] in .er-config.toml";
+        let fields = self.config.packages.items.get(&package_id).map(|p| {
+            (
+                p.label.as_deref().unwrap_or(&package_id).to_owned(),
+                p.test.clone(),
+                p.lint.clone(),
+                p.typecheck.clone(),
+                p.security.clone(),
+            )
+        });
+        let (label, test, lint, typecheck, security) = match fields {
+            Some(f) => f,
             None => {
                 self.notify(&format!("Package '{}' not found in config", package_id));
                 return;
             }
         };
-        let label = pkg.label.clone().unwrap_or_else(|| package_id.clone());
-        let not_configured = "not set for this package";
 
         let items = vec![
             HubItem {
                 label: "Run tests".into(),
                 hint: "".into(),
-                description: pkg.test.as_deref().unwrap_or(not_configured).to_string(),
+                description: test.as_deref().unwrap_or(not_configured).to_string(),
                 action: HubAction::RunPackageCommand {
                     command: "test".into(),
                     package_id: package_id.clone(),
                 },
                 is_header: false,
-                enabled: pkg.test.is_some(),
+                enabled: test.is_some(),
             },
             HubItem {
                 label: "Run linter".into(),
                 hint: "".into(),
-                description: pkg.lint.as_deref().unwrap_or(not_configured).to_string(),
+                description: lint.as_deref().unwrap_or(not_configured).to_string(),
                 action: HubAction::RunPackageCommand {
                     command: "lint".into(),
                     package_id: package_id.clone(),
                 },
                 is_header: false,
-                enabled: pkg.lint.is_some(),
+                enabled: lint.is_some(),
             },
             HubItem {
                 label: "Type check".into(),
                 hint: "".into(),
-                description: pkg.typecheck.as_deref().unwrap_or(not_configured).to_string(),
+                description: typecheck.as_deref().unwrap_or(not_configured).to_string(),
                 action: HubAction::RunPackageCommand {
                     command: "typecheck".into(),
                     package_id: package_id.clone(),
                 },
                 is_header: false,
-                enabled: pkg.typecheck.is_some(),
+                enabled: typecheck.is_some(),
             },
             HubItem {
                 label: "Security scan".into(),
                 hint: "".into(),
-                description: pkg.security.as_deref().unwrap_or(not_configured).to_string(),
+                description: security.as_deref().unwrap_or(not_configured).to_string(),
                 action: HubAction::RunPackageCommand {
                     command: "security".into(),
                     package_id: package_id.clone(),
                 },
                 is_header: false,
-                enabled: pkg.security.is_some(),
+                enabled: security.is_some(),
             },
         ];
 
         let selected = items
             .iter()
-            .position(|item| item.enabled)
+            .position(|item| !item.is_header && item.enabled)
             .or_else(|| items.iter().position(|item| !item.is_header))
             .unwrap_or(0);
 

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -4767,6 +4767,15 @@ impl App {
     pub fn overlay_close(&mut self) {
         if matches!(self.overlay, Some(OverlayData::ConfigHub { .. })) {
             self.config_hub_cancel();
+        } else if matches!(
+            self.overlay,
+            Some(OverlayData::ModalHub {
+                kind: HubKind::VerifyPackage,
+                ..
+            })
+        ) {
+            // Navigate back to the package picker instead of closing entirely.
+            self.open_verify_hub();
         } else {
             self.overlay = None;
         }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -358,9 +358,14 @@ pub enum HubAction {
     CopyLine,
     // Help — no dispatch, just informational
     /// Select a package in the verify flow, then show that package's commands
-    SelectVerifyPackage { package_id: String },
+    SelectVerifyPackage {
+        package_id: String,
+    },
     /// Run a verify command scoped to a specific package
-    RunPackageCommand { command: String, package_id: String },
+    RunPackageCommand {
+        command: String,
+        package_id: String,
+    },
 }
 
 // ── Per-Tab State ──

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -3568,10 +3568,12 @@ impl App {
             enabled: cmds.security.is_some(),
         });
 
-        // Pre-select the first selectable item
+        // Pre-select the first enabled item, falling back to the first non-header row so
+        // the cursor never lands on a section header when nothing is enabled.
         let selected = items
             .iter()
             .position(|item| !item.is_header && item.enabled)
+            .or_else(|| items.iter().position(|item| !item.is_header))
             .unwrap_or(0);
 
         self.overlay = Some(OverlayData::ModalHub {
@@ -3644,6 +3646,7 @@ impl App {
         let selected = items
             .iter()
             .position(|item| item.enabled)
+            .or_else(|| items.iter().position(|item| !item.is_header))
             .unwrap_or(0);
 
         self.overlay = Some(OverlayData::ModalHub {

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -224,6 +224,8 @@ pub enum OverlayData {
     },
     ModalHub {
         kind: HubKind,
+        /// Optional title override (e.g. "VERIFY / frontend"). Uses kind.title() if None.
+        title: Option<String>,
         items: Vec<HubItem>,
         selected: usize,
     },
@@ -255,6 +257,7 @@ pub enum HubKind {
     AiProvider,
     AiModel,
     Verify,
+    VerifyPackage,
     Help,
     Open,
     Copy,
@@ -268,6 +271,7 @@ impl HubKind {
             HubKind::AiProvider => "AI PROVIDER",
             HubKind::AiModel => "AI MODEL",
             HubKind::Verify => "VERIFY",
+            HubKind::VerifyPackage => "VERIFY",
             HubKind::Help => "HELP",
             HubKind::Open => "OPEN",
             HubKind::Copy => "COPY",
@@ -353,6 +357,10 @@ pub enum HubAction {
     CopyHunk,
     CopyLine,
     // Help — no dispatch, just informational
+    /// Select a package in the verify flow, then show that package's commands
+    SelectVerifyPackage { package_id: String },
+    /// Run a verify command scoped to a specific package
+    RunPackageCommand { command: String, package_id: String },
 }
 
 // ── Per-Tab State ──
@@ -3013,6 +3021,7 @@ impl App {
             .collect();
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::AiProvider,
+            title: None,
             items,
             selected,
         });
@@ -3064,6 +3073,7 @@ impl App {
             .collect();
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::AiModel,
+            title: None,
             items,
             selected,
         });
@@ -3300,6 +3310,7 @@ impl App {
         ];
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::Git,
+            title: None,
             items,
             selected: 0,
         });
@@ -3470,61 +3481,176 @@ impl App {
         ];
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::Ai,
+            title: None,
             items,
             selected: 0,
         });
     }
 
-    /// Open the Verify modal hub — items enabled when configured in [commands]
+    /// Open the Verify modal hub — items enabled when configured in [commands].
+    /// When [packages] is configured, a packages section appears at the top for mono-repo use.
     pub fn open_verify_hub(&mut self) {
         let cmds = &self.config.commands;
         let not_configured = "set in [commands] in .er-config.toml";
+        let mut items: Vec<HubItem> = Vec::new();
+
+        // Packages section — only shown when [packages] is configured
+        if self.config.has_packages() {
+            items.push(HubItem {
+                label: "── Packages ──".into(),
+                hint: "".into(),
+                description: "".into(),
+                action: HubAction::Noop,
+                is_header: true,
+                enabled: false,
+            });
+            for (package_id, pkg) in &self.config.packages.items {
+                let count = pkg.command_count();
+                items.push(HubItem {
+                    label: pkg.label.clone().unwrap_or_else(|| package_id.clone()),
+                    hint: package_id.clone(),
+                    description: format!("{} command(s) configured", count),
+                    action: HubAction::SelectVerifyPackage {
+                        package_id: package_id.clone(),
+                    },
+                    is_header: false,
+                    enabled: count > 0,
+                });
+            }
+            items.push(HubItem {
+                label: "── Global ──".into(),
+                hint: "".into(),
+                description: "".into(),
+                action: HubAction::Noop,
+                is_header: true,
+                enabled: false,
+            });
+        }
+
+        items.push(HubItem {
+            label: "Run tests".into(),
+            hint: "".into(),
+            description: cmds.test.as_deref().unwrap_or(not_configured).to_string(),
+            action: HubAction::RunCommand("test".into()),
+            is_header: false,
+            enabled: cmds.test.is_some(),
+        });
+        items.push(HubItem {
+            label: "Run linter".into(),
+            hint: "".into(),
+            description: cmds.lint.as_deref().unwrap_or(not_configured).to_string(),
+            action: HubAction::RunCommand("lint".into()),
+            is_header: false,
+            enabled: cmds.lint.is_some(),
+        });
+        items.push(HubItem {
+            label: "Type check".into(),
+            hint: "".into(),
+            description: cmds
+                .typecheck
+                .as_deref()
+                .unwrap_or(not_configured)
+                .to_string(),
+            action: HubAction::RunCommand("typecheck".into()),
+            is_header: false,
+            enabled: cmds.typecheck.is_some(),
+        });
+        items.push(HubItem {
+            label: "Security scan".into(),
+            hint: "".into(),
+            description: cmds
+                .security
+                .as_deref()
+                .unwrap_or(not_configured)
+                .to_string(),
+            action: HubAction::RunCommand("security".into()),
+            is_header: false,
+            enabled: cmds.security.is_some(),
+        });
+
+        // Pre-select the first selectable item
+        let selected = items
+            .iter()
+            .position(|item| !item.is_header && item.enabled)
+            .unwrap_or(0);
+
+        self.overlay = Some(OverlayData::ModalHub {
+            kind: HubKind::Verify,
+            title: None,
+            items,
+            selected,
+        });
+    }
+
+    /// Open a package-specific verify hub showing that package's configured commands.
+    pub fn open_package_commands_hub(&mut self, package_id: String) {
+        let pkg = match self.config.packages.items.get(&package_id) {
+            Some(p) => p.clone(),
+            None => {
+                self.notify(&format!("Package '{}' not found in config", package_id));
+                return;
+            }
+        };
+        let label = pkg.label.clone().unwrap_or_else(|| package_id.clone());
+        let not_configured = "not set for this package";
+
         let items = vec![
             HubItem {
                 label: "Run tests".into(),
                 hint: "".into(),
-                description: cmds.test.as_deref().unwrap_or(not_configured).to_string(),
-                action: HubAction::RunCommand("test".into()),
+                description: pkg.test.as_deref().unwrap_or(not_configured).to_string(),
+                action: HubAction::RunPackageCommand {
+                    command: "test".into(),
+                    package_id: package_id.clone(),
+                },
                 is_header: false,
-                enabled: cmds.test.is_some(),
+                enabled: pkg.test.is_some(),
             },
             HubItem {
                 label: "Run linter".into(),
                 hint: "".into(),
-                description: cmds.lint.as_deref().unwrap_or(not_configured).to_string(),
-                action: HubAction::RunCommand("lint".into()),
+                description: pkg.lint.as_deref().unwrap_or(not_configured).to_string(),
+                action: HubAction::RunPackageCommand {
+                    command: "lint".into(),
+                    package_id: package_id.clone(),
+                },
                 is_header: false,
-                enabled: cmds.lint.is_some(),
+                enabled: pkg.lint.is_some(),
             },
             HubItem {
                 label: "Type check".into(),
                 hint: "".into(),
-                description: cmds
-                    .typecheck
-                    .as_deref()
-                    .unwrap_or(not_configured)
-                    .to_string(),
-                action: HubAction::RunCommand("typecheck".into()),
+                description: pkg.typecheck.as_deref().unwrap_or(not_configured).to_string(),
+                action: HubAction::RunPackageCommand {
+                    command: "typecheck".into(),
+                    package_id: package_id.clone(),
+                },
                 is_header: false,
-                enabled: cmds.typecheck.is_some(),
+                enabled: pkg.typecheck.is_some(),
             },
             HubItem {
                 label: "Security scan".into(),
                 hint: "".into(),
-                description: cmds
-                    .security
-                    .as_deref()
-                    .unwrap_or(not_configured)
-                    .to_string(),
-                action: HubAction::RunCommand("security".into()),
+                description: pkg.security.as_deref().unwrap_or(not_configured).to_string(),
+                action: HubAction::RunPackageCommand {
+                    command: "security".into(),
+                    package_id: package_id.clone(),
+                },
                 is_header: false,
-                enabled: cmds.security.is_some(),
+                enabled: pkg.security.is_some(),
             },
         ];
+
+        let selected = items
+            .iter()
+            .position(|item| item.enabled)
+            .unwrap_or(0);
+
         self.overlay = Some(OverlayData::ModalHub {
-            kind: HubKind::Verify,
+            kind: HubKind::VerifyPackage,
+            title: Some(format!("VERIFY / {}", label)),
             items,
-            selected: 0,
+            selected,
         });
     }
 
@@ -3568,6 +3694,7 @@ impl App {
         ];
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::Copy,
+            title: None,
             items,
             selected: 0,
         });
@@ -4070,6 +4197,7 @@ impl App {
         ];
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::Help,
+            title: None,
             items,
             selected: 0,
         });
@@ -4147,6 +4275,7 @@ impl App {
             .unwrap_or(0);
         self.overlay = Some(OverlayData::ModalHub {
             kind: HubKind::Open,
+            title: None,
             items,
             selected: first_selectable,
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,6 @@ pub struct PackageConfig {
 }
 
 impl PackageConfig {
-    /// Number of commands configured for this package
     pub fn command_count(&self) -> usize {
         [&self.test, &self.lint, &self.typecheck, &self.security]
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct ErConfig {
     pub commands: CommandsConfig,
     #[serde(default)]
     pub ai_hub: AiHubConfig,
+    #[serde(default)]
+    pub packages: PackagesConfig,
 }
 
 /// [commands] section — configurable shell commands for hub actions.
@@ -43,6 +45,37 @@ pub struct CommandsConfig {
     /// Security scan (Verify hub)
     #[serde(default)]
     pub security: Option<String>,
+}
+
+/// Per-package command overrides for mono-repo setups.
+/// Each key under [packages] is a package ID with its own commands.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PackageConfig {
+    pub label: Option<String>,
+    pub test: Option<String>,
+    pub lint: Option<String>,
+    pub typecheck: Option<String>,
+    pub security: Option<String>,
+}
+
+impl PackageConfig {
+    /// Number of commands configured for this package
+    pub fn command_count(&self) -> usize {
+        [&self.test, &self.lint, &self.typecheck, &self.security]
+            .iter()
+            .filter(|c| c.is_some())
+            .count()
+    }
+}
+
+/// [packages] section — per-package command definitions for mono-repos.
+/// Each key maps to a PackageConfig with its own test/lint/typecheck/security commands.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PackagesConfig {
+    #[serde(flatten)]
+    pub items: BTreeMap<String, PackageConfig>,
 }
 
 /// [watched] section configuration
@@ -342,6 +375,22 @@ impl ErConfig {
             "lint" => self.commands.lint.clone(),
             "typecheck" => self.commands.typecheck.clone(),
             "security" => self.commands.security.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn has_packages(&self) -> bool {
+        !self.packages.items.is_empty()
+    }
+
+    /// Resolve a command for a specific package. Returns None if package or command not configured.
+    pub fn resolve_package_command(&self, package_id: &str, command: &str) -> Option<String> {
+        let pkg = self.packages.items.get(package_id)?;
+        match command {
+            "test" => pkg.test.clone(),
+            "lint" => pkg.lint.clone(),
+            "typecheck" => pkg.typecheck.clone(),
+            "security" => pkg.security.clone(),
             _ => None,
         }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -351,6 +351,15 @@ pub(super) fn dispatch_hub_action(app: &mut App, action: HubAction) -> Result<()
         HubAction::CopyLine => {
             app.copy_line()?;
         }
+        HubAction::SelectVerifyPackage { package_id } => {
+            app.open_package_commands_hub(package_id);
+        }
+        HubAction::RunPackageCommand { command, package_id } => {
+            match app.config.resolve_package_command(&package_id, &command) {
+                Some(cmd) => app.spawn_command(&format!("{}/{}", package_id, command), &cmd)?,
+                None => app.notify(&format!("{}/{}: not configured", package_id, command)),
+            }
+        }
     }
     Ok(())
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -354,12 +354,13 @@ pub(super) fn dispatch_hub_action(app: &mut App, action: HubAction) -> Result<()
         HubAction::SelectVerifyPackage { package_id } => {
             app.open_package_commands_hub(package_id);
         }
-        HubAction::RunPackageCommand { command, package_id } => {
-            match app.config.resolve_package_command(&package_id, &command) {
-                Some(cmd) => app.spawn_command(&format!("{}/{}", package_id, command), &cmd)?,
-                None => app.notify(&format!("{}/{}: not configured", package_id, command)),
-            }
-        }
+        HubAction::RunPackageCommand {
+            command,
+            package_id,
+        } => match app.config.resolve_package_command(&package_id, &command) {
+            Some(cmd) => app.spawn_command(&format!("{}/{}", package_id, command), &cmd)?,
+            None => app.notify(&format!("{}/{}: not configured", package_id, command)),
+        },
     }
     Ok(())
 }

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -331,7 +331,14 @@ fn render_filter_history(
 // Use the shared centered_rect from utils (deduplicated from overlay + settings)
 use super::utils::centered_rect;
 
-fn render_modal_hub(f: &mut Frame, area: Rect, kind: HubKind, title_override: Option<&str>, items: &[HubItem], selected: usize) {
+fn render_modal_hub(
+    f: &mut Frame,
+    area: Rect,
+    kind: HubKind,
+    title_override: Option<&str>,
+    items: &[HubItem],
+    selected: usize,
+) {
     // For Help hub, use wider popup to fit descriptions
     let is_help = kind == HubKind::Help;
     let popup_width = if is_help {

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -37,10 +37,11 @@ pub fn render_overlay(f: &mut Frame, area: Rect, overlay: &OverlayData) {
         }
         OverlayData::ModalHub {
             kind,
+            title,
             items,
             selected,
         } => {
-            render_modal_hub(f, area, *kind, items, *selected);
+            render_modal_hub(f, area, *kind, title.as_deref(), items, *selected);
         }
     }
 }
@@ -330,7 +331,7 @@ fn render_filter_history(
 // Use the shared centered_rect from utils (deduplicated from overlay + settings)
 use super::utils::centered_rect;
 
-fn render_modal_hub(f: &mut Frame, area: Rect, kind: HubKind, items: &[HubItem], selected: usize) {
+fn render_modal_hub(f: &mut Frame, area: Rect, kind: HubKind, title_override: Option<&str>, items: &[HubItem], selected: usize) {
     // For Help hub, use wider popup to fit descriptions
     let is_help = kind == HubKind::Help;
     let popup_width = if is_help {
@@ -349,7 +350,7 @@ fn render_modal_hub(f: &mut Frame, area: Rect, kind: HubKind, items: &[HubItem],
         HubKind::Git => styles::GREEN(),
         HubKind::Ai => styles::PURPLE(),
         HubKind::AiProvider | HubKind::AiModel => styles::PURPLE(),
-        HubKind::Verify => styles::YELLOW(),
+        HubKind::Verify | HubKind::VerifyPackage => styles::YELLOW(),
         HubKind::Help => styles::CYAN(),
         HubKind::Open => styles::BLUE(),
         HubKind::Copy => styles::CYAN(),
@@ -427,9 +428,10 @@ fn render_modal_hub(f: &mut Frame, area: Rect, kind: HubKind, items: &[HubItem],
         "Enter=select, Esc=close"
     };
 
+    let display_title = title_override.unwrap_or(kind.title());
     let block = Block::default()
         .title(Span::styled(
-            format!(" {} ({}) ", kind.title(), close_hint),
+            format!(" {} ({}) ", display_title, close_hint),
             ratatui::style::Style::default().fg(title_color),
         ))
         .borders(Borders::ALL)


### PR DESCRIPTION
## In plain terms

**The problem:** When working in a mono-repo with multiple packages (frontend, backend, shared), the VERIFY hub (`v`) only runs top-level commands — there's no way to scope `bun test` to just the `packages/frontend` folder.

**Why it matters:** Running all tests from root can be slow or impossible if packages have different toolchains. Developers need to run checks per-package as part of their review flow.

**The fix:** Add a `[packages]` section to `.er-config.toml`. When configured, the VERIFY hub shows packages at the top. Selecting one opens a scoped sub-hub — identical to the top-level VERIFY menu but for that package only.

**TL;DR:** `v` → pick a package → pick a command. Same muscle memory as picking AI provider then model.

## Config example

```toml
[packages.frontend]
label = "Frontend (React)"
test = "cd packages/frontend && bun test"
lint = "cd packages/frontend && bun lint"
typecheck = "cd packages/frontend && bunx tsc --noEmit"

[packages.backend]
label = "Backend (Node)"
test = "cd packages/backend && bun test"
typecheck = "cd packages/backend && bunx tsc --noEmit"
```

## Changes

- **`src/config.rs`** — `PackageConfig` + `PackagesConfig` structs; `has_packages()` + `resolve_package_command()` on `ErConfig`
- **`src/app/state/mod.rs`** — `HubKind::VerifyPackage`, `HubAction::SelectVerifyPackage` + `RunPackageCommand`; `title: Option<String>` on `OverlayData::ModalHub`; modified `open_verify_hub()` + new `open_package_commands_hub()`
- **`src/input/mod.rs`** — dispatch handlers for both new actions
- **`src/ui/overlay.rs`** — `VerifyPackage` color match; `title_override` used in block title

## Backward compatibility

Repos without `[packages]` see no change to the VERIFY hub.

## Test plan

- [ ] `cargo test` — 513 tests pass
- [ ] Repo with `[packages]` — VERIFY hub shows Packages section + Global section
- [ ] Select a package → `VERIFY / {label}` sub-hub opens with that package's commands
- [ ] Unconfigured commands in a package shown as disabled
- [ ] Select a command → runs and appears in command log
- [ ] Repo without `[packages]` — VERIFY hub unchanged