### PR TITLE
feat: GitHub-style bordered inline comment blocks

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -817,6 +817,81 @@ pub(super) fn build_agent_wizard_prompt(app: &mut App) -> Option<String> {
     }
 }
 
+/// Given a GitHub `diff_hunk` string, find the matching local line number in a file's diff.
+///
+/// GitHub's `line` field uses line numbers from the PR diff (against the PR base commit),
+/// which may differ from our local diff when `main` has advanced since the PR was filed.
+/// `diff_hunk` contains the actual diff text, so we can use content-based matching instead.
+///
+/// Returns `(hunk_index, local_line_start)` if a match is found.
+fn find_local_line_for_diff_hunk(diff_hunk: &str, file: &git::DiffFile) -> Option<(usize, usize)> {
+    // Parse diff_hunk lines: first line is the @@ header, rest are +/-/space content lines.
+    let hunk_lines: Vec<&str> = diff_hunk.lines().collect();
+    let content_lines: Vec<&str> = hunk_lines.iter().skip(1).copied().collect();
+    if content_lines.is_empty() {
+        return None;
+    }
+
+    // Strip the +/-/space prefix to get raw content (matching DiffLine.content which is pre-stripped).
+    let stripped: Vec<&str> = content_lines
+        .iter()
+        .map(|l| {
+            if l.starts_with('+') || l.starts_with('-') || l.starts_with(' ') {
+                &l[1..]
+            } else {
+                l
+            }
+        })
+        .collect();
+
+    // Use the last N lines as a sliding-window fingerprint.
+    // Skip deleted lines in the window — they won't appear on the new side of the diff.
+    let new_side_stripped: Vec<&str> = content_lines
+        .iter()
+        .zip(stripped.iter())
+        .filter(|(raw, _)| !raw.starts_with('-'))
+        .map(|(_, s)| *s)
+        .collect();
+
+    if new_side_stripped.is_empty() {
+        return None;
+    }
+
+    // Use a window of up to 4 lines ending at the target line (last line in the hunk).
+    let window_size = new_side_stripped.len().min(4);
+    let window: Vec<&str> = new_side_stripped[new_side_stripped.len() - window_size..].to_vec();
+
+    // Slide the window across each hunk in our local diff to find a content match.
+    for (hunk_idx, hunk) in file.hunks.iter().enumerate() {
+        let new_side_lines: Vec<(&str, Option<usize>)> = hunk
+            .lines
+            .iter()
+            .filter(|l| !matches!(l.line_type, git::LineType::Delete))
+            .map(|l| (l.content.as_str(), l.new_num))
+            .collect();
+
+        if new_side_lines.len() < window_size {
+            continue;
+        }
+
+        for i in 0..=(new_side_lines.len() - window_size) {
+            let candidate: Vec<&str> = new_side_lines[i..i + window_size]
+                .iter()
+                .map(|(c, _)| *c)
+                .collect();
+            if candidate == window {
+                // The last line of the window is the comment target.
+                let (_, local_new_num) = new_side_lines[i + window_size - 1];
+                if let Some(line_num) = local_new_num {
+                    return Some((hunk_idx, line_num));
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// Sync GitHub PR comments (pull)
 pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
     let tab = app.tab();
@@ -924,6 +999,19 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
     for gh in &gh_comments {
         let file_path = gh.path.clone().unwrap_or_default();
 
+        // Prefer content-based matching via diff_hunk (robust against line-number drift when
+        // main has advanced since the PR was filed). Fall back to gh.line if unavailable.
+        let resolved_line: Option<usize> = if let (Some(diff_hunk), Some(f)) = (
+            &gh.diff_hunk,
+            tab_files.iter().find(|f| f.path == file_path),
+        ) {
+            find_local_line_for_diff_hunk(diff_hunk, f)
+                .map(|(_, ln)| ln)
+                .or(gh.line)
+        } else {
+            gh.line
+        };
+
         let (
             hunk_index,
             anchor_line_content,
@@ -931,7 +1019,7 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
             anchor_ctx_after,
             anchor_old_line,
             anchor_hunk_header,
-        ) = if let Some(line) = gh.line {
+        ) = if let Some(line) = resolved_line {
             if let Some(f) = tab_files.iter().find(|f| f.path == file_path) {
                 if let Some((i, hunk)) = f
                     .hunks
@@ -1009,7 +1097,7 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
             timestamp: gh.created_at.clone(),
             file: file_path,
             hunk_index,
-            line_start: gh.line,
+            line_start: resolved_line,
             line_end: None,
             line_content: anchor_line_content,
             comment: gh.body.clone(),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1098,17 +1098,14 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
                         // Priority: 1) extract from diff_hunk content, 2) snap to the nearest
                         // line in the hunk by new_num so the anchor is never blank.
                         if let Some(dh) = gh.diff_hunk.as_deref() {
-                            let (fallback_lc, fallback_ctx) =
-                                extract_anchor_from_diff_hunk(dh);
+                            let (fallback_lc, fallback_ctx) = extract_anchor_from_diff_hunk(dh);
                             (fallback_lc, None, fallback_ctx, Vec::new())
                         } else {
                             let nearest = hunk
                                 .lines
                                 .iter()
                                 .filter_map(|l| l.new_num.map(|n| (n, l)))
-                                .min_by_key(|(n, _)| {
-                                    (*n as isize - line as isize).unsigned_abs()
-                                });
+                                .min_by_key(|(n, _)| (*n as isize - line as isize).unsigned_abs());
                             let (lc, old_ln) = nearest
                                 .map(|(_, l)| (l.content.clone(), l.old_num))
                                 .unwrap_or_default();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1008,17 +1008,25 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
     for gh in &gh_comments {
         let file_path = gh.path.clone().unwrap_or_default();
 
-        // Prefer content-based matching via diff_hunk (robust against line-number drift when
-        // main has advanced since the PR was filed). Fall back to gh.line if unavailable.
+        // Prefer content-based matching via diff_hunk — robust against line-number drift when
+        // main has advanced since the PR was filed.
+        //
+        // Fallback priority:
+        //   1. Content match (diff_hunk sliding window)
+        //   2. original_line — stable line from when the comment was first created; always
+        //      consistent with diff_hunk, never null even after the PR head is force-pushed
+        //   3. line — GitHub's current value, which GitHub nulls out when it considers the
+        //      comment outdated after a rebase
+        let stable_line = gh.original_line.or(gh.line);
         let resolved_line: Option<usize> = if let (Some(diff_hunk), Some(f)) = (
             &gh.diff_hunk,
             tab_files.iter().find(|f| f.path == file_path),
         ) {
             find_local_line_for_diff_hunk(diff_hunk, f)
                 .map(|(_, ln)| ln)
-                .or(gh.line)
+                .or(stable_line)
         } else {
-            gh.line
+            stable_line
         };
 
         let (

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -817,6 +817,39 @@ pub(super) fn build_agent_wizard_prompt(app: &mut App) -> Option<String> {
     }
 }
 
+/// Extract the commented line content and preceding context from a GitHub `diff_hunk` string.
+///
+/// GitHub's diff_hunk ends at the commented line. The last non-deleted line is the target;
+/// the preceding non-deleted lines are context. Used as a fallback when the local DiffLine
+/// lookup fails (e.g. because the PR base has drifted from our local base).
+///
+/// Returns `(line_content, context_before)`.
+fn extract_anchor_from_diff_hunk(diff_hunk: &str) -> (String, Vec<String>) {
+    let new_side: Vec<&str> = diff_hunk
+        .lines()
+        .skip(1) // skip @@ header
+        .filter(|l| !l.starts_with('-'))
+        .map(|l| {
+            if l.starts_with('+') || l.starts_with(' ') {
+                &l[1..]
+            } else {
+                l
+            }
+        })
+        .collect();
+    let line_content = new_side.last().copied().unwrap_or("").to_string();
+    let ctx_start = new_side.len().saturating_sub(4);
+    let context_before: Vec<String> = if new_side.len() > 1 {
+        new_side[ctx_start..new_side.len() - 1]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    (line_content, context_before)
+}
+
 /// Given a GitHub `diff_hunk` string, find the matching local line number in a file's diff.
 ///
 /// GitHub's `line` field uses line numbers from the PR diff (against the PR base commit),
@@ -1045,28 +1078,32 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
                     .find(|(_, h)| line >= h.new_start && line < h.new_start + h.new_count)
                 {
                     let target_idx = hunk.lines.iter().position(|l| l.new_num == Some(line));
-                    let (lc, old_ln) = if let Some(idx) = target_idx {
-                        (hunk.lines[idx].content.clone(), hunk.lines[idx].old_num)
-                    } else {
-                        (String::new(), None)
-                    };
-                    let ctx_before: Vec<String> = if let Some(idx) = target_idx {
+                    let (lc, old_ln, ctx_before, ctx_after) = if let Some(idx) = target_idx {
                         let start = idx.saturating_sub(3);
-                        hunk.lines[start..idx]
-                            .iter()
-                            .map(|l| l.content.clone())
-                            .collect()
-                    } else {
-                        Vec::new()
-                    };
-                    let ctx_after: Vec<String> = if let Some(idx) = target_idx {
                         let end = (idx + 4).min(hunk.lines.len());
-                        hunk.lines[(idx + 1)..end]
-                            .iter()
-                            .map(|l| l.content.clone())
-                            .collect()
+                        (
+                            hunk.lines[idx].content.clone(),
+                            hunk.lines[idx].old_num,
+                            hunk.lines[start..idx]
+                                .iter()
+                                .map(|l| l.content.clone())
+                                .collect(),
+                            hunk.lines[(idx + 1)..end]
+                                .iter()
+                                .map(|l| l.content.clone())
+                                .collect(),
+                        )
                     } else {
-                        Vec::new()
+                        // The GitHub line number doesn't map to a local DiffLine — this happens
+                        // when the PR base has drifted from our local base (main has advanced).
+                        // Extract content from diff_hunk so the relocation engine has real
+                        // content to search with instead of an empty string (which always → Lost).
+                        let (fallback_lc, fallback_ctx) = gh
+                            .diff_hunk
+                            .as_deref()
+                            .map(extract_anchor_from_diff_hunk)
+                            .unwrap_or_default();
+                        (fallback_lc, None, fallback_ctx, Vec::new())
                     };
                     (
                         Some(i),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -862,6 +862,9 @@ fn find_local_line_for_diff_hunk(diff_hunk: &str, file: &git::DiffFile) -> Optio
     let window: Vec<&str> = new_side_stripped[new_side_stripped.len() - window_size..].to_vec();
 
     // Slide the window across each hunk in our local diff to find a content match.
+    // Require a unique match — if the window appears more than once, fall back to gh.line
+    // to avoid silently anchoring to the wrong location in repetitive code.
+    let mut unique_match: Option<(usize, usize)> = None;
     for (hunk_idx, hunk) in file.hunks.iter().enumerate() {
         let new_side_lines: Vec<(&str, Option<usize>)> = hunk
             .lines
@@ -880,13 +883,19 @@ fn find_local_line_for_diff_hunk(diff_hunk: &str, file: &git::DiffFile) -> Optio
                 .map(|(c, _)| *c)
                 .collect();
             if candidate == window {
-                // The last line of the window is the comment target.
                 let (_, local_new_num) = new_side_lines[i + window_size - 1];
                 if let Some(line_num) = local_new_num {
-                    return Some((hunk_idx, line_num));
+                    if unique_match.is_some() {
+                        // Ambiguous — two locations match the window; refuse to guess.
+                        return None;
+                    }
+                    unique_match = Some((hunk_idx, line_num));
                 }
             }
         }
+    }
+    if let Some(m) = unique_match {
+        return Some(m);
     }
 
     None

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1094,16 +1094,26 @@ pub(super) fn sync_github_comments(app: &mut App) -> Result<()> {
                                 .collect(),
                         )
                     } else {
-                        // The GitHub line number doesn't map to a local DiffLine — this happens
-                        // when the PR base has drifted from our local base (main has advanced).
-                        // Extract content from diff_hunk so the relocation engine has real
-                        // content to search with instead of an empty string (which always → Lost).
-                        let (fallback_lc, fallback_ctx) = gh
-                            .diff_hunk
-                            .as_deref()
-                            .map(extract_anchor_from_diff_hunk)
-                            .unwrap_or_default();
-                        (fallback_lc, None, fallback_ctx, Vec::new())
+                        // The line number doesn't map to a local DiffLine — PR base has drifted.
+                        // Priority: 1) extract from diff_hunk content, 2) snap to the nearest
+                        // line in the hunk by new_num so the anchor is never blank.
+                        if let Some(dh) = gh.diff_hunk.as_deref() {
+                            let (fallback_lc, fallback_ctx) =
+                                extract_anchor_from_diff_hunk(dh);
+                            (fallback_lc, None, fallback_ctx, Vec::new())
+                        } else {
+                            let nearest = hunk
+                                .lines
+                                .iter()
+                                .filter_map(|l| l.new_num.map(|n| (n, l)))
+                                .min_by_key(|(n, _)| {
+                                    (*n as isize - line as isize).unsigned_abs()
+                                });
+                            let (lc, old_ln) = nearest
+                                .map(|(_, l)| (l.content.clone(), l.old_num))
+                                .unwrap_or_default();
+                            (lc, old_ln, Vec::new(), Vec::new())
+                        }
                     };
                     (
                         Some(i),

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -1888,6 +1888,8 @@ fn render_comment_lines(
 ) {
     let is_question = comment.comment_type() == CommentType::Question;
     let is_stale = comment.is_stale();
+    let anchor = comment.anchor_status();
+    let is_lost = anchor == "lost";
 
     let bg = if focused {
         styles::COMMENT_FOCUS_BG()
@@ -1909,17 +1911,158 @@ fn render_comment_lines(
     let icon = if is_question { "❓" } else { "💬" };
     let author = comment.author();
 
+    if inline {
+        // ── GitHub-style inline block ──
+
+        // Top label: "  ╭─ 💬 R33 ────────────────────────────────"
+        let line_label = if let Some(ln) = comment.line_start() {
+            format!("  \u{256d}\u{2500} {} R{}  ", icon, ln)
+        } else {
+            format!("  \u{256d}\u{2500} {}  ", icon)
+        };
+        // emoji occupies 2 columns; estimate display width conservatively
+        let label_cols = line_label.chars().count() + 1;
+        let fill_len = (width as usize).saturating_sub(label_cols);
+        lines.push(
+            Line::from(vec![
+                Span::styled(
+                    line_label,
+                    ratatui::style::Style::default().fg(accent).bg(bg),
+                ),
+                Span::styled(
+                    "\u{2500}".repeat(fill_len),
+                    ratatui::style::Style::default().fg(styles::BORDER()).bg(bg),
+                ),
+            ])
+            .style(ratatui::style::Style::default().bg(bg)),
+        );
+
+        // Author line: "  │  VilfredSikker  14:30:00  [badges]"
+        let bar = if focused {
+            "  \u{25b8}\u{2502}  "
+        } else {
+            "  \u{2502}  "
+        };
+        let mut author_spans = vec![
+            Span::styled(
+                bar,
+                ratatui::style::Style::default()
+                    .fg(if focused { styles::PURPLE() } else { accent })
+                    .bg(bg),
+            ),
+            Span::styled(
+                author.to_string(),
+                ratatui::style::Style::default()
+                    .fg(accent)
+                    .bg(bg)
+                    .add_modifier(ratatui::style::Modifier::BOLD),
+            ),
+        ];
+        let ts = comment.timestamp();
+        if !ts.is_empty() {
+            let time_part = ts.split('T').nth(1).unwrap_or("").trim_end_matches('Z');
+            author_spans.push(Span::styled(
+                format!("  {}", time_part),
+                ratatui::style::Style::default().fg(styles::DIM()).bg(bg),
+            ));
+        }
+        if anchor == "relocated" {
+            author_spans.push(Span::styled(
+                "  \u{21aa} moved",
+                ratatui::style::Style::default()
+                    .fg(styles::RELOCATED_INDICATOR())
+                    .bg(bg),
+            ));
+        } else if is_lost {
+            author_spans.push(Span::styled(
+                "  ? lost",
+                ratatui::style::Style::default()
+                    .fg(styles::LOST_INDICATOR())
+                    .bg(bg),
+            ));
+        }
+        if is_stale {
+            author_spans.push(Span::styled(
+                "  \u{26a0} stale",
+                ratatui::style::Style::default().fg(styles::STALE()).bg(bg),
+            ));
+        }
+        if comment.is_resolved() {
+            author_spans.push(Span::styled(
+                "  \u{2713} resolved",
+                ratatui::style::Style::default().fg(styles::GREEN()).bg(bg),
+            ));
+        }
+        if comment.comment_type() == CommentType::GitHubComment {
+            if comment.is_synced() {
+                author_spans.push(Span::styled(
+                    "  \u{2191} synced",
+                    ratatui::style::Style::default().fg(styles::GREEN()).bg(bg),
+                ));
+            } else {
+                author_spans.push(Span::styled(
+                    "  \u{2191} local",
+                    ratatui::style::Style::default().fg(styles::DIM()).bg(bg),
+                ));
+            }
+        }
+        if focused {
+            author_spans.push(Span::styled(
+                "  \u{25c6}",
+                ratatui::style::Style::default()
+                    .fg(styles::PURPLE())
+                    .bg(bg)
+                    .add_modifier(ratatui::style::Modifier::BOLD),
+            ));
+        }
+        lines.push(Line::from(author_spans).style(ratatui::style::Style::default().bg(bg)));
+
+        // Text lines: "  │   text..."
+        let bar_style = ratatui::style::Style::default().fg(accent).bg(bg);
+        let indent_str = "  \u{2502}  ";
+        let max_len = (width as usize).saturating_sub(indent_str.len() + 2);
+        let text = comment.text();
+        let text_fg = if is_stale || is_lost {
+            styles::DIM()
+        } else {
+            styles::TEXT()
+        };
+        for wrapped in word_wrap(text, max_len) {
+            lines.push(
+                Line::from(vec![
+                    Span::styled(indent_str, bar_style),
+                    Span::styled(
+                        format!("  {}", wrapped),
+                        ratatui::style::Style::default().fg(text_fg).bg(bg),
+                    ),
+                ])
+                .style(ratatui::style::Style::default().bg(bg)),
+            );
+        }
+
+        // Bottom border: "  ╰──────────────────────────────────────────"
+        let bottom_fill = (width as usize).saturating_sub(3);
+        lines.push(
+            Line::from(vec![
+                Span::styled(
+                    "  \u{2570}",
+                    ratatui::style::Style::default().fg(accent).bg(bg),
+                ),
+                Span::styled(
+                    "\u{2500}".repeat(bottom_fill),
+                    ratatui::style::Style::default().fg(styles::BORDER()).bg(bg),
+                ),
+            ])
+            .style(ratatui::style::Style::default().bg(bg)),
+        );
+        return;
+    }
+
+    // ── Non-inline (panel / hunk-level) style ──
     let mut header_spans = vec![
         Span::styled(
             if focused {
-                // Bright left marker when focused
-                if inline {
-                    format!("  ▸  {} ", icon)
-                } else {
-                    format!("▸ {} ", icon)
-                }
-            } else if inline {
-                format!("     {} ", icon)
+                format!("\u{25b8} {} ", icon)
             } else {
                 format!("  {} ", icon)
             },
@@ -1947,7 +2090,6 @@ fn render_comment_lines(
     }
 
     // Relocated/lost anchor indicators
-    let anchor = comment.anchor_status();
     if anchor == "relocated" {
         header_spans.push(Span::styled(
             "  \u{21aa} moved",
@@ -1955,7 +2097,7 @@ fn render_comment_lines(
                 .fg(styles::RELOCATED_INDICATOR())
                 .bg(bg),
         ));
-    } else if anchor == "lost" {
+    } else if is_lost {
         header_spans.push(Span::styled(
             "  ? lost",
             ratatui::style::Style::default()
@@ -1983,12 +2125,12 @@ fn render_comment_lines(
     // Synced indicator (GitHub comments only)
     if comment.is_synced() {
         header_spans.push(Span::styled(
-            "  ↑ synced",
+            "  \u{2191} synced",
             ratatui::style::Style::default().fg(styles::GREEN()).bg(bg),
         ));
     } else if comment.comment_type() == CommentType::GitHubComment {
         header_spans.push(Span::styled(
-            "  ↑ local",
+            "  \u{2191} local",
             ratatui::style::Style::default().fg(styles::DIM()).bg(bg),
         ));
     }
@@ -1996,7 +2138,7 @@ fn render_comment_lines(
     // Focus indicator
     if focused {
         header_spans.push(Span::styled(
-            "  ◆ focused",
+            "  \u{25c6} focused",
             ratatui::style::Style::default()
                 .fg(styles::PURPLE())
                 .bg(bg)
@@ -2006,21 +2148,18 @@ fn render_comment_lines(
 
     lines.push(Line::from(header_spans).style(ratatui::style::Style::default().bg(bg)));
 
-    // Comment text — split by lines first so paragraph breaks and bullet points are preserved
-    let indent: usize = if inline { 8 } else { 6 };
-    let max_len = width.saturating_sub(indent as u16) as usize;
+    // Comment text
+    let max_len = width.saturating_sub(8) as usize;
     let text = comment.text();
-    let is_lost = anchor == "lost";
     let text_fg = if is_stale || is_lost {
         styles::DIM()
     } else {
         styles::TEXT()
     };
-    let padding = " ".repeat(indent.saturating_sub(2));
     for wrapped in word_wrap(text, max_len) {
         lines.push(
             Line::from(vec![Span::styled(
-                format!("  {}{}", padding, wrapped),
+                format!("      {}", wrapped),
                 ratatui::style::Style::default().fg(text_fg).bg(bg),
             )])
             .style(ratatui::style::Style::default().bg(bg)),

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -1920,8 +1920,7 @@ fn render_comment_lines(
         } else {
             format!("  \u{256d}\u{2500} {}  ", icon)
         };
-        // emoji occupies 2 columns; estimate display width conservatively
-        let label_cols = line_label.chars().count() + 1;
+        let label_cols = Span::raw(&line_label).width();
         let fill_len = (width as usize).saturating_sub(label_cols);
         lines.push(
             Line::from(vec![


### PR DESCRIPTION
## In plain terms

**The problem:** Inline comments in the diff view were displayed as a plain single line (icon + author + text), making them hard to visually distinguish from the diff lines around them.

**Why it matters:** When reviewing code, you need to immediately spot where comments are anchored without losing your place in the diff.

**The fix:** Inline comments now render as a bordered block directly below their target line, similar to GitHub's inline comment UI:

```
    1   33 │+ return constraint_name in TEMPLATE_FK_CONSTRAINTS
          ╭─ 💬 R33 ──────────────────────────────────────────
          │  VilfredSikker  14:30:00  ↑ synced
          │    1:1 from physical plates: TEMPLATE_FK_CONSTRAINTS
          │    is a direct port of EXPERIMENT_FK_CONSTRAINTS...
          ╰────────────────────────────────────────────────────
```

**TL;DR:** Comments now have a box around them with the target line number in the header — much easier to read inline.

---

## Changes

- **`src/ui/diff_view.rs`** — `render_comment_lines()` now has two paths:
  - `inline=true`: renders a `╭─ 💬 R{n}` top label, `│` left border on author + text lines, `╰─` bottom border
  - `inline=false` (panel/hunk-level): unchanged