### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-crate Rust CLI tool (`er`) with no external services. See `CLAUDE.md` for full architecture and code conventions.
+
+### Build / Test / Lint / Run
+
+| Task | Command |
+|------|---------|
+| Build (dev) | `cargo build` |
+| Build (release) | `cargo build --release` |
+| Install binary | `cargo install --path .` |
+| Run | `er` (from any git repo) |
+| Test | `cargo test` |
+| Clippy | `cargo clippy --all-targets -- -D warnings` |
+| Format check | `cargo fmt --all -- --check` |
+| Debug mode | `ER_DEBUG=1 er` (logs to `/tmp/er_debug.log`) |
+
+### Gotchas
+
+- **Rust toolchain**: The default VM ships with Rust 1.83 which is too old — `time-core` requires `edition2024` (stabilized in 1.85). The update script runs `rustup update stable && rustup default stable` to ensure a recent toolchain.
+- **TUI requires a terminal**: `er` renders via crossterm/ratatui, so it must run inside a real terminal (tmux session, not a headless pipe). Use `tmux` to launch and `computerUse` subagent to interact with it.
+- **Clippy warnings**: As of the current codebase, `cargo clippy --all-targets -- -D warnings` reports 9 pre-existing warnings (collapsible_match, unnecessary_sort_by, manual_checked_ops). These are not regressions — they exist on `main`.
+- **No external services**: No databases, Docker, or network services needed. The only runtime dependency is `git` (and optionally `gh` CLI for GitHub PR features).
+- **`.er/` directory**: AI sidecar files are read from `.er/` in the repo root. This directory is gitignored. The TUI creates `.er/session.json` on first run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, covering:

- Build / test / lint / run command reference table
- Key gotchas (Rust toolchain version, TUI terminal requirements, pre-existing clippy warnings, no external services needed)

This file is intended for AI coding agents operating in Cursor Cloud environments.

### Demo

[er_tui_demo_mode_switching.mp4](https://cursor.com/agents/bc-a1797b64-40e7-46fa-afda-cdf6ce739b8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fer_tui_demo_mode_switching.mp4)

The `er` TUI running in the development environment, demonstrating mode switching between Branch, Unstaged, and Staged views.

[er TUI showing branch diff mode](https://cursor.com/agents/bc-a1797b64-40e7-46fa-afda-cdf6ce739b8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fer_tui_branch_diff.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1797b64-40e7-46fa-afda-cdf6ce739b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1797b64-40e7-46fa-afda-cdf6ce739b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

