### PR TITLE
feat(desktop): add project filter dropdown to inbox popover

### DIFF
--- a/desktop-ui/src/lib/components/LeftSidebar.svelte
+++ b/desktop-ui/src/lib/components/LeftSidebar.svelte
@@ -52,6 +52,7 @@
 
   let inboxPopoverOpen = $state(false);
   let inboxFilter = $state<"all" | "unread" | "read">("all");
+  let inboxProjectFilter = $state<"all" | string>("all");
   let selectedInboxMessage = $state<InboxItemSnapshot | null>(null);
   let expandedProject = $state<string | null>(null);
   let pendingBranchKey = $state<string | null>(null);
@@ -209,15 +210,54 @@
       .slice(0, 2),
   );
 
+  /** Resolve which project an inbox item belongs to (explicit id or repo/remote match). */
+  function inboxItemProjectId(item: InboxItemSnapshot): string | null {
+    if (item.target.project_id) return item.target.project_id;
+    const root = item.target.repo_root;
+    if (root) {
+      const match = projects.find((p) => p.root_path && p.root_path === root);
+      if (match) return match.id;
+    }
+    const remote = item.target.remote;
+    if (remote) {
+      const match = projects.find((p) => p.remote && p.remote === remote);
+      if (match) return match.id;
+    }
+    return null;
+  }
+
+  /** Projects that have at least one inbox item, sorted by name. */
+  const inboxProjectOptions = $derived(
+    projects
+      .filter((p) => inboxItems.some((item) => inboxItemProjectId(item) === p.id))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  );
+
+  $effect(() => {
+    if (
+      inboxProjectFilter !== "all" &&
+      !inboxProjectOptions.some((p) => p.id === inboxProjectFilter)
+    ) {
+      inboxProjectFilter = "all";
+    }
+  });
+
+  /** Inbox items filtered by the selected project. */
+  const inboxByProject = $derived(
+    inboxProjectFilter === "all"
+      ? inboxVisible
+      : inboxVisible.filter((i) => inboxItemProjectId(i) === inboxProjectFilter),
+  );
+
   /** Inbox items filtered by the popover tab selection. */
   const inboxFiltered = $derived(
-    inboxVisible.filter((i) => {
+    inboxByProject.filter((i) => {
       if (inboxFilter === "unread") return i.read_at_ms == null;
       if (inboxFilter === "read") return i.read_at_ms != null;
       return true;
     }),
   );
-  const inboxUnreadCountAll = $derived(inboxVisible.filter((i) => i.read_at_ms == null).length);
+  const inboxUnreadCountAll = $derived(inboxByProject.filter((i) => i.read_at_ms == null).length);
 
   function isProjectOpen(p: ProjectSnapshot): boolean {
     if (sidebarSearchNeedle) return true;
@@ -670,7 +710,7 @@
               type="button"
               onclick={() => (inboxFilter = "all")}
               class="h-[22px] px-2 rounded-sm text-[11px] font-medium flex items-center gap-1 {inboxFilter === 'all' ? 'bg-hover text-fg' : 'text-muted hover:text-fg-3'}"
-            >All <span class="{inboxFilter === 'all' ? 'text-muted' : 'text-muted'} ml-0.5">{inboxVisible.length}</span></button>
+            >All <span class="{inboxFilter === 'all' ? 'text-muted' : 'text-muted'} ml-0.5">{inboxByProject.length}</span></button>
             <button
               type="button"
               onclick={() => (inboxFilter = "unread")}
@@ -702,6 +742,21 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M19 6l-1 14H6L5 6M10 11v6M14 11v6M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
           </button>
         </div>
+        {#if inboxProjectOptions.length > 0}
+          <div class="flex items-center gap-2">
+            <label for="inbox-project-filter" class="text-[11px] text-muted shrink-0">Project</label>
+            <select
+              id="inbox-project-filter"
+              bind:value={inboxProjectFilter}
+              class="flex-1 min-w-0 bg-surface border border-hairline rounded px-2 py-1 text-[11px] text-fg outline-none"
+            >
+              <option value="all">All</option>
+              {#each inboxProjectOptions as project (project.id)}
+                <option value={project.id}>{project.name}</option>
+              {/each}
+            </select>
+          </div>
+        {/if}
       </div>
       <!-- Item list -->
       <div class="flex-1 overflow-y-auto p-1">

--- a/desktop-ui/src/lib/stories/Inbox.stories.ts
+++ b/desktop-ui/src/lib/stories/Inbox.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/svelte";
 import InboxHarness from "$lib/stories/InboxHarness.svelte";
-import type { InboxItemSnapshot } from "$lib/types";
+import type { InboxItemSnapshot, ProjectSnapshot } from "$lib/types";
 
 // ─── fixture items covering all supported inbox kinds ───────────────────────
 // LeftSidebar.inboxKindMeta() switches on: "pr_merged"|"merged",
@@ -9,6 +9,37 @@ import type { InboxItemSnapshot } from "$lib/types";
 // severity branch ("error"|"warning") or the default briefcase icon.
 
 const now = Date.now();
+
+const inboxProjects: ProjectSnapshot[] = [
+  {
+    id: "discovery-platform",
+    name: "discovery-platform",
+    root_path: "/Users/vilfred/Projects/discovery-platform",
+    remote: "org/discovery-platform",
+    is_active: true,
+    local_branches: [],
+    auto_branches: [],
+    saved_prs: [],
+    my_prs: [],
+    prs_to_review: [],
+    recent_prs: [],
+    recently_merged: [],
+  },
+  {
+    id: "design-system",
+    name: "design-system",
+    root_path: "/Users/vilfred/Projects/design-system",
+    remote: "org/design-system",
+    is_active: false,
+    local_branches: [],
+    auto_branches: [],
+    saved_prs: [],
+    my_prs: [],
+    prs_to_review: [],
+    recent_prs: [],
+    recently_merged: [],
+  },
+];
 
 const allKindsItems: InboxItemSnapshot[] = [
   // ── unread ──────────────────────────────────────────────────────────────
@@ -85,6 +116,18 @@ const allKindsItems: InboxItemSnapshot[] = [
     read_at_ms: now - 2 * 3_600_000,
     dedupe_key: "comment:2030:thread-8",
   },
+  {
+    id: "inbox-review-design-1",
+    kind: "review_requested",
+    severity: "info",
+    title: "Review requested: feat/button-variants",
+    body: "sam requested your review on PR #88.",
+    source: "github",
+    target: { pr_number: 88, project_id: "design-system" },
+    created_at_ms: now - 45 * 60 * 1000,
+    read_at_ms: null,
+    dedupe_key: "review_requested:88",
+  },
 ];
 
 const meta = {
@@ -106,6 +149,7 @@ type Story = StoryObj<typeof meta>;
 export const Teaser: Story = {
   args: {
     inboxItems: allKindsItems,
+    projects: inboxProjects,
     autoOpenPopover: false,
   },
 };
@@ -119,6 +163,7 @@ export const Teaser: Story = {
 export const PopoverOpen: Story = {
   args: {
     inboxItems: allKindsItems,
+    projects: inboxProjects,
     autoOpenPopover: true,
   },
 };

--- a/desktop-ui/src/lib/stories/InboxHarness.svelte
+++ b/desktop-ui/src/lib/stories/InboxHarness.svelte
@@ -3,10 +3,11 @@
   import { app } from "$lib/stores/app.svelte";
   import LeftSidebar from "$lib/components/LeftSidebar.svelte";
   import { richSnapshot } from "$lib/stories/fixtures";
-  import type { InboxItemSnapshot } from "$lib/types";
+  import type { InboxItemSnapshot, ProjectSnapshot } from "$lib/types";
 
   interface Props {
     inboxItems?: InboxItemSnapshot[];
+    projects?: ProjectSnapshot[];
     /**
      * When true, the harness performs a DOM click on the inbox "Inbox" header
      * button after mount so the popover opens without modifying LeftSidebar.
@@ -15,12 +16,13 @@
     autoOpenPopover?: boolean;
   }
 
-  const { inboxItems = [], autoOpenPopover = false }: Props = $props();
+  const { inboxItems = [], projects = [], autoOpenPopover = false }: Props = $props();
 
   // Seed app.snapshot so LeftSidebar derives the inbox state from the store.
   $effect(() => {
     app.snapshot = {
       ...richSnapshot,
+      projects,
       inbox_items: inboxItems,
       inbox_unread_count: inboxItems.filter((i) => i.read_at_ms == null).length,
       inbox_last_refresh_ms: inboxItems.length > 0 ? Date.now() - 2 * 60 * 1000 : 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Project** dropdown inside the inbox popover so notifications can be filtered per project:

- **All** — show every inbox item (default)
- **Project A / Project B / …** — only items belonging to that project

Items are matched via `target.project_id`, with fallbacks to `repo_root` and `remote` when the explicit id is missing. The All/Unread/Read tab counts respect the active project filter.

## Changes

- `LeftSidebar.svelte`: project filter state, resolution helper, dropdown UI in popover header
- `InboxHarness.svelte` / `Inbox.stories.ts`: multi-project fixture data for Storybook

## Test plan

- [ ] Open inbox popover with notifications from multiple projects
- [ ] Verify dropdown lists **All** plus each project that has inbox items
- [ ] Select a project — list and All/Unread counts update accordingly
- [ ] Switch All/Unread/Read tabs while a project is selected
- [ ] Storybook: `Layout/Inbox → PopoverOpen` shows the project dropdown
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c5300ee-e22c-4afe-870d-c55b2385940a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5300ee-e22c-4afe-870d-c55b2385940a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

