### PR TITLE
fix(cloud): gate rustup update on overlayfs VMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This is a single-crate Rust CLI tool (`er`) with no external services. See `CLAU
 
 ### Gotchas
 
-- **Rust toolchain**: The default VM ships with Rust 1.83 which is too old — `time-core` requires `edition2024` (stabilized in 1.85). The update script runs `rustup update stable && rustup default stable` to ensure a recent toolchain.
+- **Rust toolchain**: easy-review needs Rust **1.85+** (`edition2024`). Cloud VMs may ship an older or already-current stable under `/usr/local/rustup`. The install hook [`scripts/cloud-agent-install.sh`](scripts/cloud-agent-install.sh) runs `rustup update stable` **only when** `rustc` is missing or < 1.85 — unconditional `rustup update` fails on overlayfs (EXDEV / “Invalid cross-device link”) when updating the baked system toolchain. It always runs `rustup default stable` and `cargo fetch`.
 - **TUI requires a terminal**: `er` renders via crossterm/ratatui, so it must run inside a real terminal (tmux session, not a headless pipe). Use `tmux` to launch and `computerUse` subagent to interact with it.
 - **Clippy warnings**: As of the current codebase, `cargo clippy --all-targets -- -D warnings` reports 9 pre-existing warnings (collapsible_match, unnecessary_sort_by, manual_checked_ops). These are not regressions — they exist on `main`.
 - **No external services**: No databases, Docker, or network services needed. The only runtime dependency is `git` (and optionally `gh` CLI for GitHub PR features).

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Cloud-agent VM bootstrap for easy-review.
+# Only runs `rustup update` when stable is older than MIN_RUST_VERSION.
+# Unconditional updates fail on overlayfs when RUSTUP_HOME=/usr/local/rustup (EXDEV on rename).
+set -euo pipefail
+
+MIN_RUST_VERSION="${MIN_RUST_VERSION:-1.85.0}"
+
+printf '>>> [install:] start\n'
+
+rust_version_at_least() {
+  local min="$1"
+  local ver major minor patch min_major min_minor min_patch
+  ver=$(rustc --version 2>/dev/null | awk '{print $2}' | cut -d- -f1) || return 1
+  IFS=. read -r major minor patch <<<"$ver"
+  IFS=. read -r min_major min_minor min_patch <<<"$min"
+  if (( major > min_major )); then return 0; fi
+  if (( major < min_major )); then return 1; fi
+  if (( minor > min_minor )); then return 0; fi
+  if (( minor < min_minor )); then return 1; fi
+  return 0
+}
+
+if rust_version_at_least "$MIN_RUST_VERSION"; then
+  echo "Rust >= ${MIN_RUST_VERSION} already installed ($(rustc --version)), skipping rustup update"
+else
+  echo "Rust < ${MIN_RUST_VERSION} or missing; running rustup update stable"
+  rustup update stable
+fi
+
+rustup default stable
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+cargo fetch
+
+printf '<<< [install:] complete\n'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud-agent install hooks were failing with `Invalid cross-device link (os error 18)` when running unconditional `rustup update stable` against the baked `/usr/local/rustup` toolchain on overlayfs.

This adds `scripts/cloud-agent-install.sh` which:
- Skips `rustup update` when `rustc` is already **≥ 1.85** (project minimum)
- Always runs `rustup default stable` and `cargo fetch`

Also updates `AGENTS.md` to document the overlayfs gotcha.

## Cloud agent env config

Point the user install hook at:

```bash
exec /workspace/scripts/cloud-agent-install.sh
```

(or copy the script contents into the cloud-agent install script field)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01fb1a98-4a57-4925-9174-7caff65fd27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01fb1a98-4a57-4925-9174-7caff65fd27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

