### PR TITLE
Polish desktop Settings page

### DIFF
--- a/desktop-ui/src/lib/components/settings/OptionGroup.svelte
+++ b/desktop-ui/src/lib/components/settings/OptionGroup.svelte
@@ -15,14 +15,14 @@
   }
 </script>
 
-<div class="flex items-center justify-between gap-4 py-3">
+<div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 py-3">
   <div class="min-w-0">
     <div class="text-sm text-fg">{label}</div>
     {#if description}
       <div class="text-xs text-muted mt-0.5">{description}</div>
     {/if}
   </div>
-  <div class="inline-flex shrink-0 p-0.5 gap-0.5 bg-ink-850 border border-hairline rounded-lg flex-wrap justify-end">
+  <div class="inline-flex min-w-0 max-w-full p-0.5 gap-0.5 bg-ink-850 border border-hairline rounded-lg flex-wrap justify-end">
     {#each options as opt (opt)}
       <button
         type="button"

--- a/desktop-ui/src/lib/components/settings/OptionGroup.svelte
+++ b/desktop-ui/src/lib/components/settings/OptionGroup.svelte
@@ -15,20 +15,21 @@
   }
 </script>
 
-<div class="py-2">
-  <div class="mb-1.5">
+<div class="flex items-center justify-between gap-4 py-3">
+  <div class="min-w-0">
     <div class="text-sm text-fg">{label}</div>
     {#if description}
       <div class="text-xs text-muted mt-0.5">{description}</div>
     {/if}
   </div>
-  <div class="flex flex-wrap gap-1">
+  <div class="inline-flex shrink-0 p-0.5 gap-0.5 bg-ink-850 border border-hairline rounded-lg flex-wrap justify-end">
     {#each options as opt (opt)}
       <button
         type="button"
-        class="px-2.5 py-1 text-xs rounded-md border transition-colors {value === opt
-          ? 'bg-accent text-black border-accent'
-          : 'bg-surface text-fg-2 border-hairline hover:bg-hover'}"
+        aria-pressed={value === opt}
+        class="px-2.5 py-1 text-xs rounded-md transition-colors {value === opt
+          ? 'bg-accent-soft text-accent font-medium'
+          : 'text-fg-3 hover:text-fg hover:bg-hover'}"
         onclick={() => onchange(opt)}
       >
         {display(opt)}

--- a/desktop-ui/src/lib/components/settings/ProjectSettingsCard.svelte
+++ b/desktop-ui/src/lib/components/settings/ProjectSettingsCard.svelte
@@ -21,15 +21,15 @@
 
 </script>
 
-<section class="border border-hairline rounded-lg px-4 py-3 mb-3 bg-surface/40">
-  <div class="flex items-baseline justify-between gap-2 mb-1">
-    <h3 class="text-sm font-medium text-fg">{project.name}</h3>
+<section class="bg-card border border-hairline rounded-xl px-4 py-3.5 mb-4">
+  <div class="flex items-baseline justify-between gap-2">
+    <h3 class="text-sm font-semibold text-fg tracking-tight">{project.name}</h3>
     {#if project.remote}
       <span class="text-[10px] font-mono text-muted truncate">{project.remote}</span>
     {/if}
   </div>
   {#if project.root_path}
-    <p class="text-[10px] font-mono text-muted truncate mb-2" title={project.root_path}>
+    <p class="text-[10px] font-mono text-muted truncate mt-0.5 mb-2" title={project.root_path}>
       {project.root_path}
     </p>
   {/if}
@@ -39,7 +39,7 @@
       Run triage from the sidebar — hover a branch or PR row and click the scan icon.
     </p>
     <div class="py-2">
-      <div class="text-sm text-fg mb-1">Max diff size (KB)</div>
+      <div class="text-sm text-fg mb-0.5">Max diff size (KB)</div>
       <div class="text-xs text-muted mb-1.5">
         Skip sidebar triage when the filtered diff exceeds this size. Leave empty for no limit.
       </div>
@@ -48,7 +48,7 @@
           type="number"
           min="0"
           step="1"
-          class="flex-1 bg-surface border border-hairline rounded-md px-2 py-1.5 text-sm font-mono"
+          class="flex-1 bg-ink-850 border border-hairline rounded-md px-2.5 py-1.5 text-sm font-mono outline-none transition-colors placeholder:text-ink-300 hover:border-border focus:border-accent/60"
           placeholder="No limit"
           bind:value={maxDiffInput}
           onchange={() => {
@@ -62,31 +62,33 @@
   {/if}
 
   <div class="mt-3 pt-3 border-t border-hairline/60">
-    <div class="text-sm text-fg mb-1">Ignore in AI reviews</div>
+    <div class="text-sm text-fg mb-0.5">Ignore in AI reviews</div>
     <div class="text-xs text-muted mb-2">
       Glob patterns excluded from triage and full-review diffs (e.g. <code class="font-mono">**/*.lock</code>).
     </div>
     {#if ignoreGlobs.length === 0}
-      <p class="text-xs text-muted mb-2">No ignore patterns.</p>
+      <p class="text-xs text-muted/80 italic mb-2">No ignore patterns.</p>
     {:else}
-      {#each ignoreGlobs as glob, index (glob + index)}
-        <div class="flex items-center gap-2 py-1 font-mono text-xs text-fg-2">
-          <span class="flex-1 truncate" title={glob}>{glob}</span>
-          <button
-            type="button"
-            class="text-muted hover:text-red-400 px-2"
-            title="Remove"
-            onclick={() => onpatch({ reviewIgnoreGlobRemove: index })}
-          >
-            ×
-          </button>
-        </div>
-      {/each}
+      <div class="divide-y divide-hairline/40 mb-1">
+        {#each ignoreGlobs as glob, index (glob + index)}
+          <div class="flex items-center gap-2 py-1.5 font-mono text-xs text-fg-2 group">
+            <span class="flex-1 truncate" title={glob}>{glob}</span>
+            <button
+              type="button"
+              class="text-muted opacity-60 group-hover:opacity-100 hover:text-risk-high px-2 py-0.5 rounded transition-colors"
+              title="Remove"
+              onclick={() => onpatch({ reviewIgnoreGlobRemove: index })}
+            >
+              ×
+            </button>
+          </div>
+        {/each}
+      </div>
     {/if}
     <div class="flex gap-2 mt-1">
       <input
         type="text"
-        class="flex-1 bg-surface border border-hairline rounded-md px-2 py-1.5 text-sm font-mono"
+        class="flex-1 bg-ink-850 border border-hairline rounded-md px-2.5 py-1.5 text-sm font-mono outline-none transition-colors placeholder:text-ink-300 hover:border-border focus:border-accent/60"
         placeholder="Glob pattern, e.g. package-lock.json"
         bind:value={addGlob}
       />

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -51,6 +51,33 @@
   const selectedProvider = $derived(providers.find((p) => p.is_selected) ?? null);
   const selectedModels = $derived(selectedProvider?.models ?? []);
 
+  interface FieldSection {
+    title: string | null;
+    fields: ConfigHubField[];
+  }
+
+  const sections = $derived.by<FieldSection[]>(() => {
+    const out: FieldSection[] = [];
+    let current: FieldSection = { title: null, fields: [] };
+    for (const field of fields) {
+      if (field.kind === "section") {
+        if (current.fields.length > 0) out.push(current);
+        current = { title: field.title, fields: [] };
+      } else {
+        current.fields.push(field);
+      }
+    }
+    if (current.fields.length > 0) out.push(current);
+    return out;
+  });
+
+  function fieldKey(field: ConfigHubField, i: number): string {
+    if (field.kind === "bool" || field.kind === "cycle" || field.kind === "text") return field.key;
+    if (field.kind === "listEntry") return field.key + "-" + field.index;
+    if (field.kind === "section") return "section-" + field.title;
+    return "field-" + i;
+  }
+
   function applySettings(res: GetConfigHubResponse) {
     generalFields = res.settings.general;
     terminalFields = res.settings.terminal;
@@ -182,197 +209,241 @@
 </script>
 
 <div class="flex flex-col flex-1 w-full min-w-0 h-full min-h-0 bg-bg text-fg">
-  <header class="shrink-0 flex items-center gap-3 px-4 py-3 border-b border-hairline">
+  <header class="shrink-0 flex items-center gap-3 px-5 py-3 border-b border-hairline bg-surface/60">
     <button
       type="button"
-      class="text-sm text-fg-3 hover:text-fg"
+      class="inline-flex items-center gap-1.5 px-2 py-1 -ml-2 text-sm text-fg-3 hover:text-fg hover:bg-hover rounded-md transition-colors"
       onclick={onBack}
     >
-      ← Back
+      <span aria-hidden="true">←</span>
+      Back
     </button>
-    <h1 class="text-base font-semibold">Settings</h1>
-    <span class="text-xs text-muted truncate ml-auto font-mono" title={repoRoot}>
+    <div class="w-px h-4 bg-hairline" aria-hidden="true"></div>
+    <h1 class="text-base font-semibold tracking-tight">Settings</h1>
+    <span
+      class="ml-auto inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-ink-650 border border-border text-[10px] font-mono text-muted truncate"
+      title={repoRoot}
+    >
+      <span
+        class="w-1.5 h-1.5 rounded-full shrink-0 {hasLocalConfig ? 'bg-accent' : 'bg-ink-300'}"
+        aria-hidden="true"
+      ></span>
       {hasLocalConfig ? ".er-config.toml" : "global defaults"}
     </span>
   </header>
 
   {#if loading}
-    <div class="flex-1 flex items-center justify-center text-sm text-muted">Loading…</div>
-  {:else}
-    <div
-      class="shrink-0 flex gap-1 px-4 pt-3 border-b border-hairline"
-      role="tablist"
-      aria-label="Settings sections"
-    >
-      {#each TABS as tab (tab.id)}
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === tab.id}
-          class="px-3 py-1.5 text-sm rounded-t-md border-b-2 transition-colors {activeTab === tab.id
-            ? 'border-accent text-fg font-medium'
-            : 'border-transparent text-fg-3 hover:text-fg hover:bg-hover'}"
-          onclick={() => (activeTab = tab.id)}
-        >
-          {tab.label}
-        </button>
-      {/each}
+    <div class="flex-1 overflow-hidden px-6 py-6">
+      <div class="max-w-2xl mx-auto space-y-4 animate-pulse" aria-label="Loading settings">
+        <div class="h-7 w-64 bg-ink-700 rounded-lg"></div>
+        <div class="h-3 w-80 bg-ink-750 rounded"></div>
+        <div class="h-40 bg-ink-800 border border-hairline rounded-xl"></div>
+        <div class="h-40 bg-ink-800 border border-hairline rounded-xl"></div>
+      </div>
     </div>
-
-    <div class="flex-1 overflow-y-auto w-full px-6 py-4">
-      <p class="text-xs text-muted mb-4">{tabBlurb}</p>
-      {#if activeTab === "terminal" && localThemeOverride}
-        <p class="text-xs text-yellow-400/90 mb-4 border border-yellow-400/30 rounded-md px-3 py-2 bg-yellow-400/5">
-          This repo’s <code class="font-mono">.er-config.toml</code> sets theme to
-          <code class="font-mono">{localThemeOverride}</code>, which overrides your global config when you run
-          <code class="font-mono">er</code> here. Use “Save to repo” after changing theme, or remove
-          <code class="font-mono">[display].theme</code> from the repo file to follow global only.
-        </p>
-      {/if}
-
-      {#if activeTab === "projects"}
-        {#if projects.length === 0}
-          <p class="text-sm text-muted">No projects registered yet. Open a repo from the sidebar first.</p>
-        {:else}
-          {#each projects as project (project.id)}
-            <ProjectSettingsCard
-              {project}
-              onpatch={(patch) => patchProjectReviewSettings(project.id, patch)}
-            />
-          {/each}
-        {/if}
-      {:else}
-      {#each fields as field, i (field.kind === "section" ? field.title : "field-" + i + (field.kind === "bool" || field.kind === "cycle" || field.kind === "text" ? field.key : field.kind === "listEntry" ? field.key : field.label))}
-        {#if field.kind === "section"}
-          <h2 class="text-xs uppercase tracking-wider text-muted font-semibold mt-6 mb-2 first:mt-0">
-            {field.title}
-          </h2>
-        {:else if field.kind === "bool"}
-          <Toggle
-            label={field.label}
-            description={field.description}
-            checked={field.value}
-            onchange={(v) => patch(field.key, v)}
-          />
-        {:else if field.kind === "cycle"}
-          <OptionGroup
-            label={field.label}
-            description={field.description}
-            options={field.options}
-            value={field.value}
-            onchange={(v) => patch(field.key, v)}
-          />
-        {:else if field.kind === "text"}
-          <SettingsTextField
-            label={field.label}
-            description={field.description}
-            placeholder={field.placeholder}
-            value={field.value}
-            strict={field.strict}
-            warning={textWarnings[field.key] ?? null}
-            oncommit={(v) => {
-              validateText(field.key, v);
-              void patch(field.key, v);
-            }}
-          />
-        {:else if field.kind === "listEntry"}
-          <div class="flex items-center gap-2 py-1.5 font-mono text-xs text-fg-2">
-            <span class="flex-1 truncate">{field.label}</span>
+  {:else}
+    <div class="flex-1 overflow-y-auto w-full min-h-0">
+      <div class="max-w-2xl mx-auto px-6 py-5 pb-8">
+        <div
+          class="inline-flex p-0.5 gap-0.5 bg-surface border border-hairline rounded-lg"
+          role="tablist"
+          aria-label="Settings sections"
+        >
+          {#each TABS as tab (tab.id)}
             <button
               type="button"
-              class="text-muted hover:text-red-400 px-2"
-              title="Remove"
-              onclick={() => patch("watched.paths.remove", field.index)}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              class="px-3.5 py-1 text-xs rounded-md transition-colors {activeTab === tab.id
+                ? 'bg-hover text-fg font-medium shadow-sm'
+                : 'text-fg-3 hover:text-fg'}"
+              onclick={() => (activeTab = tab.id)}
             >
-              ×
+              {tab.label}
             </button>
-          </div>
-        {:else if field.kind === "listAdd"}
-          <div class="py-2 flex gap-2">
-            <input
-              type="text"
-              class="flex-1 bg-surface border border-hairline rounded-md px-2 py-1.5 text-sm font-mono"
-              placeholder="Glob pattern, e.g. .work/**"
-              bind:value={addPattern}
-            />
-            <Button
-              onclick={() => {
-                const p = addPattern.trim();
-                if (!p) return;
-                void patch("watched.paths.add", p).then(() => {
-                  addPattern = "";
-                });
-              }}
-            >
-              Add
-            </Button>
+          {/each}
+        </div>
+        <p class="text-xs text-muted mt-3 mb-5">{tabBlurb}</p>
+
+        {#if activeTab === "terminal" && localThemeOverride}
+          <div
+            class="flex gap-2.5 text-xs text-question/90 mb-5 border border-question-border rounded-lg px-3.5 py-2.5 bg-question-surface"
+          >
+            <span aria-hidden="true" class="shrink-0">⚠</span>
+            <p>
+              This repo’s <code class="font-mono">.er-config.toml</code> sets theme to
+              <code class="font-mono">{localThemeOverride}</code>, which overrides your global config when you run
+              <code class="font-mono">er</code> here. Use “Save to repo” after changing theme, or remove
+              <code class="font-mono">[display].theme</code> from the repo file to follow global only.
+            </p>
           </div>
         {/if}
-      {/each}
-      {/if}
 
-      {#if activeTab === "general"}
-        {#if providers.length > 0}
-          <h2 class="text-xs uppercase tracking-wider text-muted font-semibold mt-8 mb-2">AI Hub</h2>
-          <p class="text-xs text-muted mb-3">Session selection. Save defaults writes to config TOML.</p>
-          <div class="py-2">
-            <div class="text-sm text-fg mb-1.5">Provider</div>
-            <div class="flex flex-wrap gap-1">
-              {#each providers as p (p.id)}
-                <button
-                  type="button"
-                  class="px-2.5 py-1 text-xs rounded-md border transition-colors {p.is_selected
-                    ? 'bg-accent text-black border-accent'
-                    : 'bg-surface text-fg-2 border-hairline hover:bg-hover'}"
-                  onclick={() => void selectProvider(p.id)}
-                >
-                  {p.label}
-                </button>
+        {#if activeTab === "projects"}
+          {#if projects.length === 0}
+            <div class="border border-dashed border-border rounded-xl px-6 py-10 text-center">
+              <p class="text-sm text-fg-3 mb-1">No projects registered yet</p>
+              <p class="text-xs text-muted">Open a repo from the sidebar first.</p>
+            </div>
+          {:else}
+            {#each projects as project (project.id)}
+              <ProjectSettingsCard
+                {project}
+                onpatch={(patch) => patchProjectReviewSettings(project.id, patch)}
+              />
+            {/each}
+          {/if}
+        {:else}
+          {#each sections as section, si (section.title ?? "untitled-" + si)}
+            {#if section.title}
+              <h2 class="flex items-center gap-2 text-xs uppercase tracking-wider text-muted font-semibold mt-7 mb-2.5 first:mt-0">
+                <span class="w-1 h-3 rounded-full bg-accent/70" aria-hidden="true"></span>
+                {section.title}
+              </h2>
+            {/if}
+            <div class="bg-card border border-hairline rounded-xl divide-y divide-hairline/60">
+              {#each section.fields as field, i (fieldKey(field, i))}
+                {#if field.kind === "bool"}
+                  <div class="px-4">
+                    <Toggle
+                      label={field.label}
+                      description={field.description}
+                      checked={field.value}
+                      onchange={(v) => patch(field.key, v)}
+                    />
+                  </div>
+                {:else if field.kind === "cycle"}
+                  <div class="px-4">
+                    <OptionGroup
+                      label={field.label}
+                      description={field.description}
+                      options={field.options}
+                      value={field.value}
+                      onchange={(v) => patch(field.key, v)}
+                    />
+                  </div>
+                {:else if field.kind === "text"}
+                  <div class="px-4">
+                    <SettingsTextField
+                      label={field.label}
+                      description={field.description}
+                      placeholder={field.placeholder}
+                      value={field.value}
+                      strict={field.strict}
+                      warning={textWarnings[field.key] ?? null}
+                      oncommit={(v) => {
+                        validateText(field.key, v);
+                        void patch(field.key, v);
+                      }}
+                    />
+                  </div>
+                {:else if field.kind === "listEntry"}
+                  <div class="flex items-center gap-2 px-4 py-2 font-mono text-xs text-fg-2 group">
+                    <span class="flex-1 truncate" title={field.label}>{field.label}</span>
+                    <button
+                      type="button"
+                      class="text-muted opacity-60 group-hover:opacity-100 hover:text-risk-high px-2 py-0.5 rounded transition-colors"
+                      title="Remove"
+                      onclick={() => patch("watched.paths.remove", field.index)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                {:else if field.kind === "listAdd"}
+                  <div class="px-4 py-3 flex gap-2">
+                    <input
+                      type="text"
+                      class="flex-1 bg-ink-850 border border-hairline rounded-md px-2.5 py-1.5 text-sm font-mono outline-none transition-colors focus:border-accent/60 placeholder:text-ink-300"
+                      placeholder="Glob pattern, e.g. .work/**"
+                      bind:value={addPattern}
+                    />
+                    <Button
+                      onclick={() => {
+                        const p = addPattern.trim();
+                        if (!p) return;
+                        void patch("watched.paths.add", p).then(() => {
+                          addPattern = "";
+                        });
+                      }}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                {/if}
               {/each}
             </div>
-          </div>
-          {#if selectedModels.length > 0}
-            <div class="py-2">
-              <div class="text-sm text-fg mb-1.5">Model</div>
-              <div class="flex flex-wrap gap-1">
-                {#each selectedModels as m (m.id)}
-                  <button
-                    type="button"
-                    class="px-2.5 py-1 text-xs rounded-md border transition-colors {m.is_selected
-                      ? 'bg-accent text-black border-accent'
-                      : 'bg-surface text-fg-2 border-hairline hover:bg-hover'}"
-                    onclick={() => void selectModel(m.id)}
-                  >
-                    {m.label}
-                  </button>
-                {/each}
+          {/each}
+        {/if}
+
+        {#if activeTab === "general"}
+          <h2 class="flex items-center gap-2 text-xs uppercase tracking-wider text-muted font-semibold mt-7 mb-2.5">
+            <span class="w-1 h-3 rounded-full bg-accent/70" aria-hidden="true"></span>
+            AI Hub
+          </h2>
+          {#if providers.length > 0}
+            <div class="bg-card border border-hairline rounded-xl px-4 py-3">
+              <p class="text-xs text-muted mb-3">
+                Session selection. “Save as default” writes to config TOML.
+              </p>
+              <div class="py-1">
+                <div class="text-sm text-fg mb-1.5">Provider</div>
+                <div class="flex flex-wrap gap-1.5">
+                  {#each providers as p (p.id)}
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-xs rounded-md border transition-colors {p.is_selected
+                        ? 'bg-accent-soft text-accent border-accent-border font-medium'
+                        : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
+                      onclick={() => void selectProvider(p.id)}
+                    >
+                      {p.label}
+                    </button>
+                  {/each}
+                </div>
+              </div>
+              {#if selectedModels.length > 0}
+                <div class="py-2 mt-1">
+                  <div class="text-sm text-fg mb-1.5">Model</div>
+                  <div class="flex flex-wrap gap-1.5">
+                    {#each selectedModels as m (m.id)}
+                      <button
+                        type="button"
+                        class="px-2.5 py-1 text-xs rounded-md border transition-colors {m.is_selected
+                          ? 'bg-accent-soft text-accent border-accent-border font-medium'
+                          : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
+                        onclick={() => void selectModel(m.id)}
+                      >
+                        {m.label}
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+              <div class="mt-2 pt-2 border-t border-hairline/60">
+                <Button onclick={() => void saveDefaults()}>Save as default</Button>
               </div>
             </div>
+          {:else}
+            <div class="border border-dashed border-border rounded-xl px-6 py-8 text-center">
+              <p class="text-xs text-muted">
+                No <code class="font-mono">[ai_hub]</code> providers in config. Add providers in
+                <code class="font-mono">.er-config.toml</code>.
+              </p>
+            </div>
           {/if}
-          <div class="mt-2">
-            <Button onclick={() => void saveDefaults()}>Save as default</Button>
-          </div>
-        {:else}
-          <h2 class="text-xs uppercase tracking-wider text-muted font-semibold mt-8 mb-2">AI Hub</h2>
-          <p class="text-xs text-muted">
-            No <code class="font-mono">[ai_hub]</code> providers in config. Add providers in
-            <code class="font-mono">.er-config.toml</code>.
-          </p>
         {/if}
-      {/if}
-
+      </div>
     </div>
 
-    <footer class="shrink-0 flex flex-wrap gap-2 px-4 py-3 border-t border-hairline bg-surface">
-      <Button onclick={() => void saveLocal()}>Save to repo</Button>
-      <Button onclick={() => void saveGlobal()}>Save globally</Button>
-      <button
-        type="button"
-        class="px-3 py-1.5 text-sm text-fg-3 hover:text-fg rounded-md hover:bg-hover"
-        onclick={() => void revert()}
-      >
-        Revert
-      </button>
+    <footer class="shrink-0 flex flex-wrap items-center gap-2 px-5 py-3 border-t border-hairline bg-surface">
+      <div class="flex gap-2 max-w-2xl mx-auto w-full items-center px-1">
+        <Button variant="primary" onclick={() => void saveLocal()}>Save to repo</Button>
+        <Button onclick={() => void saveGlobal()}>Save globally</Button>
+        <Button variant="ghost" onclick={() => void revert()}>Revert</Button>
+        <span class="ml-auto text-[10px] font-mono text-muted hidden sm:block">
+          {hasLocalConfig ? ".er-config.toml" : "~/.config/er/config.toml"}
+        </span>
+      </div>
     </footer>
   {/if}
 </div>

--- a/desktop-ui/src/lib/components/settings/SettingsTextField.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsTextField.svelte
@@ -26,20 +26,23 @@
   });
 </script>
 
-<div class="py-2">
-  <label class="block text-sm text-fg mb-1">{label}</label>
+<div class="py-3">
+  <label class="block text-sm text-fg mb-0.5">{label}</label>
   {#if description}
     <p class="text-xs text-muted mb-1.5">{description}</p>
   {/if}
   <input
     type="text"
-    class="w-full bg-surface border border-hairline rounded-md px-2.5 py-1.5 text-sm text-fg outline-none focus:border-accent/60 font-mono"
+    class="w-full bg-ink-850 border border-hairline rounded-md px-2.5 py-1.5 text-sm text-fg outline-none font-mono transition-colors placeholder:text-ink-300 hover:border-border focus:border-accent/60"
     {placeholder}
     bind:value={draft}
     onblur={() => oncommit(draft)}
     onkeydown={(e) => e.key === "Enter" && (e.currentTarget as HTMLInputElement).blur()}
   />
   {#if strict && warning}
-    <p class="text-xs text-amber-400/90 mt-1">{warning}</p>
+    <p class="flex items-center gap-1.5 text-xs text-risk-med mt-1.5">
+      <span aria-hidden="true">⚠</span>
+      {warning}
+    </p>
   {/if}
 </div>

--- a/desktop-ui/src/lib/components/settings/Toggle.svelte
+++ b/desktop-ui/src/lib/components/settings/Toggle.svelte
@@ -10,7 +10,7 @@
   const { checked, label, description = "", disabled = false, onchange }: Props = $props();
 </script>
 
-<label class="flex items-start justify-between gap-4 py-2 group {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}">
+<label class="flex items-center justify-between gap-4 py-3 group {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}">
   <span class="min-w-0">
     <span class="block text-sm text-fg">{label}</span>
     {#if description}
@@ -21,18 +21,19 @@
     type="button"
     role="switch"
     aria-checked={checked}
+    aria-label={label}
     disabled={disabled}
-    class="relative shrink-0 w-9 h-5 rounded-full border transition-colors {checked
+    class="relative shrink-0 w-9 h-5 rounded-full border transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-accent/40 {checked
       ? 'bg-accent border-accent'
-      : 'bg-ink-700 border-hairline'} disabled:cursor-not-allowed"
+      : 'bg-ink-700 border-border group-hover:border-ink-400'} disabled:cursor-not-allowed"
     onclick={() => {
       if (!disabled) onchange(!checked);
     }}
   >
     <span
-      class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {checked
-        ? 'translate-x-4'
-        : ''}"
+      class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full shadow transition-all duration-150 {checked
+        ? 'translate-x-4 bg-white'
+        : 'bg-ink-200 group-hover:bg-ink-100'}"
     ></span>
   </button>
 </label>


### PR DESCRIPTION
Closes #67

Reworks the desktop Settings page from a flat, full-bleed field list into a structured layout using the existing design tokens:

- Centered, readable content column; fields grouped into cards per section with accent-tick section headers
- Segmented control tabs instead of underline tabs
- Refined primitives: Toggle (focus ring, hover affordance), OptionGroup (right-aligned segmented control), text inputs (recessed `ink-850` wells, accent focus border, placeholder color)
- Footer hierarchy: primary "Save to repo", secondary "Save globally", ghost "Revert", plus the active config file path
- Config-target pill in the header, skeleton loading state, dashed-border empty states for Projects and AI Hub

**Verification:** `svelte-check` 0 errors, `vite build` passes.

https://claude.ai/code/session_016hkCShQssxEjLTRiYRWacU

---
_Generated by [Claude Code](https://claude.ai/code/session_016hkCShQssxEjLTRiYRWacU)_