### PR TITLE
Export page: rendered preview + Markdown/HTML formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "log",
  "notify-rust",
  "portable-pty",
+ "pulldown-cmark",
  "rfd",
  "serde",
  "serde_json",
@@ -3745,6 +3746,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,6 +5822,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/er-desktop/Cargo.toml
+++ b/crates/er-desktop/Cargo.toml
@@ -29,6 +29,7 @@ rfd = "0.15"
 dirs.workspace = true
 portable-pty = "0.8"
 ureq = { version = "2", default-features = false, features = ["tls"] }
+pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify-rust = "4.17"

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -6053,19 +6053,21 @@ pub fn update_thread_message(
     Ok(snap_from(&app, &state))
 }
 
-// ── Review export (markdown) ─────────────────────────────────────────────────
+// ── Review export (markdown / html) ──────────────────────────────────────────
 
-use crate::export::{render_markdown, ExportOpts};
+use crate::export::{render_export, render_markdown, ExportOpts};
 
-/// Render the active tab's annotations as markdown and return the body to
-/// the UI for clipboard copy / preview.
+/// Render the active tab's annotations in the format selected by
+/// `opts.format` (markdown or standalone HTML) and return the body to the UI
+/// for clipboard copy / preview.
 #[tauri::command]
 pub fn export_review(opts: ExportOpts, state: State<AppState>) -> Result<String, String> {
     let app = state.app.lock().map_err(|e| e.to_string())?;
-    Ok(render_markdown(app.tab(), &opts))
+    Ok(render_export(app.tab(), &opts))
 }
 
-/// Render and write to disk. Empty `path` writes to `<comments_dir>/export.md`.
+/// Render and write to disk. Empty `path` writes to
+/// `<comments_dir>/export.<md|html>` based on `opts.format`.
 /// Returns the resolved absolute path so the UI can show it in a toast.
 #[tauri::command]
 pub fn export_review_to_file(
@@ -6075,11 +6077,11 @@ pub fn export_review_to_file(
 ) -> Result<String, String> {
     let app = state.app.lock().map_err(|e| e.to_string())?;
     let tab = app.tab();
-    let body = render_markdown(tab, &opts);
+    let body = render_export(tab, &opts);
     let target = if path.trim().is_empty() {
         let dir = tab.comments_dir();
         std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {dir}: {e}"))?;
-        format!("{dir}/export.md")
+        format!("{dir}/export.{}", opts.format.extension())
     } else {
         path
     };

--- a/crates/er-desktop/src/export.rs
+++ b/crates/er-desktop/src/export.rs
@@ -14,6 +14,26 @@ fn default_true() -> bool {
     true
 }
 
+/// Output format for the export body. `Markdown` is the raw document;
+/// `Html` is the same document rendered to a standalone dark-themed page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportFormat {
+    #[default]
+    Markdown,
+    Html,
+}
+
+impl ExportFormat {
+    /// File extension for `export.<ext>` when saving to disk.
+    pub fn extension(self) -> &'static str {
+        match self {
+            ExportFormat::Markdown => "md",
+            ExportFormat::Html => "html",
+        }
+    }
+}
+
 /// Toggles for which annotation kinds to include in the export.
 ///
 /// JSON shape from the UI uses camelCase (Tauri 2 default).
@@ -26,6 +46,8 @@ pub struct ExportOpts {
     pub only_unresolved: bool,
     #[serde(default = "default_true")]
     pub include_annotations: bool,
+    #[serde(default)]
+    pub format: ExportFormat,
 }
 
 impl Default for ExportOpts {
@@ -36,18 +58,33 @@ impl Default for ExportOpts {
             include_findings: true,
             only_unresolved: false,
             include_annotations: true,
+            format: ExportFormat::Markdown,
         }
+    }
+}
+
+/// Render the export body in the format selected by `opts.format`.
+/// Both formats share the same markdown source — HTML is derived from it.
+pub fn render_export(tab: &TabState, opts: &ExportOpts) -> String {
+    let markdown = render_markdown(tab, opts);
+    match opts.format {
+        ExportFormat::Markdown => markdown,
+        ExportFormat::Html => render_html_document(&markdown, branch_label(tab)),
+    }
+}
+
+fn branch_label(tab: &TabState) -> &str {
+    if tab.current_branch.is_empty() {
+        "(unknown)"
+    } else {
+        tab.current_branch.as_str()
     }
 }
 
 /// Render the active tab's annotations as a single markdown document, grouped
 /// by file path. Returns a placeholder body when there is nothing to export.
 pub fn render_markdown(tab: &TabState, opts: &ExportOpts) -> String {
-    let branch = if tab.current_branch.is_empty() {
-        "(unknown)"
-    } else {
-        tab.current_branch.as_str()
-    };
+    let branch = branch_label(tab);
 
     // Group items by file path while preserving insertion order across kinds.
     // Within a file we emit: questions → comments → findings, matching the
@@ -357,6 +394,118 @@ fn push_blockquote(out: &mut String, body: &str, depth: usize) {
     out.push('\n');
 }
 
+/// Convert markdown to an HTML fragment via pulldown-cmark.
+///
+/// Raw HTML embedded in annotation text is re-emitted as text events so it is
+/// escaped by the serializer — review content is arbitrary user/AI text and
+/// must never become live markup in the exported page.
+pub fn markdown_to_html(markdown: &str) -> String {
+    use pulldown_cmark::{html, Event, Options, Parser};
+    let parser = Parser::new_ext(markdown, Options::empty()).map(|event| match event {
+        Event::Html(raw) => Event::Text(raw),
+        Event::InlineHtml(raw) => Event::Text(raw),
+        other => other,
+    });
+    let mut out = String::new();
+    html::push_html(&mut out, parser);
+    out
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Wrap rendered markdown in a standalone HTML document. The embedded styles
+/// mirror the desktop dark theme (ink scale + semantic accents) so the saved
+/// page reads like the app: dense, monospace headers, semantic color only.
+pub fn render_html_document(markdown: &str, title: &str) -> String {
+    let body = markdown_to_html(markdown);
+    let title = html_escape(title);
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Review export — {title}</title>
+<style>
+  :root {{
+    --bg: #0a0a0a;
+    --surface: #0d0d0d;
+    --border: #2a2a2a;
+    --hairline: #1f1f1f;
+    --fg: #f5f5f5;
+    --fg-2: #cccccc;
+    --fg-3: #999999;
+    --muted: #5e5e5e;
+    --accent: #ff6a3d;
+    --code-fg: #07c480;
+    --code-bg: rgba(34, 197, 94, 0.08);
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+    max-width: 860px;
+    background: var(--bg);
+    color: var(--fg-2);
+    font: 14px/1.55 "DM Sans", system-ui, sans-serif;
+    overflow-wrap: anywhere;
+  }}
+  h1 {{ font-size: 1.3rem; color: var(--fg); margin: 0 0 1rem; }}
+  h2 {{
+    font-size: 0.95rem;
+    font-family: var(--mono);
+    color: var(--fg-2);
+    margin: 1.4rem 0 0.5rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid var(--hairline);
+  }}
+  h3 {{ font-size: 0.85rem; color: var(--fg-2); margin: 1rem 0 0.35rem; }}
+  h4, h5, h6 {{ font-size: 0.8rem; color: var(--fg-3); margin: 0.8rem 0 0.3rem; }}
+  p {{ margin: 0 0 0.5rem; }}
+  ul, ol {{ margin: 0.3rem 0 0.6rem 1.3rem; padding: 0; }}
+  li {{ margin: 0.15rem 0; }}
+  blockquote {{
+    margin: 0.35rem 0 0.7rem;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--border);
+    color: var(--fg-3);
+  }}
+  blockquote blockquote {{ margin: 0.25rem 0; }}
+  code {{
+    font-family: var(--mono);
+    font-size: 0.85em;
+    color: var(--code-fg);
+    background: var(--code-bg);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }}
+  pre {{
+    margin: 0.5rem 0 0.8rem;
+    padding: 0.6rem 0.7rem;
+    background: var(--surface);
+    border: 1px solid var(--hairline);
+    border-radius: 6px;
+    overflow-x: auto;
+  }}
+  pre code {{ background: none; padding: 0; color: var(--fg-2); }}
+  a {{ color: var(--accent); }}
+  strong {{ color: var(--fg); }}
+  hr {{ border: 0; border-top: 1px solid var(--hairline); margin: 1rem 0; }}
+</style>
+</head>
+<body>
+{body}</body>
+</html>
+"#
+    )
+}
+
 /// Minimal "Xm ago" / "Xh ago" / "Xd ago" label from an ISO 8601 timestamp.
 /// Returns "" if parsing fails (we don't pull chrono just for this).
 fn ago_label(ts: &str) -> String {
@@ -501,6 +650,7 @@ mod tests {
             include_findings: false,
             only_unresolved: true,
             include_annotations: false,
+            ..ExportOpts::default()
         };
         let out = render_markdown(&tab, &opts);
 
@@ -519,6 +669,96 @@ mod tests {
         let tab = tab_with_ai(AiState::default());
         let out = render_markdown(&tab, &ExportOpts::default());
         assert!(out.contains("No annotations."), "got:\n{out}");
+    }
+
+    #[test]
+    fn html_format_renders_standalone_document() {
+        let mut ai = AiState::default();
+        ai.questions = Some(ErQuestions {
+            version: 1,
+            diff_hash: String::new(),
+            questions: vec![make_question(
+                "q-1",
+                "src/a.ts",
+                7,
+                "Is `unwrap` safe here?",
+                false,
+            )],
+        });
+        let tab = tab_with_ai(ai);
+        let opts = ExportOpts {
+            format: ExportFormat::Html,
+            ..ExportOpts::default()
+        };
+        let out = render_export(&tab, &opts);
+
+        assert!(out.starts_with("<!doctype html>"), "got:\n{out}");
+        assert!(out.contains("</html>"), "got:\n{out}");
+        assert!(
+            out.contains("<h1>Review export — feature</h1>"),
+            "missing rendered h1:\n{out}"
+        );
+        assert!(
+            out.contains("<h2>src/a.ts</h2>"),
+            "missing rendered file heading:\n{out}"
+        );
+        assert!(
+            out.contains("<code>unwrap</code>"),
+            "inline code should render:\n{out}"
+        );
+    }
+
+    #[test]
+    fn html_format_escapes_raw_html_in_annotations() {
+        let mut ai = AiState::default();
+        ai.questions = Some(ErQuestions {
+            version: 1,
+            diff_hash: String::new(),
+            questions: vec![make_question(
+                "q-1",
+                "src/a.ts",
+                1,
+                "<script>alert(1)</script> <img src=x onerror=alert(2)>",
+                false,
+            )],
+        });
+        let tab = tab_with_ai(ai);
+        let opts = ExportOpts {
+            format: ExportFormat::Html,
+            ..ExportOpts::default()
+        };
+        let out = render_export(&tab, &opts);
+
+        assert!(
+            !out.contains("<script>alert(1)"),
+            "raw script tag must be escaped:\n{out}"
+        );
+        assert!(
+            !out.contains("<img src=x"),
+            "raw img tag must be escaped:\n{out}"
+        );
+        assert!(
+            out.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+            "expected escaped script tag:\n{out}"
+        );
+    }
+
+    #[test]
+    fn markdown_format_is_default_and_unchanged() {
+        let tab = tab_with_ai(AiState::default());
+        let opts: ExportOpts = serde_json::from_str(
+            r#"{"includeComments":true,"includeQuestions":true,"includeFindings":true,"onlyUnresolved":false}"#,
+        )
+        .unwrap();
+        assert_eq!(opts.format, ExportFormat::Markdown);
+        assert_eq!(render_export(&tab, &opts), render_markdown(&tab, &opts));
+
+        let html_opts: ExportOpts =
+            serde_json::from_str(r#"{"includeComments":true,"includeQuestions":true,"includeFindings":true,"onlyUnresolved":false,"format":"html"}"#)
+                .unwrap();
+        assert_eq!(html_opts.format, ExportFormat::Html);
+        assert_eq!(ExportFormat::Markdown.extension(), "md");
+        assert_eq!(ExportFormat::Html.extension(), "html");
     }
 
     #[test]

--- a/desktop-ui/src/lib/components/ExportReviewView.svelte
+++ b/desktop-ui/src/lib/components/ExportReviewView.svelte
@@ -4,20 +4,25 @@
   import MarkdownText from "$lib/components/ui/MarkdownText.svelte";
   import { app } from "$lib/stores/app.svelte";
 
+  type ExportFormat = "markdown" | "html";
+  type PreviewView = "rendered" | "source";
   type ExportOpts = {
     includeComments: boolean;
     includeQuestions: boolean;
     includeFindings: boolean;
     includeAnnotations: boolean;
     onlyUnresolved: boolean;
+    format: ExportFormat;
   };
-  type ExportOptionKey = keyof ExportOpts;
+  type ExportOptionKey = keyof Omit<ExportOpts, "format">;
 
   let includeComments = $state(true);
   let includeQuestions = $state(true);
   let includeFindings = $state(true);
   let includeAnnotations = $state(true);
   let onlyUnresolved = $state(false);
+  let format = $state<ExportFormat>("markdown");
+  let previewView = $state<PreviewView>("rendered");
 
   let preview = $state("");
   let loadingPreview = $state(false);
@@ -34,7 +39,14 @@
       includeFindings,
       includeAnnotations,
       onlyUnresolved,
+      format,
     };
+  }
+
+  function setFormat(next: ExportFormat) {
+    if (next === format) return;
+    format = next;
+    void refreshPreview();
   }
 
   async function refreshPreview(optsSnapshot = currentExportOpts()) {
@@ -59,6 +71,7 @@
     includeFindings = nextOpts.includeFindings;
     includeAnnotations = nextOpts.includeAnnotations;
     onlyUnresolved = nextOpts.onlyUnresolved;
+    format = nextOpts.format;
     void refreshPreview(nextOpts);
   }
 
@@ -68,6 +81,7 @@
 
   function includeAllOptions() {
     applyExportOpts({
+      ...currentExportOpts(),
       includeComments: true,
       includeQuestions: true,
       includeFindings: true,
@@ -78,6 +92,7 @@
 
   function excludeAllOptions() {
     applyExportOpts({
+      ...currentExportOpts(),
       includeComments: false,
       includeQuestions: false,
       includeFindings: false,
@@ -94,8 +109,8 @@
     try {
       const body = await invoke<string>("export_review", { opts: currentExportOpts() });
       await copyToClipboard(body);
-      app.pushLog("info", "clipboard", `Copied ${body.length} chars`);
-      savedPath = "Copied to clipboard";
+      app.pushLog("info", "clipboard", `Copied ${body.length} chars (${format})`);
+      savedPath = `Copied ${format === "html" ? "HTML" : "markdown"} to clipboard`;
       savedAt = Date.now();
       setTimeout(() => {
         if (Date.now() - savedAt >= 1900) savedPath = null;
@@ -146,8 +161,29 @@
     {#if loadingPreview}
       <span class="text-[11px] text-muted mono">Refreshing…</span>
     {/if}
+    <div
+      class="ml-auto flex items-center rounded border border-border overflow-hidden"
+      role="group"
+      aria-label="Export format"
+    >
+      <button
+        class={`px-2 py-1 text-xs ${format === "markdown" ? "bg-hover text-fg" : "text-muted hover:text-fg-2"}`}
+        aria-pressed={format === "markdown"}
+        onclick={() => setFormat("markdown")}
+      >
+        Markdown
+      </button>
+      <span class="w-px self-stretch bg-border" aria-hidden="true"></span>
+      <button
+        class={`px-2 py-1 text-xs ${format === "html" ? "bg-hover text-fg" : "text-muted hover:text-fg-2"}`}
+        aria-pressed={format === "html"}
+        onclick={() => setFormat("html")}
+      >
+        HTML
+      </button>
+    </div>
     <button
-      class="ml-auto px-2 py-1 text-xs border border-border rounded hover:bg-hover"
+      class="px-2 py-1 text-xs border border-border rounded hover:bg-hover"
       onclick={handleCopyToClipboard}
       disabled={loadingPreview && !preview}
     >
@@ -232,19 +268,56 @@
     {/if}
   </div>
 
-  <div class="flex-1 min-h-0 overflow-y-auto p-4">
-    <div class="text-[10px] uppercase tracking-wider text-muted mb-1">Preview</div>
-    <div class="min-h-full text-[12px] text-fg-2 bg-bg border border-hairline rounded p-3 break-words export-preview">
-      {#if preview}
-        <MarkdownText text={preview} className="export-preview-markdown" />
-      {:else if loadingPreview}
-        <p class="text-muted mono">(loading…)</p>
-      {:else if error}
-        <p class="text-del-fg mono">(error) {error}</p>
-      {:else}
-        <p class="text-muted">No preview.</p>
-      {/if}
+  <div class="flex-1 min-h-0 overflow-hidden p-4 flex flex-col">
+    <div class="flex items-center gap-2 mb-1">
+      <span class="text-[10px] uppercase tracking-wider text-muted">
+        Preview — {format === "html" ? "export.html" : "export.md"}
+      </span>
+      <div class="ml-auto flex items-center gap-2 text-[10px] uppercase tracking-wider">
+        <button
+          class={previewView === "rendered" ? "text-fg-2" : "text-muted hover:text-fg-3"}
+          aria-pressed={previewView === "rendered"}
+          onclick={() => (previewView = "rendered")}
+        >
+          Rendered
+        </button>
+        <button
+          class={previewView === "source" ? "text-fg-2" : "text-muted hover:text-fg-3"}
+          aria-pressed={previewView === "source"}
+          onclick={() => (previewView = "source")}
+        >
+          Source
+        </button>
+      </div>
     </div>
+    {#if preview && previewView === "rendered" && format === "html"}
+      <!-- WYSIWYG preview of the standalone HTML document. sandbox="" blocks
+           scripts/navigation; the document itself escapes annotation HTML. -->
+      <iframe
+        class="flex-1 min-h-0 w-full bg-bg border border-hairline rounded"
+        title="HTML export preview"
+        sandbox=""
+        srcdoc={preview}
+      ></iframe>
+    {:else}
+      <div
+        class="flex-1 min-h-0 overflow-y-auto text-[12px] text-fg-2 bg-bg border border-hairline rounded p-3 break-words export-preview"
+      >
+        {#if preview}
+          {#if previewView === "source"}
+            <pre class="mono text-[11px] leading-relaxed text-fg-3 whitespace-pre-wrap break-words">{preview}</pre>
+          {:else}
+            <MarkdownText text={preview} className="export-preview-markdown" />
+          {/if}
+        {:else if loadingPreview}
+          <p class="text-muted mono">(loading…)</p>
+        {:else if error}
+          <p class="text-del-fg mono">(error) {error}</p>
+        {:else}
+          <p class="text-muted">No preview.</p>
+        {/if}
+      </div>
+    {/if}
   </div>
 </div>
 


### PR DESCRIPTION
Closes #68

The Export page now supports both Markdown and HTML output, with a rendered preview instead of raw text:

- Segmented format toggle (Markdown / HTML) in the toolbar; the format flows through preview, Copy to clipboard, and Save to file (`export.md` / `export.html`)
- Rendered/Source preview toggle — rendered markdown uses the existing safe `MarkdownText` renderer; rendered HTML shows the actual exported document in a sandboxed, script-free iframe
- Rust side: `ExportFormat` enum on `ExportOpts` (serde-defaulted to markdown for back-compat); `markdown_to_html()` via `pulldown-cmark` with raw HTML re-emitted as escaped text so annotation content can never inject live markup; standalone HTML document styled to match the app's dark theme tokens

**Verification:** all 8 `export.rs` unit tests pass; frontend `vite build` succeeds. Note: the Tauri crate couldn't be compiled in the CI-less agent environment (missing `webkit2gtk`), so a local `cargo build` is worth running to confirm the `commands.rs` wiring.

https://claude.ai/code/session_016hkCShQssxEjLTRiYRWacU

---
_Generated by [Claude Code](https://claude.ai/code/session_016hkCShQssxEjLTRiYRWacU)_