### PR TITLE
Fix reply rendering in narrow side panel

### DIFF
--- a/desktop-ui/src/lib/components/InlineFinding.svelte
+++ b/desktop-ui/src/lib/components/InlineFinding.svelte
@@ -296,19 +296,19 @@
                 <MarkdownText text={reply.body_markdown} className="text-sm text-fg-2" />
               </div>
             {/if}
+            {#if reply.id && reply.body_markdown !== "…thinking"}
+              <ReplyActionBar
+                {reply}
+                rootThreadId={thread?.id ?? null}
+                findingId={finding.id}
+                isQuestion={thread?.kind === "question"}
+                parentSynced={thread?.synced ?? false}
+                threadResolved={thread?.resolved ?? false}
+                onEdit={reply.editable ? () => openEdit(reply) : undefined}
+                onDelete={() => deleteReply(reply.id, reply.origin)}
+              />
+            {/if}
           </div>
-          {#if reply.id && reply.body_markdown !== "…thinking"}
-            <ReplyActionBar
-              {reply}
-              rootThreadId={thread?.id ?? null}
-              findingId={finding.id}
-              isQuestion={thread?.kind === "question"}
-              parentSynced={thread?.synced ?? false}
-              threadResolved={thread?.resolved ?? false}
-              onEdit={reply.editable ? () => openEdit(reply) : undefined}
-              onDelete={() => deleteReply(reply.id, reply.origin)}
-            />
-          {/if}
         </div>
       {/each}
     </div>

--- a/desktop-ui/src/lib/components/InlineThread.svelte
+++ b/desktop-ui/src/lib/components/InlineThread.svelte
@@ -285,18 +285,18 @@
                 <MarkdownText text={reply.body_markdown} className="text-sm text-fg-2" />
               </div>
             {/if}
+            {#if reply.id && reply.body_markdown !== "…thinking"}
+              <ReplyActionBar
+                reply={{ ...reply, origin: reply.origin ?? "thread_reply" }}
+                rootThreadId={thread.id}
+                {isQuestion}
+                parentSynced={thread.synced}
+                threadResolved={thread.resolved}
+                onEdit={reply.kind === "you" ? () => openEdit(reply.id, reply.body_markdown) : undefined}
+                onDelete={() => deleteReply(reply.id)}
+              />
+            {/if}
           </div>
-          {#if reply.id && reply.body_markdown !== "…thinking"}
-            <ReplyActionBar
-              reply={{ ...reply, origin: reply.origin ?? "thread_reply" }}
-              rootThreadId={thread.id}
-              {isQuestion}
-              parentSynced={thread.synced}
-              threadResolved={thread.resolved}
-              onEdit={reply.kind === "you" ? () => openEdit(reply.id, reply.body_markdown) : undefined}
-              onDelete={() => deleteReply(reply.id)}
-            />
-          {/if}
         </div>
       {/each}
     </div>

--- a/desktop-ui/src/lib/components/ReplyActionBar.svelte
+++ b/desktop-ui/src/lib/components/ReplyActionBar.svelte
@@ -93,7 +93,7 @@
   }
 </script>
 
-<div class="self-start shrink-0 flex flex-wrap gap-0.5 opacity-0 group-hover/row:opacity-100 text-[10px]">
+<div class="mt-1 -ml-1 flex flex-wrap gap-0.5 opacity-0 group-hover/row:opacity-100 text-[10px]">
   {#if showAskAi}
     <button type="button" onclick={() => void askAi()} title="Ask AI about this reply" class="px-1 py-0.5 rounded text-fg-3 hover:bg-hover">Ask AI</button>
   {/if}


### PR DESCRIPTION
## Problem

Comment replies rendered fine inline in the diff view but were broken in the right side panel: the reply body disappeared and the author line overlapped the hover action buttons.

## Cause

`ReplyActionBar` was rendered as a `shrink-0` flex sibling next to the reply body. With up to 7 buttons (Ask AI, Validate, Copy, Edit, Push, Resolve, Delete) its fixed width exceeds the 340px panel, so the `flex-1 min-w-0` body column collapsed to zero width. The inline diff view is wide enough that the bug never showed there.

## Fix

Move the action bar into the content column, below the reply body, in both `InlineThread.svelte` and `InlineFinding.svelte`. It now wraps within the available width (still appears on row hover) instead of competing with the body for horizontal space, so it works at any panel width.

Verified with `vite build` and `bun test src` (304 pass).

https://claude.ai/code/session_016NdEwdrXDrmggUraSTG3vr

---
_Generated by [Claude Code](https://claude.ai/code/session_016NdEwdrXDrmggUraSTG3vr)_