### PR TITLE
docs: static documentation site for the terminal UI and desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ AI writes code faster than you can review it. `er` makes review fast, navigable,
 ![Rust](https://img.shields.io/badge/Rust-000000?logo=rust&logoColor=white)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 
+📚 **Documentation:** the full guide lives in [`docs/guide/`](docs/guide/index.html) — getting started, core concepts shared by both apps, and dedicated sections for the [terminal UI](docs/guide/tui.html) and the [desktop app](docs/guide/desktop.html). When published via GitHub Pages it is served from the site root under `/guide/`.
+
 ## Install
 
 ### Quick install (macOS / Linux)

--- a/docs/guide/ai-review.html
+++ b/docs/guide/ai-review.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Review — easy-review docs</title>
+  <meta name="description" content="How easy-review's AI review loop works: sidecar artifacts, risk levels, inline findings, expert agents, the professor, view modes, staleness, and the AI Hub.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>AI Review</h1>
+    <p class="lead">
+      This is what <code>er</code> is named for. It does not run AI itself — it <strong>reads</strong> structured review
+      artifacts that AI tools you run write to disk, and renders them inline against the diff. This page explains the
+      loop, the artifacts, and the agents that produce them.
+    </p>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p><strong><code>er</code> is a viewer and orchestrator, not a model.</strong> No code is sent anywhere by
+      <code>er</code>. You bring your own AI tool (Claude Code, Codex, Cursor, …) and credentials; you are the customer of
+      those providers and responsible for their terms of use.</p></div>
+    </div>
+
+    <h2>The loop</h2>
+    <p>The recommended setup is a split screen — your AI tool on one side, <code>er</code> on the other.</p>
+    <table>
+      <thead><tr><th>Step</th><th>Where</th><th>What happens</th></tr></thead>
+      <tbody>
+        <tr><td>1</td><td>Claude Code</td><td><code>/er-review</code> analyzes the diff and writes sidecar files.</td></tr>
+        <tr><td>2</td><td><code>er</code></td><td>Detects the new files automatically; press <kbd>v</kbd> to show findings inline.</td></tr>
+        <tr><td>3</td><td><code>er</code></td><td>You read findings, leave questions with <kbd>q</kbd>, comments with <kbd>c</kbd>.</td></tr>
+        <tr><td>4</td><td>Claude Code</td><td><code>/er-questions</code> reads your feedback, responds, and updates the files.</td></tr>
+        <tr><td>5</td><td><code>er</code></td><td>Auto-refreshes; AI responses appear inline. Continue reviewing.</td></tr>
+        <tr><td>6</td><td>Claude Code</td><td><code>/er-publish</code> validates freshness and posts to your GitHub PR.</td></tr>
+      </tbody>
+    </table>
+    <p>The desktop app can spawn these same agents itself from its AI Hub, so you do not strictly need a second terminal
+    — see <a href="desktop-features.html">Desktop Features</a>.</p>
+
+    <h2>What a review produces</h2>
+    <p>A full review (<code>/er-review</code>) writes several sidecar files. <code>er</code> reads them and turns them into UI:</p>
+    <table>
+      <thead><tr><th>File</th><th>Becomes</th></tr></thead>
+      <tbody>
+        <tr><td><code>review.json</code></td><td>Per-file <strong>risk levels</strong> (high / medium / low) in the file list, plus <strong>inline findings</strong> in the diff.</td></tr>
+        <tr><td><code>order.json</code></td><td>A suggested <strong>review order</strong>.</td></tr>
+        <tr><td><code>checklist.json</code></td><td>A <strong>verification checklist</strong> of things to confirm.</td></tr>
+        <tr><td><code>summary.md</code></td><td>A markdown <strong>summary</strong> of the change.</td></tr>
+      </tbody>
+    </table>
+    <p>Findings render as inline banners attached to the relevant lines, color-coded by the agent that produced them.
+    See <a href="storage.html">Review Storage</a> for the complete file list and where it lives on disk.</p>
+
+    <h2>Severity model</h2>
+    <p>All the review skills share one severity scale and a “what not to flag” list:</p>
+    <table>
+      <thead><tr><th>Level</th><th>Meaning</th></tr></thead>
+      <tbody>
+        <tr><td><strong>P0 — high</strong></td><td>Must fix.</td></tr>
+        <tr><td><strong>P1 — medium</strong></td><td>Should fix.</td></tr>
+        <tr><td><strong>P2 — low</strong></td><td>Nice to fix.</td></tr>
+      </tbody>
+    </table>
+    <p>By design the agents <strong>never</strong> flag naming, formatting, style, or pure file moves — that noise is
+    what makes AI review tiring. Summaries and checklists focus on P0/P1.</p>
+
+    <h2>Expert agents</h2>
+    <p>
+      Beyond the general review, specialized <strong>expert</strong> agents look at one dimension each and write only to
+      <code>experts/&lt;id&gt;.json</code> — they never overwrite the general artifacts. When their output matches the
+      current diff hash, <code>er</code> merges their findings in as additional inline banners, each labeled with the
+      expert's name.
+    </p>
+    <table>
+      <thead><tr><th>Expert</th><th>Focus</th></tr></thead>
+      <tbody>
+        <tr><td><code>security</code></td><td>Security issues</td></tr>
+        <tr><td><code>performance</code></td><td>Performance</td></tr>
+        <tr><td><code>reliability</code></td><td>Reliability / robustness</td></tr>
+        <tr><td><code>testing</code></td><td>Test coverage and quality</td></tr>
+        <tr><td><code>api</code></td><td>API design and contracts</td></tr>
+        <tr><td><code>patterns</code></td><td>Pattern consistency with the codebase</td></tr>
+        <tr><td><code>simplifying</code></td><td>Readability and complexity</td></tr>
+        <tr><td><code>mentorship</code></td><td>Exemplary patterns worth reinforcing</td></tr>
+      </tbody>
+    </table>
+
+    <h2>The professor</h2>
+    <p>
+      <code>/er-professor</code> is not a code review — it is a learning agent. It writes teaching insights to
+      <code>professor.json</code>, merged inline and labeled with a <strong>Professor</strong> pill. Use it to understand
+      <em>why</em> a change is shaped the way it is, rather than to find defects.
+    </p>
+
+    <h2>Triage</h2>
+    <p>
+      <code>/er-triage</code> is a fast first pass: a quick branch scan that produces a first impression, a routing
+      verdict (run a general review? an expert? skip deep review?), and a priority file list, written to
+      <code>triage.json</code>. It is the cheapest way to decide how much review a branch actually warrants.
+    </p>
+
+    <h2>AI view modes <span class="pill tui">terminal</span></h2>
+    <p>
+      In the terminal, press <kbd>v</kbd> (or <kbd>V</kbd> to cycle backward) to move through the AI presentation modes —
+      from a plain diff, to findings overlaid inline, to a side panel with the summary and risk breakdown, to a
+      dedicated AI review layout. Cycling lets you dial the amount of AI context up or down without leaving the diff.
+    </p>
+
+    <h2>Staleness</h2>
+    <p>
+      Every sidecar records the SHA-256 hash of the diff it was generated against. When the diff changes — which happens
+      constantly in watch mode — any AI data whose hash no longer matches is dimmed with a <strong>stale</strong>
+      warning. You are never misled into trusting analysis of code that has since changed. Re-run the relevant skill to
+      refresh it.
+    </p>
+
+    <h2>Choosing a model: the AI Hub</h2>
+    <p>
+      <code>er</code> can drive different providers and models. The <code>[agent]</code> config sets a single default
+      command; the optional <code>[ai_hub]</code> config defines presets (Claude, Codex, Cursor and their models) you can
+      switch between at runtime without editing config mid-session. You can even pin specific reviewer kinds to specific
+      models — for example, run cheap, fast triage on a smaller model. The full schema is in
+      <a href="configuration.html#ai-hub">Configuration → AI Hub</a>.
+    </p>
+
+    <h2>Trying it without an AI tool</h2>
+    <p>To explore how the overlays render without running a real review, generate sample artifacts:</p>
+    <pre><code>cd your-repo
+bash /path/to/easy-review/scripts/generate-test-fixtures.sh</code></pre>
+    <p>This writes <code>.er/</code> files with a matching diff hash so the AI views light up against your current diff.</p>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p>The agents themselves are the <a href="skills.html">Claude Code Skills</a>. That page is the full catalog
+      of <code>/er-*</code> commands and what each one writes.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/assets/docs.css
+++ b/docs/guide/assets/docs.css
@@ -1,0 +1,440 @@
+/* ============================================================
+   easy-review documentation — shared styles
+   Static, zero-build. Matches the brand theme from ../index.html.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg: #0b0b0f;
+  --surface: #13131a;
+  --surface-2: #1a1a24;
+  --border: #2a2a3a;
+  --border-bright: #3a3a50;
+  --text: #e4e4ef;
+  --text-dim: #8888a0;
+  --text-muted: #55556a;
+  --green: #4ade80;
+  --red: #f87171;
+  --yellow: #facc15;
+  --blue: #60a5fa;
+  --cyan: #22d3ee;
+  --accent: #a78bfa;
+  --accent-dim: #7c5cbf;
+  --orange: #d18616;
+
+  --mono: 'JetBrains Mono', ui-monospace, monospace;
+  --body: 'Outfit', system-ui, sans-serif;
+
+  --sidebar-w: 17rem;
+  --toc-w: 14rem;
+  --topbar-h: 3.5rem;
+  --content-max: 50rem;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--body);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre, kbd { font-family: var(--mono); }
+
+/* ── Top bar ─────────────────────────────────────────────── */
+.topbar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--topbar-h);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.25rem;
+  background: rgba(11, 11, 15, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.topbar .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 1rem;
+}
+.topbar .brand .er { color: var(--accent); }
+.topbar .brand .sub { color: var(--text-muted); font-weight: 400; font-size: 0.85rem; }
+.topbar .brand .docs-tag {
+  color: var(--text-dim);
+  font-weight: 400;
+  font-size: 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.05rem 0.4rem;
+  font-family: var(--body);
+}
+.topbar .links { display: flex; align-items: center; gap: 1.25rem; }
+.topbar .links a { color: var(--text-dim); font-size: 0.85rem; }
+.topbar .links a:hover { color: var(--text); text-decoration: none; }
+.topbar .menu-btn {
+  display: none;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+.layout {
+  display: flex;
+  max-width: 90rem;
+  margin: 0 auto;
+  padding-top: var(--topbar-h);
+}
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+.sidebar {
+  position: fixed;
+  top: var(--topbar-h);
+  bottom: 0;
+  width: var(--sidebar-w);
+  overflow-y: auto;
+  padding: 1.5rem 1rem 3rem 1.25rem;
+  border-right: 1px solid var(--border);
+  background: var(--bg);
+}
+.sidebar .nav-section { margin-bottom: 1.5rem; }
+.sidebar .nav-section > .nav-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin: 0 0 0.5rem 0.5rem;
+}
+.sidebar a.nav-link {
+  display: block;
+  padding: 0.32rem 0.6rem;
+  border-radius: 6px;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+  border-left: 2px solid transparent;
+}
+.sidebar a.nav-link:hover {
+  color: var(--text);
+  background: var(--surface);
+  text-decoration: none;
+}
+.sidebar a.nav-link.active {
+  color: var(--accent);
+  background: rgba(167, 139, 250, 0.1);
+  border-left-color: var(--accent);
+  font-weight: 500;
+}
+
+/* ── Main content ────────────────────────────────────────── */
+.content {
+  flex: 1;
+  min-width: 0;
+  max-width: var(--content-max);
+  margin-left: var(--sidebar-w);
+  padding: 2.5rem 3rem 5rem;
+}
+
+.content .eyebrow {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin: 0 0 0.5rem;
+}
+
+.content h1 {
+  font-size: 2.2rem;
+  font-weight: 600;
+  line-height: 1.15;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+.content h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 2.75rem 0 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  letter-spacing: -0.01em;
+}
+.content h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 2rem 0 0.75rem;
+}
+.content h4 { font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; }
+
+.content h2 .anchor, .content h3 .anchor {
+  opacity: 0;
+  margin-left: 0.4rem;
+  color: var(--text-muted);
+  font-weight: 400;
+  text-decoration: none;
+}
+.content h2:hover .anchor, .content h3:hover .anchor { opacity: 1; }
+
+.content p { margin: 0.9rem 0; color: var(--text); }
+.content .lead {
+  font-size: 1.15rem;
+  color: var(--text-dim);
+  font-weight: 300;
+  line-height: 1.6;
+}
+
+.content ul, .content ol { margin: 0.9rem 0; padding-left: 1.4rem; }
+.content li { margin: 0.4rem 0; }
+.content li::marker { color: var(--text-muted); }
+
+.content strong { color: var(--text); font-weight: 600; }
+.content em { color: var(--text-dim); }
+
+/* Inline code */
+.content :not(pre) > code {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.08em 0.38em;
+  font-size: 0.85em;
+  color: var(--cyan);
+  white-space: nowrap;
+}
+
+/* Code blocks */
+.content pre {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  font-size: 0.84rem;
+  line-height: 1.6;
+  margin: 1.2rem 0;
+}
+.content pre code { color: var(--text); white-space: pre; }
+.content pre .cmt { color: var(--text-muted); }
+.content pre .tok-key { color: var(--accent); }
+.content pre .tok-str { color: var(--green); }
+.content pre .tok-flag { color: var(--cyan); }
+.copy-btn {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: 5px;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.45rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  font-family: var(--mono);
+}
+.content pre:hover .copy-btn { opacity: 1; }
+.copy-btn:hover { color: var(--text); border-color: var(--border-bright); }
+
+/* Tables */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.2rem 0;
+  font-size: 0.88rem;
+}
+.content th, .content td {
+  text-align: left;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.content th {
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border-bright);
+}
+.content td code { white-space: nowrap; }
+.content tbody tr:hover { background: var(--surface); }
+
+/* Keycaps */
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0.05rem 0.4rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-bottom: 2px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.78rem;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+/* Callouts */
+.callout {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1.3rem 0;
+  padding: 0.85rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  background: var(--surface);
+  font-size: 0.92rem;
+}
+.callout .ico { flex-shrink: 0; font-size: 1rem; line-height: 1.5; }
+.callout p { margin: 0.2rem 0; }
+.callout p:first-child { margin-top: 0; }
+.callout p:last-child { margin-bottom: 0; }
+.callout.note { border-left-color: var(--blue); }
+.callout.note .ico { color: var(--blue); }
+.callout.tip { border-left-color: var(--green); }
+.callout.tip .ico { color: var(--green); }
+.callout.warn { border-left-color: var(--yellow); }
+.callout.warn .ico { color: var(--yellow); }
+.callout.danger { border-left-color: var(--red); }
+.callout.danger .ico { color: var(--red); }
+
+/* Pills / accent labels */
+.pill {
+  display: inline-block;
+  padding: 0.05rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-family: var(--mono);
+  border: 1px solid var(--border);
+}
+.pill.tui { color: var(--accent); border-color: var(--accent-dim); background: rgba(167,139,250,0.1); }
+.pill.desktop { color: var(--cyan); border-color: var(--cyan); background: rgba(34,211,238,0.08); }
+.pill.both { color: var(--green); border-color: var(--green); background: rgba(74,222,128,0.08); }
+
+/* Cards grid (home page) */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.card {
+  display: block;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  transition: border-color 0.15s, transform 0.15s;
+}
+.card:hover { border-color: var(--border-bright); transform: translateY(-2px); text-decoration: none; }
+.card h3 { margin: 0 0 0.35rem; font-size: 1rem; color: var(--text); }
+.card p { margin: 0; font-size: 0.85rem; color: var(--text-dim); }
+.card .card-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+
+/* Key reference list */
+.keyref { color: var(--accent); }
+
+/* Prev / next */
+.page-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 3.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+.page-nav a {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+}
+.page-nav a:hover { border-color: var(--border-bright); text-decoration: none; background: var(--surface); }
+.page-nav a.next { text-align: right; }
+.page-nav .dir { font-size: 0.72rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.page-nav .ttl { color: var(--accent); font-size: 0.95rem; }
+
+/* ── Right-hand TOC ──────────────────────────────────────── */
+.toc {
+  position: fixed;
+  top: var(--topbar-h);
+  right: max(1rem, calc((100vw - 90rem) / 2 + 1rem));
+  width: var(--toc-w);
+  max-height: calc(100vh - var(--topbar-h));
+  overflow-y: auto;
+  padding: 2.5rem 0.5rem 2rem;
+  font-size: 0.82rem;
+}
+.toc .toc-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+.toc a {
+  display: block;
+  padding: 0.2rem 0.6rem;
+  color: var(--text-muted);
+  border-left: 2px solid var(--border);
+}
+.toc a:hover { color: var(--text); text-decoration: none; }
+.toc a.h3 { padding-left: 1.3rem; }
+.toc a.active { color: var(--accent); border-left-color: var(--accent); }
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 1280px) {
+  .toc { display: none; }
+  .content { margin-left: var(--sidebar-w); }
+}
+@media (max-width: 900px) {
+  .topbar .menu-btn { display: block; }
+  .topbar .links .hide-sm { display: none; }
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 55;
+    width: min(20rem, 85vw);
+    box-shadow: 0 0 40px rgba(0,0,0,0.5);
+  }
+  body.nav-open .sidebar { transform: translateX(0); }
+  body.nav-open::after {
+    content: '';
+    position: fixed;
+    inset: var(--topbar-h) 0 0 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 54;
+  }
+  .content { margin-left: 0; padding: 2rem 1.25rem 4rem; max-width: 100%; }
+}

--- a/docs/guide/assets/docs.js
+++ b/docs/guide/assets/docs.js
@@ -1,0 +1,204 @@
+/* ============================================================
+   easy-review documentation — shared chrome
+   Builds the top bar, sidebar nav, right-hand TOC, prev/next,
+   heading anchors, and code copy buttons. No build step.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var REPO = 'https://github.com/VilfredSikker/easy-review';
+
+  // Ordered navigation model. `file` is relative to /docs/guide/.
+  var NAV = [
+    { section: 'Getting Started', pages: [
+      { file: 'index.html', title: 'Introduction' },
+      { file: 'installation.html', title: 'Installation' },
+      { file: 'quick-start.html', title: 'Quick Start' }
+    ]},
+    { section: 'Core Concepts', pages: [
+      { file: 'concepts.html', title: 'How er Works' },
+      { file: 'diff-modes.html', title: 'Diff Modes' },
+      { file: 'reviewing.html', title: 'Reviewing & Navigation' },
+      { file: 'comments.html', title: 'Comments & Questions' },
+      { file: 'ai-review.html', title: 'AI Review' },
+      { file: 'github.html', title: 'GitHub & Pull Requests' },
+      { file: 'configuration.html', title: 'Configuration' },
+      { file: 'storage.html', title: 'Review Storage' },
+      { file: 'skills.html', title: 'Claude Code Skills' }
+    ]},
+    { section: 'Terminal UI (er)', pages: [
+      { file: 'tui.html', title: 'Overview' },
+      { file: 'tui-keybindings.html', title: 'Keybinding Reference' }
+    ]},
+    { section: 'Desktop App', pages: [
+      { file: 'desktop.html', title: 'Overview' },
+      { file: 'desktop-features.html', title: 'Features in Depth' }
+    ]},
+    { section: 'Help', pages: [
+      { file: 'troubleshooting.html', title: 'Troubleshooting & FAQ' }
+    ]}
+  ];
+
+  function currentFile() {
+    var path = location.pathname.split('/').pop();
+    return path === '' ? 'index.html' : path;
+  }
+
+  // Flat ordered list for prev/next.
+  function flatPages() {
+    var out = [];
+    NAV.forEach(function (s) { s.pages.forEach(function (p) { out.push(p); }); });
+    return out;
+  }
+
+  function el(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+
+  function buildTopbar() {
+    var bar = el('header', 'topbar');
+    bar.innerHTML =
+      '<button class="menu-btn" aria-label="Toggle navigation">☰</button>' +
+      '<a class="brand" href="index.html">' +
+        '<span class="er">er</span>' +
+        '<span class="sub">easy-review</span>' +
+        '<span class="docs-tag">docs</span>' +
+      '</a>' +
+      '<div class="links">' +
+        '<a class="hide-sm" href="../index.html">Home</a>' +
+        '<a href="' + REPO + '" target="_blank" rel="noopener">GitHub ↗</a>' +
+      '</div>';
+    bar.querySelector('.menu-btn').addEventListener('click', function () {
+      document.body.classList.toggle('nav-open');
+    });
+    return bar;
+  }
+
+  function buildSidebar() {
+    var aside = el('aside', 'sidebar');
+    var cur = currentFile();
+    NAV.forEach(function (s) {
+      var sec = el('div', 'nav-section');
+      sec.appendChild(el('div', 'nav-title', s.section));
+      s.pages.forEach(function (p) {
+        var a = el('a', 'nav-link', p.title);
+        a.href = p.file;
+        if (p.file === cur) a.classList.add('active');
+        sec.appendChild(a);
+      });
+      aside.appendChild(sec);
+    });
+    // Close mobile drawer when a link is chosen.
+    aside.addEventListener('click', function (e) {
+      if (e.target.classList.contains('nav-link')) document.body.classList.remove('nav-open');
+    });
+    return aside;
+  }
+
+  function slugify(text) {
+    return text.toLowerCase().replace(/[^\w]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
+  function decorateHeadings(content) {
+    var heads = content.querySelectorAll('h2, h3');
+    heads.forEach(function (h) {
+      if (!h.id) h.id = slugify(h.textContent);
+      var a = el('a', 'anchor', '#');
+      a.href = '#' + h.id;
+      a.setAttribute('aria-label', 'Link to this section');
+      h.appendChild(a);
+    });
+    return heads;
+  }
+
+  function buildToc(heads) {
+    if (!heads.length) return null;
+    var nav = el('nav', 'toc');
+    nav.appendChild(el('div', 'toc-title', 'On this page'));
+    heads.forEach(function (h) {
+      var a = el('a', h.tagName.toLowerCase(), h.firstChild ? h.childNodes[0].textContent : h.textContent);
+      a.href = '#' + h.id;
+      nav.appendChild(a);
+    });
+    return nav;
+  }
+
+  function buildPageNav(content) {
+    var pages = flatPages();
+    var cur = currentFile();
+    var idx = pages.findIndex(function (p) { return p.file === cur; });
+    if (idx < 0) return;
+    var wrap = el('nav', 'page-nav');
+    if (idx > 0) {
+      var prev = pages[idx - 1];
+      var a = el('a', 'prev', '<div class="dir">← Previous</div><div class="ttl">' + prev.title + '</div>');
+      a.href = prev.file;
+      wrap.appendChild(a);
+    } else {
+      wrap.appendChild(el('span'));
+    }
+    if (idx < pages.length - 1) {
+      var next = pages[idx + 1];
+      var b = el('a', 'next', '<div class="dir">Next →</div><div class="ttl">' + next.title + '</div>');
+      b.href = next.file;
+      wrap.appendChild(b);
+    }
+    content.appendChild(wrap);
+  }
+
+  function addCopyButtons(content) {
+    content.querySelectorAll('pre').forEach(function (pre) {
+      var btn = el('button', 'copy-btn', 'copy');
+      btn.addEventListener('click', function () {
+        var code = pre.querySelector('code');
+        navigator.clipboard.writeText((code || pre).innerText).then(function () {
+          btn.textContent = 'copied';
+          setTimeout(function () { btn.textContent = 'copy'; }, 1400);
+        });
+      });
+      pre.appendChild(btn);
+    });
+  }
+
+  function scrollSpy(heads, toc) {
+    if (!toc) return;
+    var links = {};
+    toc.querySelectorAll('a').forEach(function (a) { links[a.getAttribute('href').slice(1)] = a; });
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) {
+          Object.keys(links).forEach(function (k) { links[k].classList.remove('active'); });
+          if (links[en.target.id]) links[en.target.id].classList.add('active');
+        }
+      });
+    }, { rootMargin: '-10% 0px -75% 0px' });
+    heads.forEach(function (h) { obs.observe(h); });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var content = document.querySelector('main.content');
+    if (!content) return;
+
+    var heads = decorateHeadings(content);
+    addCopyButtons(content);
+    buildPageNav(content);
+
+    var topbar = buildTopbar();
+    var sidebar = buildSidebar();
+    var toc = buildToc(heads);
+
+    var layout = el('div', 'layout');
+    layout.appendChild(sidebar);
+    content.parentNode.removeChild(content);
+    layout.appendChild(content);
+    if (toc) layout.appendChild(toc);
+
+    document.body.insertBefore(layout, document.body.firstChild);
+    document.body.insertBefore(topbar, document.body.firstChild);
+
+    scrollSpy(heads, toc);
+  });
+})();

--- a/docs/guide/comments.html
+++ b/docs/guide/comments.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Comments &amp; Questions — easy-review docs</title>
+  <meta name="description" content="Two comment types in easy-review: private questions answered by AI, and GitHub comments that sync to a PR. Replies, deletion, staleness, and comment focus mode.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Comments &amp; Questions</h1>
+    <p class="lead">
+      <code>er</code> keeps two separate streams of inline notes: <strong>questions</strong> you keep to yourself (and
+      hand to your AI), and <strong>GitHub comments</strong> that sync to a pull request. They look different, use
+      different keys, and never get confused with one another — so a private thought can't accidentally end up on a PR.
+    </p>
+
+    <h2>Why two kinds?</h2>
+    <table>
+      <thead><tr><th></th><th>Questions <span style="color:var(--yellow)">●</span></th><th>GitHub comments <span style="color:var(--cyan)">●</span></th></tr></thead>
+      <tbody>
+        <tr><td>Color</td><td>Yellow</td><td>Cyan</td></tr>
+        <tr><td>Keys</td><td><kbd>q</kbd> line · <kbd>Q</kbd> hunk</td><td><kbd>c</kbd> line · <kbd>C</kbd> hunk</td></tr>
+        <tr><td>Audience</td><td>You and your AI tools</td><td>Your PR reviewers</td></tr>
+        <tr><td>Stored in</td><td><code>questions.json</code></td><td><code>github-comments.json</code></td></tr>
+        <tr><td>Replies?</td><td>No (use AI to answer)</td><td>Yes — single-level threads</td></tr>
+        <tr><td>Synced upstream?</td><td>Never — stays local</td><td>Yes, two-way via <code>gh</code></td></tr>
+      </tbody>
+    </table>
+    <p>
+      Questions are your scratchpad: “why is this here?”, “does this handle the empty case?”. The
+      <code>/er-questions</code> skill reads them, answers, and updates the file in place. GitHub comments are the things
+      you actually want your team to see on the PR.
+    </p>
+
+    <h2>Leaving a note</h2>
+    <p>
+      Navigate to a line (with the arrow keys) or sit on a hunk, then press the matching key. <strong>Lowercase targets
+      the current line; uppercase targets the whole hunk.</strong>
+    </p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>q</kbd></td><td>Add a question on the current line</td></tr>
+        <tr><td><kbd>Q</kbd></td><td>Add a question on the current hunk</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Add a GitHub comment on the current line</td></tr>
+        <tr><td><kbd>C</kbd></td><td>Add a GitHub comment on the current hunk</td></tr>
+      </tbody>
+    </table>
+    <p>
+      A small input opens at the bottom; type your note and confirm. The note then renders <strong>inline</strong>,
+      right after its target line in the diff — not bundled at the end of the hunk — so the conversation sits exactly
+      where the code is.
+    </p>
+
+    <h2>Comment focus mode</h2>
+    <p>
+      To act on existing notes rather than the diff, enter <strong>comment focus mode</strong> with <kbd>Tab</kbd>. Now
+      the arrow keys move between comments instead of lines, and these actions apply to the focused comment:
+    </p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>Tab</kbd></td><td>Enter / leave comment focus mode</td></tr>
+        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Move between comments</td></tr>
+        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment (GitHub comments only)</td></tr>
+        <tr><td><kbd>d</kbd></td><td>Delete the focused comment</td></tr>
+        <tr><td><kbd>R</kbd></td><td>Toggle resolved</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Replies are single-level</h2>
+    <p>
+      GitHub comments support a reply thread: a parent comment plus any number of replies. Replies cannot themselves
+      have replies — the model is intentionally flat (parent + children, no recursive nesting) to keep it simple and to
+      match how GitHub PR review threads behave. Questions do not have replies; the way you “answer” a question is to run
+      <code>/er-questions</code> and let the AI respond.
+    </p>
+
+    <h2>Comments follow the code (and warn when stale)</h2>
+    <p>
+      Each note stores the <em>content</em> of the line it was attached to. When the diff changes, <code>er</code> tries
+      to re-anchor the note to that same line even if it moved. If the target line disappears entirely, the note is
+      marked <strong>stale</strong>: it renders dimmed with a warning indicator so you know it may be misplaced and
+      should be revisited. This staleness is tracked per comment, independently of the file-level AI staleness described
+      in <a href="ai-review.html">AI Review</a>.
+    </p>
+
+    <h2>Syncing GitHub comments</h2>
+    <p>With the <code>gh</code> CLI configured and a pull request in view, comments sync both directions:</p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>G</kbd></td><td>Pull review comments <em>from</em> GitHub into your diff</td></tr>
+        <tr><td><kbd>P</kbd></td><td>Push your local comments <em>to</em> GitHub</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Each GitHub comment records its <code>source</code> (local or github), the upstream <code>github_id</code>, the
+      <code>author</code>, and whether it has been <code>synced</code>. Pulling deduplicates on the GitHub id, so you can
+      pull repeatedly without creating copies. The full sync flow lives in
+      <a href="github.html">GitHub &amp; Pull Requests</a>.
+    </p>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p>Rule of thumb: use <kbd>q</kbd> while you are still figuring out whether something is a problem, and
+      <kbd>c</kbd> once you are ready to say it out loud on the PR. <code>/er-publish</code> includes your GitHub comments
+      when it posts the review.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/concepts.html
+++ b/docs/guide/concepts.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How er Works — easy-review docs</title>
+  <meta name="description" content="The mental model behind easy-review: base branch detection, watch mode, review tracking, the AI sidecar loop, and how the terminal and desktop apps share state.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>How <code>er</code> Works</h1>
+    <p class="lead">
+      Everything in this section applies to both the terminal and desktop apps — they share one review engine. This
+      page is the mental model; the pages that follow drill into each piece.
+    </p>
+
+    <h2>The core idea</h2>
+    <p>
+      Most diff tools assume <em>you</em> wrote the code and just want to look at it before committing. <code>er</code>
+      assumes an AI assistant may have written a lot of it, that the diff keeps changing while you read, and that
+      review is now the bottleneck. So it optimizes for three things: <strong>speed</strong> (instant startup, keyboard
+      navigation), <strong>liveness</strong> (the diff updates itself as code changes), and a <strong>feedback loop</strong>
+      with whatever AI tools you already use.
+    </p>
+
+    <h2>It shells out to git</h2>
+    <p>
+      <code>er</code> does not reimplement git. It runs <code>git diff</code> and friends and parses the unified diff
+      output into a structured model: each <strong>file</strong> contains <strong>hunks</strong>, and each hunk contains
+      <strong>lines</strong>. Every git invocation passes <code>--no-color</code> and <code>--no-ext-diff</code>, so
+      external diff tools like difftastic or delta never interfere. Because git is always installed and battle-tested,
+      this handles every edge case for free.
+    </p>
+
+    <h2>Base branch is detected for you</h2>
+    <p>
+      When you open the branch diff, <code>er</code> needs to know what to compare against. It works down a fallback chain:
+    </p>
+    <ol>
+      <li>Your branch's <strong>upstream tracking branch</strong>, if set.</li>
+      <li><code>main</code></li>
+      <li><code>master</code></li>
+      <li><code>develop</code></li>
+      <li><code>dev</code></li>
+    </ol>
+    <p>
+      You never have to pass a base branch. When the <code>gh</code> CLI is available and your branch has an open pull
+      request that targets a <em>different</em> base, <code>er</code> shows a hint — it does not silently switch on you.
+    </p>
+
+    <h2>Watch mode keeps the diff live</h2>
+    <p>
+      A file-system watcher runs from launch. It monitors three things at once: your working tree (edits),
+      <code>.git/index</code> (staging), and <code>.git/refs/</code> (commits). Changes are debounced — roughly half a
+      second — so a burst of saves becomes a single refresh. The result: leave <code>er</code> open beside your AI
+      assistant and the diff simply follows along. This is a core feature, not a toggle you have to discover; it is on
+      by default.
+    </p>
+    <p>One consequence worth knowing: when a file's diff content actually changes, <code>er</code>
+    <strong>auto-unmarks</strong> it as reviewed. Stale “reviewed” state can never hide new changes from you.</p>
+
+    <h2>Review tracking is first-class</h2>
+    <p>
+      A review is a stateful activity, not a one-shot glance. <code>er</code> remembers which files you have marked
+      reviewed, lets you filter to what remains, and can jump you to the next unreviewed file. That state persists
+      between sessions, keyed to the repository and branch, so a long review survives closing the app. See
+      <a href="reviewing.html">Reviewing &amp; Navigation</a>.
+    </p>
+
+    <h2>Two kinds of notes</h2>
+    <p>
+      <code>er</code> deliberately separates <strong>private questions</strong> (notes to yourself or to your AI, kept
+      local) from <strong>GitHub comments</strong> (PR discussion that syncs upstream). They use different keys and
+      different colors so you never accidentally publish a private thought. Both anchor to an exact line and follow it
+      as the code shifts. Details in <a href="comments.html">Comments &amp; Questions</a>.
+    </p>
+
+    <h2>The AI loop reads sidecar files</h2>
+    <p>
+      This is the part that makes <code>er</code> more than a diff viewer, so it is worth being precise:
+      <strong><code>er</code> does not run any AI model.</strong> Instead, AI tools you run (via the included Claude Code
+      skills, or the desktop app's built-in agent spawns) write structured <strong>sidecar files</strong> — risk levels,
+      findings, a checklist, a summary. <code>er</code> reads those files and renders them inline. The loop looks like this:
+    </p>
+    <pre><code>  you / your AI tool                 er
+  ──────────────────                 ──
+  /er-review            ──writes──&gt;  review.json, checklist.json, …
+                                     reads &amp; renders findings inline
+  press q to ask        ──writes──&gt;  questions.json
+  /er-questions         ──reads───&gt;  responds, updates files
+                                     refreshes, shows answers inline
+  /er-publish           ──reads───&gt;  posts review to your GitHub PR</code></pre>
+    <p>
+      Each sidecar records a SHA-256 hash of the diff it was generated against. When the underlying diff changes, that
+      AI data is dimmed with a <strong>stale</strong> warning, so you always know whether the analysis still matches the
+      code. Full details in <a href="ai-review.html">AI Review</a> and <a href="storage.html">Review Storage</a>.
+    </p>
+
+    <h2>The terminal and desktop apps share everything</h2>
+    <p>
+      Both front ends are thin shells over the same engine (<code>er-engine</code>). They read and write the same review
+      data, keyed per repository, branch, and view. You can run a review in the desktop app and pick it up in the
+      terminal, or vice versa — the reviewed marks, questions, comments, and AI artifacts are the same files underneath.
+      By default those files live in managed application data, <em>not</em> in your repository; see
+      <a href="storage.html">Review Storage</a>.
+    </p>
+
+    <h2>No backend, no telemetry</h2>
+    <p>
+      There is no server, no database, and no network calls of <code>er</code>'s own. It talks to your local
+      <code>git</code>, optionally to <code>gh</code> for pull request features, and reads files written by AI tools you
+      control. Your code never leaves your machine because of <code>er</code>.
+    </p>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>With the model in hand, the rest of Core Concepts is a tour of each capability. Start with
+      <a href="diff-modes.html">Diff Modes</a>.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/configuration.html
+++ b/docs/guide/configuration.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configuration — easy-review docs</title>
+  <meta name="description" content="Configure easy-review with TOML: features, display, agent and AI Hub, watched files, summary, and commands. Per-repo and global config, plus the live settings overlay.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Configuration</h1>
+    <p class="lead">
+      <code>er</code> is configured with TOML — there are no required CLI flags. Settings are deep-merged: a global file
+      provides shared defaults, and a per-repo file overrides individual fields. The desktop app exposes most of these
+      through a settings GUI.
+    </p>
+
+    <h2>Where config lives</h2>
+    <table>
+      <thead><tr><th>Location</th><th>Scope</th><th>Priority</th></tr></thead>
+      <tbody>
+        <tr><td><code>.er-config.toml</code> (repo root)</td><td>Per-repo</td><td>Highest</td></tr>
+        <tr><td><code>~/.config/er/config.toml</code></td><td>Global</td><td>Middle</td></tr>
+        <tr><td>built-in</td><td>Defaults</td><td>Lowest</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Merging is deep and per-field: a repo file only needs to specify what differs from your global config. Everything
+      else inherits from global, then from the built-in defaults. A complete annotated template ships as
+      <code>config.toml.example</code> in the repository.
+    </p>
+
+    <h2>Live editing <span class="pill tui">terminal</span></h2>
+    <p>
+      Press <kbd>S</kbd> inside <code>er</code> to open the settings overlay. Changes apply immediately so you can see
+      the effect. Press <kbd>s</kbd> to persist them to your global config, or <kbd>Esc</kbd> to revert. The desktop app
+      has a dedicated settings page covering the same options plus desktop-only ones.
+    </p>
+
+    <h2><code>[features]</code> — which modes and features are on</h2>
+    <p>Feature toggles. All default to <code>true</code> except <code>blame_annotations</code>.</p>
+    <pre><code>[features]
+view_branch    = <span class="tok-key">true</span>   <span class="cmt"># Branch diff (key 1)</span>
+view_unstaged  = <span class="tok-key">true</span>   <span class="cmt"># Unstaged changes (key 2)</span>
+view_staged    = <span class="tok-key">true</span>   <span class="cmt"># Staged changes (key 3)</span>
+view_history   = <span class="tok-key">true</span>   <span class="cmt"># Commit history (key 4)</span>
+view_conflicts = <span class="tok-key">true</span>   <span class="cmt"># Merge conflicts (key 5)</span>
+view_hidden    = <span class="tok-key">true</span>   <span class="cmt"># Hidden / ignored files (key 6)</span>
+ai_overlays    = <span class="tok-key">true</span>   <span class="cmt"># AI view cycling (v / V)</span>
+split_diff        = <span class="tok-key">true</span>    <span class="cmt"># Side-by-side diff view</span>
+exit_heatmap      = <span class="tok-key">true</span>    <span class="cmt"># Review heatmap on exit</span>
+bookmarks         = <span class="tok-key">true</span>    <span class="cmt"># Diff bookmarks</span>
+blame_annotations = <span class="tok-key">false</span>   <span class="cmt"># Inline git blame (off by default)</span></code></pre>
+    <p>Disabling a view mode removes its tab and renumbers the rest — there are no gaps in the number keys.</p>
+
+    <h2><code>[display]</code> — rendering</h2>
+    <pre><code>[display]
+theme        = <span class="tok-str">"ocean-depth"</span>  <span class="cmt"># ocean-depth | moonlight | daybreak | high-contrast</span>
+line_numbers = <span class="tok-key">true</span>
+wrap_lines   = <span class="tok-key">false</span>         <span class="cmt"># wrap long lines instead of scrolling horizontally</span>
+split_diff   = <span class="tok-key">false</span>
+tab_width    = <span class="tok-key">4</span>             <span class="cmt"># spaces per tab (1–16)</span>
+auto_context_threshold = <span class="tok-key">50</span>  <span class="cmt"># auto-expand full context for files with ≤ N diff lines (0 disables)</span></code></pre>
+    <p>The theme drives both the terminal and desktop UIs. Each maps to a matching syntax-highlighting theme.</p>
+
+    <h2><code>[hints]</code> — bottom-bar key hints <span class="pill tui">terminal</span></h2>
+    <pre><code>[hints]
+navigation = <span class="tok-key">true</span>   <span class="cmt"># j/k, n/N, Space, /</span>
+comments   = <span class="tok-key">true</span>   <span class="cmt"># r, d</span>
+staging    = <span class="tok-key">true</span>   <span class="cmt"># s, commit</span>
+verbose    = <span class="tok-key">false</span>  <span class="cmt"># show all keybindings</span></code></pre>
+
+    <h2 id="ai-hub"><code>[agent]</code> and <code>[ai_hub]</code> — AI providers</h2>
+    <p>
+      <code>[agent]</code> sets the single command used to run AI review actions. <code>{prompt}</code> is replaced with
+      the generated prompt.
+    </p>
+    <pre><code>[agent]
+command = <span class="tok-str">"claude"</span>
+args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"--output-format"</span>, <span class="tok-str">"stream-json"</span>, <span class="tok-str">"-p"</span>, <span class="tok-str">"{prompt}"</span>]</code></pre>
+    <p>
+      The optional <code>[ai_hub]</code> block defines <strong>presets</strong> — multiple providers and their models —
+      so you can switch at runtime without editing config. Provider <code>args</code> are the shared base; each model's
+      <code>args</code> are appended after them.
+    </p>
+    <pre><code>[ai_hub]
+default_provider = <span class="tok-str">"claude"</span>
+default_model    = <span class="tok-str">"sonnet-4.6"</span>
+
+[ai_hub.reviewer_models]
+triage = <span class="tok-str">"haiku-4.5"</span>          <span class="cmt"># pin specific reviewer kinds to specific models</span>
+
+[ai_hub.providers.claude]
+label   = <span class="tok-str">"Claude"</span>
+command = <span class="tok-str">"claude"</span>
+args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"-p"</span>, <span class="tok-str">"{prompt}"</span>]
+
+[[ai_hub.providers.claude.models]]
+id    = <span class="tok-str">"sonnet-4.6"</span>
+label = <span class="tok-str">"Sonnet 4.6"</span>
+args  = [<span class="tok-str">"--model"</span>, <span class="tok-str">"claude-sonnet-4-6"</span>]
+<span class="cmt"># optional metadata: description, cost_per_1k_in, cost_per_1k_out, avg_latency_ms</span></code></pre>
+    <ul>
+      <li>If <code>[ai_hub]</code> is absent, <code>er</code> falls back to the single <code>[agent]</code> config.</li>
+      <li>Selection is session-local; the presets themselves come from TOML.</li>
+      <li>On load, <code>er</code> merges any missing built-in catalog models into your config <em>in memory</em> — it does
+      not rewrite your file.</li>
+      <li>Providers in the example config include Claude, Codex, and Cursor.</li>
+      <li>The selected provider/model applies to AI Hub actions: review, questions, quiz, wizard, and summary.</li>
+    </ul>
+
+    <h2><code>[summary]</code> — diff summaries</h2>
+    <pre><code>[summary]
+<span class="cmt"># command = "claude"                        # defaults to agent.command</span>
+<span class="cmt"># args    = ["--print", "-p", "{diff}"]     # {diff} is replaced with the raw diff</span>
+push_to_pr = <span class="tok-key">false</span>                       <span class="cmt"># auto-push the summary to the GitHub PR body</span></code></pre>
+
+    <h2 id="watched"><code>[watched]</code> — monitor git-ignored files</h2>
+    <p>
+      Glob patterns for ignored paths to watch — for example, an AI assistant's sync folder. Watched files appear in the
+      file tree alongside tracked changes; toggle the section with <kbd>W</kbd>.
+    </p>
+    <pre><code>[watched]
+paths     = [<span class="tok-str">".work/**/*"</span>, <span class="tok-str">".er/**/*"</span>]  <span class="cmt"># patterns matched against the repo root</span>
+diff_mode = <span class="tok-str">"content"</span>                  <span class="cmt"># "content" (show file) or "snapshot" (diff vs saved baseline)</span></code></pre>
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p>Watched files should be in <code>.gitignore</code>. <code>er</code> runs a safety check and warns if a
+      watched pattern is not actually ignored.</p></div>
+    </div>
+
+    <h2><code>[commands]</code> — hub shell actions</h2>
+    <p>
+      Optional shell commands for hub actions, run via <code>sh -c</code>. Leave one unset to hide that action.
+      Placeholders: <code>{base}</code>, <code>{branch}</code>, <code>{repo}</code>, <code>{output}</code>.
+    </p>
+    <pre><code>[commands]
+<span class="cmt"># summary   = "claude --print -p 'Summarize this diff: {base}...{branch}'"</span>
+<span class="cmt"># test      = "cargo test"</span>
+<span class="cmt"># lint      = "cargo clippy"</span>
+<span class="cmt"># typecheck = "cargo check"</span>
+<span class="cmt"># security  = "cargo audit"</span></code></pre>
+
+    <h2>Worked example</h2>
+    <p>Global (<code>~/.config/er/config.toml</code>) holds preferences shared across repos:</p>
+    <pre><code>[features]
+blame_annotations = <span class="tok-key">true</span>
+
+[display]
+tab_width  = <span class="tok-key">2</span>
+wrap_lines = <span class="tok-key">true</span>
+
+[watched]
+paths = [<span class="tok-str">".work/**/*"</span>, <span class="tok-str">".er/**/*"</span>]</code></pre>
+    <p>Per-repo (<code>.er-config.toml</code>) overrides only what differs:</p>
+    <pre><code>[display]
+tab_width = <span class="tok-key">4</span>
+
+[watched]
+paths     = [<span class="tok-str">".work/**/*"</span>, <span class="tok-str">".er/**/*"</span>, <span class="tok-str">"logs/**/*.log"</span>]
+diff_mode = <span class="tok-str">"snapshot"</span></code></pre>
+    <p>
+      Result: <code>blame_annotations</code> and <code>wrap_lines</code> come from global; <code>tab_width = 4</code> and
+      the extra watched path come from the repo file.
+    </p>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/desktop-features.html
+++ b/docs/guide/desktop-features.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Desktop Features in Depth — easy-review docs</title>
+  <meta name="description" content="In-depth look at the easy-review desktop app: review arena, AI Hub, inline threads, browser annotations, terminal drawer, export, references, split/word diff, settings, and shortcuts.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Desktop App</p>
+    <h1>Features in Depth</h1>
+    <p class="lead">
+      A tour of the capabilities that are unique to the desktop app. For the shared review model — diff modes, comments,
+      AI sidecars — see <a href="concepts.html">Core Concepts</a>.
+    </p>
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p>The desktop app is evolving quickly. Treat specific shortcuts and panel names as current-as-of-writing
+      rather than a frozen contract.</p></div>
+    </div>
+
+    <h2>Diff rendering: split and word diff</h2>
+    <p>
+      Beyond the unified view, the desktop app offers a <strong>split (side-by-side)</strong> diff — old on the left, new
+      on the right — toggleable from the keyboard or command palette. Within changed lines it computes an
+      <strong>intra-line word diff</strong>, so a renamed variable or a tweaked literal is highlighted at the token level
+      rather than marking the whole line changed. Syntax highlighting runs client-side via Shiki in a Web Worker, cached
+      per file.
+    </p>
+
+    <h2 id="arena">The review arena</h2>
+    <p>
+      The arena runs multiple AI reviewers over the same diff and reconciles their findings — think of it as a panel of
+      reviewers rather than a single pass.
+    </p>
+    <ul>
+      <li><strong>Configure a run</strong> — pick reviewers (models and/or specialized agents like Security, Performance,
+      Testing), choose a scope (full branch, unstaged, staged, or selected files), set the number of rounds, and pick an
+      arbiter model.</li>
+      <li><strong>Cost preview</strong> — an estimate based on each model's per-1k-token pricing, with an approval gate
+      before anything runs.</li>
+      <li><strong>Watch progress</strong> — a minimizable panel shows the current round and phase, with a cancel button.</li>
+      <li><strong>Read the results</strong> — three layouts: a <em>bracket</em> view of how verdicts flowed, a
+      <em>matrix</em> of reviewers against findings, and a <em>funnel</em> from proposed to final.</li>
+      <li><strong>History</strong> — past arena runs on the current branch are listed with their reviewer and finding counts.</li>
+    </ul>
+    <p>
+      Concurrency is bounded: spawns go through a queue with a configurable cap (default 3, adjustable in settings), and a
+      process-wide semaphore keeps simultaneous runs from multiplying agent subprocesses.
+    </p>
+
+    <h2>AI Hub: providers, models, reviewers</h2>
+    <p>
+      The AI action palette (<kbd>Cmd</kbd>+<kbd>A</kbd>) is the desktop's front door to AI. From it you can run a review,
+      launch the arena, choose a <strong>provider</strong> (Claude, Codex, Cursor), pick a specific <strong>model</strong>,
+      select which <strong>reviewer kinds</strong> to run, and reach export, the browser, and settings. Running reviews
+      surface as background tasks with cancellation; results land in the Review tab, filterable by severity or by agent.
+      The provider and model catalog comes from your <a href="configuration.html#ai-hub">AI Hub configuration</a>.
+    </p>
+
+    <h2>Inline threads &amp; findings</h2>
+    <p>
+      Comments and questions render as <strong>inline threads</strong> on the diff, with a reply composer. Two desktop
+      conveniences stand out:
+    </p>
+    <ul>
+      <li><strong>Ask AI</strong> — prompt an agent to validate or expand on a thread directly from the comment.</li>
+      <li><strong>Promote to GitHub</strong> — turn a private question into a GitHub PR comment when you decide it is worth
+      raising.</li>
+    </ul>
+    <p>
+      AI findings render as inline cards with a severity badge and an agent pill (Security, Performance, Professor, …),
+      their own reply thread, and a control to promote them into GitHub comments. Resolved and stale states are tracked
+      just as in the terminal.
+    </p>
+
+    <h2>Embedded browser &amp; page annotations</h2>
+    <p>
+      The desktop app can show a real embedded browser beside your diff — handy for reading docs, a design system, or an
+      API while you review. It loads real <code>http://localhost</code> URLs so logins and sessions work like a normal
+      browser, with an iframe proxy fallback. Its <strong>annotation mode</strong> lets you click elements on the page to
+      drop pins, optionally capturing a screenshot crop and DOM context, then write a markdown note. Annotations can link
+      back to specific lines in the diff, and findings in code can link out to page sections.
+    </p>
+
+    <h2>Embedded terminal drawer</h2>
+    <p>
+      A resizable terminal drawer runs a full shell (xterm.js + PTY) per tab, themed to match the app. Run tests, git
+      commands, or anything else without leaving the review. It includes a generous scrollback buffer and a one-click
+      “checkout this branch” helper.
+    </p>
+
+    <h2>Code references &amp; “find usages”</h2>
+    <p>
+      A search bar (<kbd>Cmd</kbd>+<kbd>F</kbd>) prefills from selected text or a hovered identifier. Hovering an
+      identifier highlights every occurrence in the diff, and a “find usages” popover lists references with surrounding
+      line context (calls, assignments, and so on). A ruler along the scroll gutter marks where matches are.
+    </p>
+
+    <h2>Triage &amp; professor</h2>
+    <p>
+      The Review tab can show a <strong>triage card</strong> with a routing verdict (general review, expert review,
+      arena, professor, or skip), a confidence level, rationale, and priority files — each with a one-click button to run
+      the recommended next step. A <strong>professor focus</strong> flow lets you pair an expert with a custom focus
+      prompt and scope for a deeper, teaching-oriented pass.
+    </p>
+
+    <h2>Export a review</h2>
+    <p>
+      The export view renders a live markdown preview of your findings, comments, questions, and annotations, with
+      toggles to include or exclude each type and an “unresolved only” filter. Copy it to the clipboard or save it to
+      <code>export.md</code> — useful for a review summary in a PR description or a writeup.
+    </p>
+
+    <h2>Tabs, projects, and PRs</h2>
+    <ul>
+      <li><strong>Persistent tabs</strong> — open repos, branches, and PRs as tabs that survive restarts; drag to reorder.</li>
+      <li><strong>Lazy restoration</strong> — inactive tabs are lightweight stubs until selected, with background warming
+      for fast switching.</li>
+      <li><strong>Project / branch picker</strong> — switch repositories and branches from the sidebar.</li>
+      <li><strong>Remote PR review</strong> — paste a PR URL (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd>) and review
+      against remote refs without a checkout.</li>
+      <li><strong>Worktree picker</strong> — jump between git worktrees.</li>
+    </ul>
+
+    <h2>Settings GUI</h2>
+    <p>The settings page exposes configuration as a UI, organized into tabs:</p>
+    <table>
+      <thead><tr><th>Tab</th><th>Covers</th></tr></thead>
+      <tbody>
+        <tr><td><strong>General</strong></td><td>Theme, default AI provider and model, agent effort and concurrency cap. Shared with the terminal where applicable.</td></tr>
+        <tr><td><strong>Projects</strong></td><td>Per-project triage timing, file-size limits, and review ignore patterns.</td></tr>
+        <tr><td><strong>Terminal</strong></td><td>TUI display and key-hint options.</td></tr>
+      </tbody>
+    </table>
+    <p>The same <a href="configuration.html">themes</a> drive both the desktop and terminal UIs; changing one restyles the app live.</p>
+
+    <h2>Keyboard shortcuts</h2>
+    <p>The desktop app is heavily keyboard-driven too. Current shortcuts include:</p>
+    <table>
+      <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>Cmd</kbd>+<kbd>A</kbd></td><td>AI action palette (run review, pick agents)</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>K</kbd></td><td>Command palette</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>F</kbd></td><td>Diff search (prefilled from selection)</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>B</kbd></td><td>Cycle browser layout (hidden → split → fullscreen)</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd></td><td>Open the export view</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>T</kbd></td><td>Toggle the terminal drawer (also the backtick key)</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></td><td>New tab</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>W</kbd></td><td>Close the current tab</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>1</kbd>…<kbd>9</kbd></td><td>Jump to tab N</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd></td><td>Open a PR by URL</td></tr>
+        <tr><td><kbd>Cmd</kbd>+<kbd>R</kbd></td><td>Force refresh (fetch from remote)</td></tr>
+        <tr><td><kbd>[</kbd> / <kbd>]</kbd> / <kbd>\</kbd></td><td>Toggle left panel / right panel / file tree</td></tr>
+        <tr><td><kbd>d</kbd></td><td>Toggle unified ↔ split diff</td></tr>
+        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Navigate files</td></tr>
+        <tr><td><kbd>e</kbd></td><td>Open the selected file in your editor</td></tr>
+        <tr><td><kbd>Esc</kbd></td><td>Close modals / clear highlights (in precedence order)</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>Q</kbd></td><td>Quit</td></tr>
+      </tbody>
+    </table>
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>On non-macOS platforms, <kbd>Cmd</kbd> maps to the platform's primary modifier. The live shortcut list in
+      the command palette is always the source of truth.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/desktop.html
+++ b/docs/guide/desktop.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Desktop App Overview — easy-review docs</title>
+  <meta name="description" content="The easy-review desktop app: a Tauri + Svelte review application with a multi-panel layout, embedded terminal and browser, multi-model review arena, and a settings GUI.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Desktop App</p>
+    <h1>Desktop App Overview</h1>
+    <p class="lead">
+      The desktop app is a graphical front end for the same review engine the terminal uses. It trades the terminal's
+      instant, minimal feel for a richer surface: split diffs, an embedded terminal and browser, a multi-model review
+      “arena”, point-and-click settings, and persistent tabs. Everything shared with the terminal is covered under
+      <a href="concepts.html">Core Concepts</a>; this section is the desktop-specific parts.
+    </p>
+
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p>The desktop app is in <strong>active development</strong>. It is built from source today (it is not part of
+      the published releases yet), and details such as exact keyboard shortcuts may change. See
+      <a href="installation.html#desktop-app">Installation</a> for build steps.</p></div>
+    </div>
+
+    <h2>How it relates to the terminal app</h2>
+    <p>
+      Same engine, same data. The desktop app reads and writes the same review files per repository, branch, and view, so
+      a review started in the terminal continues in the desktop app and vice versa. The mental model — diff modes, watch
+      mode, reviewed marks, questions vs GitHub comments, AI sidecars and staleness — is identical. What differs is the
+      presentation and a set of features only a GUI can offer.
+    </p>
+
+    <h2>The layout</h2>
+    <p>The window is organized into several regions:</p>
+    <table>
+      <thead><tr><th>Region</th><th>Purpose</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Tab strip</strong> (top)</td><td>Open repos, branches, and PRs as tabs. Drag to reorder, middle-click to close, jump with <kbd>Cmd</kbd>+<kbd>1…9</kbd>.</td></tr>
+        <tr><td><strong>Branch context bar</strong></td><td>Current branch, base comparison, PR number, change summary, and a Local&nbsp;Branch ↔ PR&nbsp;Diff toggle.</td></tr>
+        <tr><td><strong>Left sidebar</strong></td><td>Collapsible file tree with search, plus a project / branch / PR picker for switching context.</td></tr>
+        <tr><td><strong>Diff view</strong> (center)</td><td>Unified or split diff with inline threads, AI findings, and intra-line word-diff highlighting.</td></tr>
+        <tr><td><strong>Right panel</strong></td><td>Three tabs — Branch (git/PR status), Review (AI findings, summary, arena history), and Notes (questions &amp; GitHub comments).</td></tr>
+        <tr><td><strong>Browser</strong> (optional)</td><td>An embedded webview for docs, design systems, or APIs, with an annotation mode.</td></tr>
+        <tr><td><strong>Terminal drawer</strong> (bottom)</td><td>A resizable embedded shell for running commands without leaving the app.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Command surfaces</h2>
+    <p>Two palettes make everything reachable without hunting through menus:</p>
+    <ul>
+      <li><strong>Command palette</strong> (<kbd>Cmd</kbd>+<kbd>K</kbd>) — a searchable list of actions, navigation, and
+      files in the current diff.</li>
+      <li><strong>AI action palette / AI Hub</strong> (<kbd>Cmd</kbd>+<kbd>A</kbd>) — run a review, launch the arena,
+      pick a provider and model, choose specialized reviewers, export, and more.</li>
+    </ul>
+
+    <h2>What the desktop adds over the terminal</h2>
+    <table>
+      <thead><tr><th>Capability</th><th>Desktop</th><th>Terminal</th></tr></thead>
+      <tbody>
+        <tr><td>Split-mode (side-by-side) diff</td><td>Yes</td><td>—</td></tr>
+        <tr><td>Intra-line word-diff highlighting</td><td>Yes</td><td>—</td></tr>
+        <tr><td>Embedded terminal drawer</td><td>Yes</td><td>—</td></tr>
+        <tr><td>Embedded browser + page annotations</td><td>Yes</td><td>—</td></tr>
+        <tr><td>Multi-model review arena</td><td>Full UI (bracket / matrix / funnel)</td><td>CLI output</td></tr>
+        <tr><td>Settings as a GUI</td><td>Yes</td><td>Overlay + TOML</td></tr>
+        <tr><td>Persistent, drag-to-reorder tabs</td><td>Yes</td><td>Session tabs</td></tr>
+        <tr><td>Reference “find usages” popover</td><td>Yes</td><td>—</td></tr>
+        <tr><td>Export review to markdown</td><td>Preview + copy/save</td><td>—</td></tr>
+        <tr><td>Keyboard-driven, zero-dependency, instant start</td><td>—</td><td>Yes</td></tr>
+      </tbody>
+    </table>
+    <p>Each of these is covered in depth on the next page.</p>
+
+    <h2>Running it</h2>
+    <pre><code><span class="cmt"># development shell with hot reload</span>
+./scripts/tauri-dev.sh
+
+<span class="cmt"># with extra logging (e.g. the review arena)</span>
+./scripts/tauri-dev.sh --logs arena
+
+<span class="cmt"># build a release bundle (.app + .dmg on macOS)</span>
+./scripts/tauri-build.sh</code></pre>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p><strong>Next:</strong> <a href="desktop-features.html">Features in Depth</a> walks through the arena,
+      browser annotations, terminal drawer, export, references, and the desktop keyboard shortcuts.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/diff-modes.html
+++ b/docs/guide/diff-modes.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diff Modes — easy-review docs</title>
+  <meta name="description" content="The six diff modes in easy-review: branch, unstaged, staged, commit history, merge conflicts, and hidden/ignored files — plus PR diff and recency sorting.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Diff Modes</h1>
+    <p class="lead">
+      A “mode” is simply <em>which set of changes</em> <code>er</code> is showing you. There are six built-in modes plus
+      a pull-request mode. In the terminal you switch with the number keys; in the desktop app you switch from the
+      branch context bar.
+    </p>
+
+    <h2>The six modes at a glance</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Mode</th><th>Shows</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>1</kbd></td><td>Branch</td><td>Everything that differs between your branch and its detected base branch.</td></tr>
+        <tr><td><kbd>2</kbd></td><td>Unstaged</td><td>Working-tree changes you have not staged yet (<code>git diff</code>).</td></tr>
+        <tr><td><kbd>3</kbd></td><td>Staged</td><td>Changes in the index, ready to commit (<code>git diff --cached</code>).</td></tr>
+        <tr><td><kbd>4</kbd></td><td>History</td><td>Commit-by-commit view of your branch's history.</td></tr>
+        <tr><td><kbd>5</kbd></td><td>Conflicts</td><td>Files with unresolved merge conflicts.</td></tr>
+        <tr><td><kbd>6</kbd></td><td>Hidden</td><td>Hidden / git-ignored files that <code>er</code> can still surface.</td></tr>
+      </tbody>
+    </table>
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>Tab numbers are assigned dynamically to the modes that are <em>enabled</em>. If you disable a mode in
+      <a href="configuration.html">configuration</a>, the remaining modes renumber so there are no gaps.</p></div>
+    </div>
+
+    <h2>Branch <span class="pill both">both</span></h2>
+    <p>
+      The default mode and the one you will use most. It answers “what does this branch change?” by diffing against the
+      auto-detected base branch (see <a href="concepts.html#base-branch-is-detected-for-you">base branch detection</a>).
+      This is the right mode for reviewing a feature branch or a pull request's worth of work.
+    </p>
+
+    <h2>Unstaged <span class="pill both">both</span></h2>
+    <p>
+      Your in-progress edits that have not been <code>git add</code>-ed. Pairs naturally with watch mode while an AI
+      assistant is actively editing — you see changes appear as they are written.
+    </p>
+
+    <h2>Staged <span class="pill both">both</span></h2>
+    <p>
+      What is in the index and would go into your next commit. From the terminal you can <strong>stage or unstage</strong>
+      the current file with <kbd>s</kbd>, and in staged mode you can commit and push without leaving <code>er</code>
+      (<kbd>Ctrl</kbd>+<kbd>P</kbd>). After you commit, <code>er</code> automatically switches to a view of exactly what
+      you just committed (<code>git diff HEAD~1 HEAD</code>) so you can confirm it before moving on.
+    </p>
+
+    <h2>History <span class="pill both">both</span></h2>
+    <p>
+      A commit log for your branch. Selecting a commit loads its full diff (the parser runs <code>git log</code> plus a
+      <code>git diff</code> per commit). Recent commits are cached so scrolling back through history stays fast. Use this
+      to review work commit by commit rather than as one big squashed diff.
+    </p>
+
+    <h2>Conflicts <span class="pill both">both</span></h2>
+    <p>
+      Surfaces files with unresolved merge conflicts so you can find and work through them quickly during a merge or
+      rebase.
+    </p>
+
+    <h2>Hidden / ignored <span class="pill both">both</span></h2>
+    <p>
+      Files git normally hides — ignored paths and the like. This is distinct from the <strong>watched files</strong>
+      feature (configurable globs for git-ignored paths such as agent sync folders), which you toggle with <kbd>W</kbd>.
+      See <a href="configuration.html#watched">Watched files</a>.
+    </p>
+
+    <h2>Pull request mode <span class="pill both">both</span></h2>
+    <p>
+      Not a number key — you enter it by opening a PR. From the terminal:
+    </p>
+    <pre><code>er --pr 42
+er https://github.com/owner/repo/pull/42</code></pre>
+    <p>
+      In PR mode the right-hand panel shows CI checks, reviewer decisions, and labels, and comment sync targets that
+      pull request. The desktop app has a “PR Diff” toggle and a paste-a-URL modal. PR review can be done against remote
+      refs without checking out the branch. See <a href="github.html">GitHub &amp; Pull Requests</a>.
+    </p>
+
+    <h2>Sorting by recency</h2>
+    <p>
+      In any mode, press <kbd>Shift</kbd>+<kbd>R</kbd> to toggle sorting files by modification time. When an AI tool just
+      touched a handful of files, this floats them to the top of the list so you review the freshest changes first.
+    </p>
+
+    <h2>Performance with large diffs</h2>
+    <p><code>er</code> is built to stay fast even on enormous diffs. Three mechanisms do the heavy lifting:</p>
+    <ul>
+      <li><strong>Auto-compaction</strong> — lock files, generated code, minified assets, and files over ~500 lines are
+      compacted automatically: their hunks are cleared from memory and shown as a single collapsed entry. Press
+      <kbd>Enter</kbd> to expand one on demand.</li>
+      <li><strong>Two-phase lazy parsing</strong> — diffs above ~5,000 lines get a header-only scan for the file list,
+      and individual files are parsed only when you navigate to them.</li>
+      <li><strong>Viewport rendering</strong> — only the rows visible on screen (plus a small buffer) are ever built, so
+      a 5,000-line file renders like a 60-line one.</li>
+    </ul>
+    <p>You rarely have to think about any of this — it just keeps scrolling smooth.</p>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/github.html
+++ b/docs/guide/github.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub &amp; Pull Requests — easy-review docs</title>
+  <meta name="description" content="Open and review GitHub pull requests in easy-review: PR by number or URL, CI and reviewer status, two-way comment sync, and pushing from the TUI.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>GitHub &amp; Pull Requests</h1>
+    <p class="lead">
+      <code>er</code> integrates with GitHub through the <code>gh</code> CLI — no API tokens to manage. Open a pull
+      request, see its CI and reviewer status, sync comments both ways, and push your work, all without opening a browser.
+    </p>
+
+    <h2>Prerequisites</h2>
+    <p>
+      Install the <a href="https://cli.github.com" target="_blank" rel="noopener">GitHub CLI</a> and authenticate once:
+    </p>
+    <pre><code>gh auth login</code></pre>
+    <p>
+      <code>er</code> shells out to <code>gh</code> and reuses that authentication. There is no separate token to
+      configure, and GitHub features simply stay hidden if <code>gh</code> is not available.
+    </p>
+
+    <h2>Opening a pull request</h2>
+    <p>From the terminal, open a PR by number or by URL:</p>
+    <pre><code><span class="cmt"># by number, in the current repo</span>
+er --pr 42
+
+<span class="cmt"># by full URL (any repo)</span>
+er https://github.com/owner/repo/pull/42</code></pre>
+    <p>
+      The desktop app offers a “PR Diff” toggle in the branch context bar and a paste-a-URL modal
+      (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd>). PR review works against remote refs, so you can review a pull
+      request <strong>without checking out</strong> its branch into your working tree.
+    </p>
+
+    <h2>Automatic base detection &amp; the PR hint</h2>
+    <p>
+      When you are on a branch that has an open PR, <code>er</code> notices it. If the PR targets a base branch different
+      from the one <code>er</code> auto-detected, it shows a <strong>hint</strong> rather than switching silently — you
+      stay in control of what you are comparing against. The PR base check runs on a background thread so it never slows
+      startup.
+    </p>
+
+    <h2>The PR context panel</h2>
+    <p>In PR mode the right-hand panel summarizes the pull request without a browser round-trip:</p>
+    <ul>
+      <li><strong>CI checks</strong> — build, tests, and other checks with pass/fail/running status.</li>
+      <li><strong>Reviewers</strong> — who approved, who requested changes, who is still pending.</li>
+      <li><strong>Labels</strong> — the PR's labels.</li>
+      <li><strong>Title &amp; base</strong> — e.g. <code>feat/auth-refactor → main</code>.</li>
+    </ul>
+
+    <h2>Two-way comment sync</h2>
+    <p>GitHub comments (the cyan <kbd>c</kbd>/<kbd>C</kbd> notes) sync in both directions:</p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>G</kbd></td><td><strong>Pull</strong> review comments from the PR into your diff view</td></tr>
+        <tr><td><kbd>P</kbd></td><td><strong>Push</strong> your local comments up to the PR</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Pulled comments appear inline, anchored to their lines, alongside your own. Each comment tracks its
+      <code>source</code>, GitHub <code>id</code>, <code>author</code>, and <code>synced</code> flag. Because
+      deduplication keys on the GitHub id, pulling repeatedly is safe — you will not get duplicates. Pushing marks your
+      comments as synced. Replies are single-level threads, matching GitHub's PR review model (see
+      <a href="comments.html">Comments &amp; Questions</a>).
+    </p>
+
+    <h2>Publishing an AI review to a PR</h2>
+    <p>
+      The <code>/er-publish</code> skill takes your review — AI findings plus your GitHub comments — validates that it is
+      still fresh against the current diff, and posts it to the pull request as inline review comments. This is the
+      bridge from a local <code>er</code> session to a review your team sees on GitHub. See
+      <a href="skills.html">Claude Code Skills</a>.
+    </p>
+
+    <h2>Staging, committing, and pushing <span class="pill tui">terminal</span></h2>
+    <p>You can move work along without leaving <code>er</code>:</p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>s</kbd></td><td>Stage / unstage the current file</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Git push (from staged mode)</td></tr>
+      </tbody>
+    </table>
+    <p>
+      After you commit, <code>er</code> switches to a view of exactly what was committed so you can confirm it. Staging
+      is file-level. For richer git operations, drop to your shell — <code>er</code> is a review tool, not a full git client.
+    </p>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>The desktop app surfaces the same GitHub data through cards (branch status, checks, comments) and can
+      submit reviews from its UI. See <a href="desktop-features.html">Desktop Features</a>.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>easy-review documentation</title>
+  <meta name="description" content="Documentation for easy-review (er) — a fast git diff review tool for developers who work with AI coding assistants. Terminal UI and desktop app.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">easy-review documentation</p>
+    <h1>Review diffs at the speed of thought</h1>
+    <p class="lead">
+      <strong>easy-review</strong> (the <code>er</code> binary) is a git diff review tool built for
+      developers who work with AI coding assistants. AI writes code faster than you can read it —
+      <code>er</code> makes review fast, navigable, and live-updating, whether you prefer a keyboard-driven
+      terminal UI or a full desktop application.
+    </p>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div>
+        <p><strong>New here?</strong> Start with <a href="installation.html">Installation</a>, then walk through
+        your first review in the <a href="quick-start.html">Quick Start</a>. If you just want the key map,
+        jump to the <a href="tui-keybindings.html">Keybinding Reference</a>.</p>
+      </div>
+    </div>
+
+    <h2>Two front ends, one engine</h2>
+    <p>
+      <code>er</code> ships as two applications that share the same review engine, the same on-disk review data,
+      and the same core concepts. Pick the one that fits how you work — or use both on the same repository and
+      branch, since they read and write the same review files.
+    </p>
+
+    <div class="card-grid">
+      <a class="card" href="tui.html">
+        <div class="card-eyebrow">Terminal</div>
+        <h3>The <code>er</code> TUI</h3>
+        <p>A single static binary. Keyboard-driven, instant startup, runs anywhere a terminal does — perfect next to Claude Code in a split pane.</p>
+      </a>
+      <a class="card" href="desktop.html">
+        <div class="card-eyebrow">Desktop</div>
+        <h3>The desktop app</h3>
+        <p>A Tauri application with split diffs, an embedded terminal and browser, multi-model review “arena”, and a settings GUI.</p>
+      </a>
+    </div>
+
+    <h2>What you can do with it</h2>
+    <ul>
+      <li><strong>Read diffs in six modes</strong> — branch, unstaged, staged, commit history, merge conflicts, and hidden/ignored files.</li>
+      <li><strong>Follow changes live</strong> — watch mode refreshes the diff as files are saved, staged, and committed.</li>
+      <li><strong>Track your progress</strong> — mark files reviewed, filter to what is left, jump to the next unreviewed file.</li>
+      <li><strong>Leave two kinds of notes</strong> — private questions for yourself or your AI, and GitHub comments that sync to a pull request.</li>
+      <li><strong>Layer in AI analysis</strong> — per-file risk levels, inline findings, a review checklist, and specialized expert agents.</li>
+      <li><strong>Work with pull requests</strong> — open a PR by number or URL, see CI and reviewer status, and sync comments two ways.</li>
+    </ul>
+
+    <h2>How this documentation is organized</h2>
+    <p>
+      Most features work the same in both the terminal and desktop apps. Those shared ideas live under
+      <strong>Core Concepts</strong>. Where the two differ, the dedicated <strong>Terminal UI</strong> and
+      <strong>Desktop App</strong> sections cover what is unique to each. Throughout the docs, look for these badges:
+    </p>
+    <p>
+      <span class="pill both">both</span> works in the terminal and desktop apps &nbsp;
+      <span class="pill tui">terminal</span> terminal UI only &nbsp;
+      <span class="pill desktop">desktop</span> desktop app only
+    </p>
+
+    <table>
+      <thead><tr><th>If you want to…</th><th>Read</th></tr></thead>
+      <tbody>
+        <tr><td>Install either app</td><td><a href="installation.html">Installation</a></td></tr>
+        <tr><td>Run your first review end to end</td><td><a href="quick-start.html">Quick Start</a></td></tr>
+        <tr><td>Understand the mental model</td><td><a href="concepts.html">How er Works</a></td></tr>
+        <tr><td>Learn the diff modes</td><td><a href="diff-modes.html">Diff Modes</a></td></tr>
+        <tr><td>Comment and ask questions</td><td><a href="comments.html">Comments &amp; Questions</a></td></tr>
+        <tr><td>Set up the AI review loop</td><td><a href="ai-review.html">AI Review</a> &amp; <a href="skills.html">Skills</a></td></tr>
+        <tr><td>Connect a GitHub pull request</td><td><a href="github.html">GitHub &amp; Pull Requests</a></td></tr>
+        <tr><td>Customize behavior</td><td><a href="configuration.html">Configuration</a></td></tr>
+        <tr><td>Memorize the keyboard</td><td><a href="tui-keybindings.html">Keybinding Reference</a></td></tr>
+      </tbody>
+    </table>
+
+    <h2>A note on your data</h2>
+    <p>
+      <code>er</code> is a <strong>viewer and orchestrator</strong>. It does not run AI models itself, and it does
+      not transmit your code anywhere. There is no telemetry, no analytics, and no backend — it shells out to your
+      local <code>git</code> (and optionally the <code>gh</code> CLI) and reads review artifacts that AI tools
+      <em>you</em> run write to disk. You bring your own AI tools and credentials. See
+      <a href="ai-review.html">AI Review</a> for how that loop works.
+    </p>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Installation — easy-review docs</title>
+  <meta name="description" content="Install the easy-review terminal UI and build the desktop app. Requirements, quick install script, and building from source.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Getting Started</p>
+    <h1>Installation</h1>
+    <p class="lead">
+      The terminal app (<code>er</code>) is a single binary you can install in seconds. The desktop app is
+      currently built from source. Both need <code>git</code>; everything else is optional.
+    </p>
+
+    <h2>Requirements</h2>
+    <table>
+      <thead><tr><th>Dependency</th><th>Needed for</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td><strong>git</strong></td><td>Everything</td><td>Required. <code>er</code> shells out to git for all diff operations.</td></tr>
+        <tr><td><strong>gh</strong> (GitHub CLI)</td><td>Pull request features</td><td>Optional. Used for PR metadata and two-way comment sync. Install from <a href="https://cli.github.com" target="_blank" rel="noopener">cli.github.com</a> and run <code>gh auth login</code>. No API token to manage.</td></tr>
+        <tr><td>An AI coding tool</td><td>AI review</td><td>Optional. e.g. Claude Code, Codex, or Cursor. You bring your own tool and credentials.</td></tr>
+        <tr><td><strong>Rust 1.85+</strong></td><td>Building from source</td><td>Not needed if you use the install script. The workspace uses the 2024 edition.</td></tr>
+        <tr><td><strong>Node.js / Bun</strong></td><td>Desktop UI dev</td><td>Only for working on the desktop frontend.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Terminal app (<code>er</code>) <span class="pill tui">terminal</span></h2>
+
+    <h3>Quick install — macOS &amp; Linux</h3>
+    <p>The install script downloads a pre-built binary into <code>~/.local/bin/</code>:</p>
+    <pre><code>curl -fsSL https://raw.githubusercontent.com/VilfredSikker/easy-review/main/install.sh | bash</code></pre>
+    <p>Install to a different directory, or pin a version:</p>
+    <pre><code><span class="cmt"># custom install directory</span>
+curl -fsSL https://raw.githubusercontent.com/VilfredSikker/easy-review/main/install.sh | bash -s -- --dir /usr/local/bin
+
+<span class="cmt"># a specific released version</span>
+curl -fsSL https://raw.githubusercontent.com/VilfredSikker/easy-review/main/install.sh | bash -s -- --version v0.3.0</code></pre>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>Make sure your install directory is on your <code>PATH</code>. For <code>~/.local/bin</code>, add
+      <code>export PATH="$HOME/.local/bin:$PATH"</code> to your shell profile if it is not already there.</p></div>
+    </div>
+
+    <h3>From source with Cargo</h3>
+    <pre><code>git clone https://github.com/VilfredSikker/easy-review.git
+cd easy-review
+cargo install --path crates/er-tui</code></pre>
+    <p>Or install directly from the repository without cloning:</p>
+    <pre><code>cargo install --git https://github.com/VilfredSikker/easy-review er-tui</code></pre>
+    <p>This produces a single <code>er</code> binary with no runtime dependencies beyond git.</p>
+
+    <h3>Verify the install</h3>
+    <pre><code>er --help
+cd ~/some/git/repo
+er</code></pre>
+
+    <h2 id="desktop-app">Desktop app <span class="pill desktop">desktop</span></h2>
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p>The desktop app is in active development and is <strong>not</strong> part of the published GitHub
+      releases yet — only the <code>er</code> terminal binary is released. To run it today, build it from source.</p></div>
+    </div>
+
+    <h3>Run in development</h3>
+    <pre><code>git clone https://github.com/VilfredSikker/easy-review.git
+cd easy-review
+./scripts/tauri-dev.sh</code></pre>
+    <p>This launches the Tauri dev shell with the Svelte frontend and hot reload.</p>
+
+    <h3>Build a release bundle</h3>
+    <pre><code>./scripts/tauri-build.sh</code></pre>
+    <p>On macOS this produces an <code>Easy Review.app</code> and a <code>.dmg</code> under the desktop build target.
+    Building requires <code>cargo-tauri</code> and the platform WebView dependencies (WebKit/GTK on Linux).</p>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p>The terminal and desktop apps read and write the same review data per repository and branch, so you can
+      install both and switch between them freely. See <a href="storage.html">Review Storage</a> for where that data lives.</p></div>
+    </div>
+
+    <h2>Updating</h2>
+    <ul>
+      <li><strong>Script install:</strong> re-run the install command to fetch the latest release.</li>
+      <li><strong>Cargo install:</strong> re-run <code>cargo install --git … er-tui</code> (add <code>--force</code> if needed).</li>
+      <li><strong>From a clone:</strong> <code>git pull</code> then rebuild.</li>
+    </ul>
+
+    <h2>Uninstalling</h2>
+    <p>Delete the <code>er</code> binary from your install directory (e.g. <code>rm ~/.local/bin/er</code>). Review
+    data lives separately in managed storage — see <a href="storage.html">Review Storage</a> for those paths if you
+    want to remove it too.</p>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/quick-start.html
+++ b/docs/guide/quick-start.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quick Start — easy-review docs</title>
+  <meta name="description" content="Run your first review with easy-review: open a diff, navigate, mark files reviewed, leave comments, and layer in AI analysis.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Getting Started</p>
+    <h1>Quick Start</h1>
+    <p class="lead">
+      This walkthrough takes you from “installed” to a complete review loop in a few minutes. It uses the terminal
+      app, but every concept maps directly onto the desktop app — see <a href="desktop.html">Desktop Overview</a> for
+      its equivalents.
+    </p>
+
+    <h2>1. Open a diff</h2>
+    <p>From inside any git repository, run:</p>
+    <pre><code>er</code></pre>
+    <p>
+      <code>er</code> opens on the <strong>branch diff</strong> — everything that differs between your current branch
+      and its base. The base branch is detected automatically from your upstream tracking branch, falling back to
+      <code>main</code>, <code>master</code>, <code>develop</code>, then <code>dev</code>. You did not have to specify it.
+    </p>
+    <p>You will see three regions: a file list on the left, the diff in the center, and a context panel on the right.
+    The top bar shows the available diff modes and any detected pull request; the bottom bar shows key hints.</p>
+
+    <h2>2. Move around</h2>
+    <p>Everything is keyboard-driven. The essentials:</p>
+    <table>
+      <thead><tr><th>Keys</th><th>Move</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
+        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line within hunks</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+        <tr><td><kbd>/</kbd></td><td>Search files by name</td></tr>
+      </tbody>
+    </table>
+    <p>The full map is on the <a href="tui-keybindings.html">Keybinding Reference</a> page.</p>
+
+    <h2>3. Switch diff modes</h2>
+    <p>Press a number key to change what you are looking at:</p>
+    <pre><code><span class="cmt"># 1  branch diff (vs base)     4  commit history</span>
+<span class="cmt"># 2  unstaged changes          5  merge conflicts</span>
+<span class="cmt"># 3  staged changes            6  hidden / ignored files</span></code></pre>
+    <p>See <a href="diff-modes.html">Diff Modes</a> for what each one shows and when to reach for it.</p>
+
+    <h2>4. Track your progress</h2>
+    <p>As you finish a file, mark it reviewed:</p>
+    <ul>
+      <li><kbd>Space</kbd> — toggle the current file as reviewed.</li>
+      <li><kbd>u</kbd> — filter the list down to files you have <em>not</em> reviewed.</li>
+      <li><kbd>U</kbd> — jump straight to the next unreviewed file.</li>
+    </ul>
+    <p>If a file's diff changes underneath you (because watch mode picked up an edit), its reviewed mark clears
+    automatically so you never miss new changes.</p>
+
+    <h2>5. Leave notes</h2>
+    <p><code>er</code> has two kinds of inline notes, on two different keys:</p>
+    <table>
+      <thead><tr><th>Key</th><th>Note type</th><th>Goes to</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>q</kbd> / <kbd>Q</kbd></td><td>Private <strong>question</strong> (yellow)</td><td>Stays local; read by your AI tools</td></tr>
+        <tr><td><kbd>c</kbd> / <kbd>C</kbd></td><td><strong>GitHub comment</strong> (cyan)</td><td>Syncs to a pull request</td></tr>
+      </tbody>
+    </table>
+    <p>Lowercase targets the current line; uppercase targets the whole hunk. Read more in
+    <a href="comments.html">Comments &amp; Questions</a>.</p>
+
+    <h2>6. Add AI analysis (optional)</h2>
+    <p>This is where <code>er</code> earns its name. The recommended setup is a split screen: your AI coding tool on
+    one side, <code>er</code> on the other.</p>
+    <ol>
+      <li>In Claude Code (or your tool of choice), run <code>/er-review</code>. It writes review artifacts to disk.</li>
+      <li><code>er</code> notices the new data automatically. Press <kbd>v</kbd> to cycle through the AI view modes —
+      findings appear inline in the diff, with per-file risk levels in the file list.</li>
+      <li>Leave questions with <kbd>q</kbd>; run <code>/er-questions</code> to have the AI respond.</li>
+      <li>When you are happy, run <code>/er-publish</code> to post the review to your GitHub PR.</li>
+    </ol>
+    <p>The whole loop is described in <a href="ai-review.html">AI Review</a> and the
+    <a href="skills.html">Claude Code Skills</a> catalog.</p>
+
+    <h2>7. Watch it stay live</h2>
+    <p>
+      Watch mode is on by default. Leave <code>er</code> open while your AI assistant edits code: every save, stage,
+      and commit refreshes the diff within a fraction of a second. The <span style="color:var(--green)">● WATCH</span>
+      indicator in the top bar shows it is active; toggle it with <kbd>w</kbd>.
+    </p>
+
+    <h2>8. Quit</h2>
+    <p>Press <kbd>Ctrl</kbd>+<kbd>q</kbd> to exit. Your reviewed marks, comments, and questions are persisted, so you
+    can pick the review back up exactly where you left off.</p>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p><strong>Next:</strong> read <a href="concepts.html">How er Works</a> to understand the model behind all
+      of this, or skip to <a href="github.html">GitHub &amp; Pull Requests</a> if you are reviewing a PR.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/reviewing.html
+++ b/docs/guide/reviewing.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reviewing &amp; Navigation — easy-review docs</title>
+  <meta name="description" content="Navigate diffs, mark files reviewed, filter and search, sort by risk and recency, and use editor and clipboard integration in easy-review.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Reviewing &amp; Navigation</h1>
+    <p class="lead">
+      The day-to-day of a review: moving through files and hunks, tracking what you have covered, narrowing the list to
+      what matters, and jumping out to your editor when you need to. Keys below are the terminal defaults; the desktop
+      app offers the same actions through its UI and its own shortcuts.
+    </p>
+
+    <h2>Navigating the diff</h2>
+    <p>The three panels — file list, diff, context panel — are driven entirely from the keyboard.</p>
+    <table>
+      <thead><tr><th>Keys</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
+        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line within hunks</td></tr>
+        <tr><td><kbd>h</kbd> / <kbd>l</kbd></td><td>Scroll the diff left / right</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+      </tbody>
+    </table>
+    <p>
+      A <strong>sticky file-path header</strong> keeps the current file's name pinned at the top of the diff as you
+      scroll, so you always know where you are. Line-level navigation with the arrow keys is what lets you attach
+      comments to an exact line rather than a whole hunk.
+    </p>
+
+    <h2>Marking files reviewed</h2>
+    <p>Review is stateful. As you finish each file, record it:</p>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>Space</kbd></td><td>Toggle the current file as reviewed</td></tr>
+        <tr><td><kbd>u</kbd></td><td>Filter the list to unreviewed files only</td></tr>
+        <tr><td><kbd>U</kbd></td><td>Jump to the next unreviewed file</td></tr>
+      </tbody>
+    </table>
+    <p>
+      The status bar shows a running <em>reviewed / total</em> count (respecting any active filter). Reviewed state is
+      persisted per repository and branch, so you can close <code>er</code> mid-review and resume later.
+    </p>
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p><strong>Auto-unmark:</strong> if watch mode detects that a file's diff actually changed, that file's
+      reviewed mark clears automatically. New changes can never hide behind a stale checkmark.</p></div>
+    </div>
+
+    <h2>Searching</h2>
+    <p>
+      Press <kbd>/</kbd> to search files by name. Type to filter the list incrementally; <kbd>Esc</kbd> clears the
+      search. This is a quick way to jump to a known file in a large changeset.
+    </p>
+
+    <h2>Filtering</h2>
+    <p>
+      Filtering is more powerful than search: it is a composable expression over glob, status, size, and risk. Press
+      <kbd>f</kbd> to type a filter. Combine clauses with commas; prefix with <code>+</code> to include and
+      <code>-</code> to exclude.
+    </p>
+    <pre><code><span class="cmt"># only Rust files</span>
++*.rs
+
+<span class="cmt"># Rust files, but not lock files, and only files with &gt; 50 changed lines</span>
++*.rs,-*.lock,&gt;50</code></pre>
+    <table>
+      <thead><tr><th>Clause</th><th>Meaning</th></tr></thead>
+      <tbody>
+        <tr><td><code>+glob</code> / <code>-glob</code></td><td>Include / exclude files matching a glob pattern</td></tr>
+        <tr><td><code>&gt;N</code> / <code>&lt;N</code></td><td>Files with more / fewer than N changed lines</td></tr>
+        <tr><td>status &amp; risk rules</td><td>Filter by file status or AI risk level</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Press <kbd>F</kbd> for built-in <strong>presets</strong> and your filter <strong>history</strong>. You can also
+      pre-filter from the command line: <code>er --filter '*.rs'</code>. Clear an active filter with <kbd>Esc</kbd>
+      (innermost first — it clears search before filter).
+    </p>
+
+    <h2>Sorting</h2>
+    <ul>
+      <li><strong>By recency</strong> — <kbd>Shift</kbd>+<kbd>R</kbd> toggles modification-time sorting in any mode, so
+      the files your AI just touched rise to the top.</li>
+      <li><strong>By risk</strong> — when an AI review has run, files carry risk indicators (high / medium / low) in the
+      list. The <code>/er-risk-sort</code> skill reorders the review so the highest-risk files come first. See
+      <a href="ai-review.html">AI Review</a>.</li>
+    </ul>
+
+    <h2>Editor &amp; clipboard integration</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>e</kbd></td><td>Open the current file in <code>$EDITOR</code></td></tr>
+        <tr><td><kbd>y</kbd></td><td>Copy the current hunk to the clipboard</td></tr>
+        <tr><td><kbd>r</kbd></td><td>Manually refresh the diff</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Copying a hunk is handy for pasting a specific change into a chat with your AI assistant or a teammate. Opening in
+      your editor jumps you straight to the file you are reviewing.
+    </p>
+
+    <h2>Tabs &amp; multiple repositories</h2>
+    <p>
+      You can open more than one repository or git worktree at once and treat them as tabs:
+    </p>
+    <pre><code>er ~/projects/api ~/projects/frontend</code></pre>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>]</kbd> / <kbd>[</kbd></td><td>Next / previous tab</td></tr>
+        <tr><td><kbd>x</kbd></td><td>Close the current tab</td></tr>
+        <tr><td><kbd>t</kbd></td><td>Worktree picker</td></tr>
+        <tr><td><kbd>o</kbd></td><td>Directory browser (open another repo)</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Each tab keeps its own review state, and watch notifications surface across tabs so you know when another repo or
+      worktree has new changes. The desktop app extends this with persistent, drag-to-reorder tabs — see
+      <a href="desktop-features.html">Desktop Features</a>.
+    </p>
+
+    <h2>Settings overlay</h2>
+    <p>
+      Press <kbd>S</kbd> to open the settings overlay and adjust display and feature options live. Changes apply
+      immediately; <kbd>s</kbd> persists them, <kbd>Esc</kbd> reverts. The full list of options is in
+      <a href="configuration.html">Configuration</a>.
+    </p>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/skills.html
+++ b/docs/guide/skills.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Code Skills — easy-review docs</title>
+  <meta name="description" content="The /er-* Claude Code skills that power easy-review's AI loop: review, experts, professor, triage, questions, publish, quiz, and the review philosophy behind them.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Claude Code Skills</h1>
+    <p class="lead">
+      The AI half of <code>er</code>'s feedback loop is a set of Claude Code skills — slash commands like
+      <code>/er-review</code>. Each generates sidecar files that <code>er</code> reads and renders. This page is the full
+      catalog and how the skills fit together.
+    </p>
+
+    <h2>Setup</h2>
+    <p>
+      Skills are auto-discovered from <code>.claude/commands/</code> in the repository root, so anyone who clones the repo
+      and uses Claude Code gets them with no installation. The source of truth is the <code>skills/</code> directory;
+      the files in <code>.claude/commands/</code> are symlinks to each <code>skills/&lt;name&gt;/SKILL.md</code>.
+    </p>
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>The skills document their output as <code>.er/&lt;file&gt;</code> relative to the repo. With default
+      managed storage, run reviews through <code>er</code>'s own agent commands, or set <code>ER_REPO_LOCAL=1</code> so
+      skill output lands where <code>er</code> reads it. See <a href="storage.html">Review Storage</a>.</p></div>
+    </div>
+
+    <h2>The standard loop</h2>
+    <table>
+      <thead><tr><th>Step</th><th>Where</th><th>Command</th><th>What happens</th></tr></thead>
+      <tbody>
+        <tr><td>1</td><td>Claude Code</td><td><code>/er-review</code></td><td>Writes the review sidecar files</td></tr>
+        <tr><td>2</td><td><code>er</code></td><td><kbd>v</kbd></td><td>Detects new files; shows findings inline</td></tr>
+        <tr><td>3</td><td><code>er</code></td><td><kbd>q</kbd> / <kbd>c</kbd></td><td>Leave questions and comments</td></tr>
+        <tr><td>4</td><td>Claude Code</td><td><code>/er-questions</code></td><td>Reads feedback, responds, archives</td></tr>
+        <tr><td>5</td><td><code>er</code></td><td>—</td><td>Auto-refreshes; AI responses appear inline</td></tr>
+        <tr><td>6</td><td>Claude Code</td><td><code>/er-publish</code></td><td>Validates freshness, posts to the GitHub PR</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Full catalog</h2>
+    <h3>Core review</h3>
+    <table>
+      <thead><tr><th>Skill</th><th>What it does</th></tr></thead>
+      <tbody>
+        <tr><td><code>/er-triage</code></td><td>Fast branch scan: first impression, routing verdict, priority files → <code>triage.json</code></td></tr>
+        <tr><td><code>/er-review</code></td><td>Full review: risk levels, findings, order, checklist, summary</td></tr>
+        <tr><td><code>/er-questions</code></td><td>Process human feedback, respond to comments, add new findings</td></tr>
+        <tr><td><code>/er-publish</code></td><td>Publish review findings to a GitHub PR as inline comments</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Expert reviews</h3>
+    <p>Each expert looks at a single dimension and writes only to <code>experts/&lt;id&gt;.json</code>.</p>
+    <table>
+      <thead><tr><th>Skill</th><th>Focus</th></tr></thead>
+      <tbody>
+        <tr><td><code>/er-review-security</code></td><td>Security findings</td></tr>
+        <tr><td><code>/er-review-performance</code></td><td>Performance</td></tr>
+        <tr><td><code>/er-review-reliability</code></td><td>Reliability</td></tr>
+        <tr><td><code>/er-review-testing</code></td><td>Testing</td></tr>
+        <tr><td><code>/er-review-api</code></td><td>API / contracts</td></tr>
+        <tr><td><code>/er-review-patterns</code></td><td>Pattern consistency</td></tr>
+        <tr><td><code>/er-review-simplifying</code></td><td>Readability / complexity</td></tr>
+        <tr><td><code>/er-review-mentorship</code></td><td>Exemplary patterns to foster</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Learning &amp; housekeeping</h3>
+    <table>
+      <thead><tr><th>Skill</th><th>What it does</th></tr></thead>
+      <tbody>
+        <tr><td><code>/er-professor</code></td><td>Learning agent: teaching insights → <code>professor.json</code></td></tr>
+        <tr><td><code>/er-risk-sort</code></td><td>Re-sort the file review order by P0 → P1 → P2, cosmetic files last</td></tr>
+        <tr><td><code>/er-summary</code></td><td>Regenerate the markdown summary (P0/P1 focus, no cosmetic noise)</td></tr>
+        <tr><td><code>/er-checklist</code></td><td>Regenerate the review checklist (P0/P1 only, includes test-quality items)</td></tr>
+        <tr><td><code>/er-refresh</code></td><td>Refresh review artifacts against the current diff</td></tr>
+        <tr><td><code>/er-wizard</code></td><td>Guided setup / workflow helper</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Comprehension quiz (optional)</h3>
+    <p>A workflow for checking that you actually understood a change before approving it.</p>
+    <table>
+      <thead><tr><th>Skill</th><th>What it does</th></tr></thead>
+      <tbody>
+        <tr><td><code>/er-quiz</code></td><td>Generate comprehension questions about the P0/P1 changes → <code>quiz.json</code></td></tr>
+        <tr><td><code>/er-quiz-review</code></td><td>Evaluate your answers and write teaching feedback → <code>quiz-feedback.json</code></td></tr>
+      </tbody>
+    </table>
+    <p>
+      In the terminal, press <kbd>8</kbd> for quiz mode, answer the questions, then run <code>/er-quiz-review</code>.
+      Feedback appears inline after the next refresh.
+    </p>
+
+    <h2>Review philosophy</h2>
+    <p>
+      Every skill shares one severity model and a “what not to flag” list, documented in
+      <code>skills/REVIEW_PHILOSOPHY.md</code> and <code>skills/REVIEW_RULES.md</code>:
+    </p>
+    <ul>
+      <li><strong>P0 (high)</strong> = must fix · <strong>P1 (medium)</strong> = should fix · <strong>P2 (low)</strong> = nice to fix.</li>
+      <li>Never flag naming, formatting, style, or file moves.</li>
+    </ul>
+    <p>The professor follows a separate <code>skills/PROFESSOR_PHILOSOPHY.md</code> — it teaches rather than critiques.</p>
+
+    <h2>Multi-reviewer runs</h2>
+    <p>
+      You can run the general review, any experts, and the professor concurrently. <code>er</code> merges each fresh
+      sidecar (matching the current diff hash) into the in-memory review, and every finding carries an <strong>agent
+      pill</strong> — <code>General</code>, <code>Security</code>, <code>Professor</code>, and so on — so you can tell at a
+      glance which agent raised it. The desktop app makes this a first-class flow with its multi-model
+      <a href="desktop-features.html#arena">review arena</a>.
+    </p>
+
+    <h2>Testing without running skills</h2>
+    <p>To see the overlays without invoking an AI tool, generate fixtures with a matching diff hash:</p>
+    <pre><code>cd your-repo
+bash /path/to/easy-review/scripts/generate-test-fixtures.sh</code></pre>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/storage.html
+++ b/docs/guide/storage.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Review Storage — easy-review docs</title>
+  <meta name="description" content="Where easy-review keeps review data: managed app-data storage shared by the TUI and desktop, view buckets, PR keys, the sidecar file list, and repo-local mode.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Core Concepts</p>
+    <h1>Review Storage</h1>
+    <p class="lead">
+      Reviewed marks, comments, questions, AI artifacts, and session state are stored as files on disk. By default they
+      live in <strong>managed application data</strong> — not in your repository — and are shared between the terminal
+      and desktop apps per repo, branch, and view.
+    </p>
+
+    <h2>Why managed storage?</h2>
+    <p>
+      Keeping review sidecars out of your working tree means they never clutter <code>git status</code>, never need a
+      <code>.gitignore</code> entry, and never risk being committed by accident. Both front ends resolve the same path
+      for a given tab, so a review you start in the desktop app continues seamlessly in the terminal.
+    </p>
+
+    <h2>Where the root is</h2>
+    <table>
+      <thead><tr><th>Platform</th><th>Storage root</th></tr></thead>
+      <tbody>
+        <tr><td>Linux</td><td><code>~/.local/share/easy-review/</code></td></tr>
+        <tr><td>macOS</td><td><code>~/Library/Application Support/easy-review/</code></td></tr>
+        <tr><td>Windows</td><td><code>%APPDATA%\easy-review\</code></td></tr>
+      </tbody>
+    </table>
+
+    <h2>Layout for local diff modes</h2>
+    <p>
+      Branch (<kbd>1</kbd>), unstaged (<kbd>2</kbd>), staged (<kbd>3</kbd>), and history (<kbd>4</kbd>) each get their own
+      <em>view bucket</em> directory under the repo and branch:
+    </p>
+    <pre><code>&lt;root&gt;/repos/&lt;repo-slug&gt;/branches/&lt;branch-slug&gt;/view-buckets/&lt;bucket&gt;/</code></pre>
+    <p>where <code>&lt;bucket&gt;</code> is <code>branch</code>, <code>unstaged</code>, <code>staged</code>, or
+    <code>history</code>. For example, on Linux for the <code>easy-review</code> repo on <code>main</code>, branch diff:</p>
+    <pre><code>~/.local/share/easy-review/repos/easy-review/branches/main/view-buckets/branch/</code></pre>
+
+    <h2>Layout for PR diff mode</h2>
+    <p>Pull request reviews are keyed by <code>owner/repo</code> and PR number, so a local clone and a remote PR tab share one location:</p>
+    <pre><code>&lt;root&gt;/repos/&lt;owner-repo-slug&gt;/prs/pr-&lt;N&gt;/</code></pre>
+    <p>
+      The <code>&lt;repo-slug&gt;</code> comes from the <code>origin</code> remote name (falling back to the repo folder
+      name). Slashes in branch names become <code>-</code>.
+    </p>
+
+    <h2>The sidecar files</h2>
+    <p>The filenames are identical in managed storage and in repo-local mode:</p>
+    <table>
+      <thead><tr><th>File</th><th>Written by</th><th>Purpose</th></tr></thead>
+      <tbody>
+        <tr><td><code>review.json</code></td><td><code>/er-review</code></td><td>Per-file risk levels and inline findings</td></tr>
+        <tr><td><code>order.json</code></td><td><code>/er-review</code></td><td>Suggested review order</td></tr>
+        <tr><td><code>checklist.json</code></td><td><code>/er-review</code></td><td>Review checklist items</td></tr>
+        <tr><td><code>summary.md</code></td><td><code>/er-summary</code></td><td>Markdown summary of changes</td></tr>
+        <tr><td><code>triage.json</code></td><td><code>/er-triage</code></td><td>Fast branch scan / routing</td></tr>
+        <tr><td><code>professor.json</code></td><td><code>/er-professor</code></td><td>Teaching / learning insights</td></tr>
+        <tr><td><code>experts/*.json</code></td><td><code>/er-review-*</code></td><td>Domain-specific expert findings</td></tr>
+        <tr><td><code>questions.json</code></td><td><code>er</code> (<kbd>q</kbd>/<kbd>Q</kbd>)</td><td>Personal review questions</td></tr>
+        <tr><td><code>github-comments.json</code></td><td><code>er</code> (<kbd>c</kbd>/<kbd>C</kbd>)</td><td>GitHub PR comments</td></tr>
+        <tr><td><code>session.json</code></td><td><code>er</code></td><td>Session metadata</td></tr>
+        <tr><td><code>reviewed</code></td><td><code>er</code></td><td>Per-file reviewed markers</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Each JSON sidecar stores a SHA-256 <code>diff_hash</code> of the diff it was generated against. When the diff
+      changes, the matching AI data is dimmed with a stale warning. Writes are atomic (write to a temp file, then rename),
+      so a crash mid-write never corrupts your data.
+    </p>
+
+    <h2>Repo-local mode</h2>
+    <p>
+      Set <code>ER_REPO_LOCAL=1</code> to read and write a <code>.er/</code> directory inside the repository instead of
+      managed storage. This is useful for debugging, or to line up with Claude Code skills that document their output as
+      <code>.er/&lt;file&gt;</code> relative to the repo.
+    </p>
+    <pre><code>ER_REPO_LOCAL=1 er</code></pre>
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p>In repo-local mode, add <code>.er/</code> to your <code>.gitignore</code> so review artifacts are not committed.</p></div>
+    </div>
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>With default managed storage, run reviews through <code>er</code>'s own agent commands (in the desktop app
+      or TUI), or use <code>ER_REPO_LOCAL=1</code> so that skills run in Claude Code write where <code>er</code> reads.</p></div>
+    </div>
+
+    <h2>Migration from older versions</h2>
+    <p>
+      Earlier versions scattered sidecar dotfiles in the repo root, then consolidated them into a repo <code>.er/</code>
+      directory. Legacy repo <code>.er/</code> and <code>~/.cache/er/</code> data is migrated once, automatically, the
+      first time you open a repo with a current build.
+    </p>
+
+    <h2>Tests &amp; overrides</h2>
+    <p>Set <code>ER_STORAGE_ROOT=/tmp/...</code> to redirect managed storage — primarily used by the test suite.</p>
+
+    <h2>Cleaning up</h2>
+    <p>From the terminal you can remove artifacts for the current file (<kbd>z</kbd>) or all of them (<kbd>Z</kbd>). The
+    repository also ships helper scripts:</p>
+    <pre><code>scripts/er-cleanup-reviews.sh     <span class="cmt"># remove review.json, checklist, summary, …</span>
+scripts/er-cleanup-questions.sh   <span class="cmt"># remove questions.json</span></code></pre>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/troubleshooting.html
+++ b/docs/guide/troubleshooting.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Troubleshooting &amp; FAQ — easy-review docs</title>
+  <meta name="description" content="Common issues and questions for easy-review: base branch, missing AI data, GitHub auth, watch mode, storage location, performance, and how your data is handled.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Help</p>
+    <h1>Troubleshooting &amp; FAQ</h1>
+    <p class="lead">
+      Answers to the questions that come up most often, and fixes for the things that occasionally go sideways.
+    </p>
+
+    <h2>Troubleshooting</h2>
+
+    <h3><code>er</code> shows the wrong base branch</h3>
+    <p>
+      The base is auto-detected: upstream tracking → <code>main</code> → <code>master</code> → <code>develop</code> →
+      <code>dev</code>. If it picks the wrong one, set your branch's upstream so tracking wins:
+      <code>git branch --set-upstream-to=origin/main</code>. When a PR is detected with a different target,
+      <code>er</code> shows a hint rather than switching automatically.
+    </p>
+
+    <h3>AI findings do not appear</h3>
+    <ul>
+      <li><strong>Check where the artifacts went.</strong> By default <code>er</code> reads from managed storage, not the
+      repo's <code>.er/</code>. If you ran a skill in Claude Code that wrote to <code>.er/</code>, either run reviews
+      through <code>er</code>'s own agent commands or launch <code>er</code> with <code>ER_REPO_LOCAL=1</code>. See
+      <a href="storage.html">Review Storage</a>.</li>
+      <li><strong>Check freshness.</strong> If the diff changed after the review ran, the data is dimmed as
+      <em>stale</em>. Re-run the relevant skill.</li>
+      <li><strong>Cycle the view.</strong> In the terminal, press <kbd>v</kbd> to make sure you are in an AI view mode.</li>
+      <li><strong>Try fixtures.</strong> Run <code>scripts/generate-test-fixtures.sh</code> in your repo to confirm the
+      overlay renders at all.</li>
+    </ul>
+
+    <h3>GitHub features are missing or failing</h3>
+    <p>
+      GitHub integration requires the <code>gh</code> CLI, authenticated with <code>gh auth login</code>. If <kbd>G</kbd>
+      / <kbd>P</kbd> do nothing or PR data is absent, run <code>gh auth status</code> to confirm you are logged in and
+      that <code>gh</code> is on your <code>PATH</code>.
+    </p>
+
+    <h3>The diff is not updating</h3>
+    <p>
+      Watch mode should refresh on saves, staging, and commits. Confirm the <span style="color:var(--green)">● WATCH</span>
+      indicator is on (toggle with <kbd>w</kbd>), and press <kbd>r</kbd> to force a manual refresh. Watch uses a ~500ms
+      debounce, so a burst of changes lands as one update.
+    </p>
+
+    <h3>A huge file is collapsed and I can't see it</h3>
+    <p>
+      Lock files, generated code, and files over ~500 lines are <strong>auto-compacted</strong> — shown as a single
+      collapsed entry to keep things fast. Press <kbd>Enter</kbd> on it to expand on demand. See
+      <a href="diff-modes.html#performance-with-large-diffs">large-diff performance</a>.
+    </p>
+
+    <h3><code>er</code> exits immediately or renders nothing</h3>
+    <p>
+      The terminal UI needs a real TTY. Running it through a pipe or a non-interactive context will not work — launch it
+      in an actual terminal (a tmux pane is fine).
+    </p>
+
+    <h3>The <code>target/</code> directory is enormous (building from source)</h3>
+    <p>
+      Building the whole workspace compiles the Tauri desktop app into the shared <code>target/</code>, which can balloon.
+      Use the scoped scripts: <code>./scripts/er-tui.sh</code> for TUI work and <code>./scripts/tauri-dev.sh</code> for
+      desktop, and run <code>./scripts/cargo-gc.sh</code> to reclaim space.
+    </p>
+
+    <h3>Getting a debug log</h3>
+    <p>Run <code>ER_DEBUG=1 er</code>. It writes <code>/tmp/er_debug.log</code> (overwritten on each git diff) and shows
+    the memory budget in the status bar.</p>
+
+    <h2>FAQ</h2>
+
+    <h3>Does <code>er</code> run AI or send my code anywhere?</h3>
+    <p>
+      No. <code>er</code> does not run AI models and has no backend, telemetry, or analytics. It shells out to your local
+      <code>git</code> (and optionally <code>gh</code>) and reads artifacts that AI tools <em>you</em> run write to disk.
+      You bring your own AI tool and credentials, and you are the customer of those providers.
+    </p>
+
+    <h3>Which AI tools work with it?</h3>
+    <p>
+      Any tool you can drive from the command line. The included skills target Claude Code, and the AI Hub config ships
+      presets for Claude, Codex, and Cursor. See <a href="configuration.html#ai-hub">AI Hub configuration</a>.
+    </p>
+
+    <h3>Do I have to use AI at all?</h3>
+    <p>
+      No. Every non-AI feature — diff modes, navigation, reviewed tracking, comments, GitHub sync, filtering — works on
+      its own. AI review is an optional layer on top.
+    </p>
+
+    <h3>Can I use the terminal and desktop apps together?</h3>
+    <p>
+      Yes. They share one engine and the same on-disk review data per repo, branch, and view, so you can switch between
+      them mid-review.
+    </p>
+
+    <h3>Where is my review data stored, and is it in git?</h3>
+    <p>
+      By default it is in managed application data outside your repository, so it never touches <code>git status</code>.
+      Set <code>ER_REPO_LOCAL=1</code> to use a repo <code>.er/</code> directory instead (add it to <code>.gitignore</code>
+      if you do). Full paths are in <a href="storage.html">Review Storage</a>.
+    </p>
+
+    <h3>What does the desktop app add over the terminal?</h3>
+    <p>
+      Split and word diffs, an embedded terminal and browser, the multi-model review arena, a settings GUI, persistent
+      drag-to-reorder tabs, and reference “find usages”. The terminal wins on speed, zero dependencies, and running
+      anywhere a terminal does. See the <a href="desktop.html">Desktop Overview</a>.
+    </p>
+
+    <h3>Is the desktop app released?</h3>
+    <p>
+      Not yet — published releases are the <code>er</code> terminal binary only. Build the desktop app from source with
+      <code>./scripts/tauri-dev.sh</code> or <code>./scripts/tauri-build.sh</code>.
+    </p>
+
+    <h3>How do I report a bug or request a feature?</h3>
+    <p>
+      Open an issue on the <a href="https://github.com/VilfredSikker/easy-review" target="_blank" rel="noopener">GitHub
+      repository</a>.
+    </p>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>Building from source or contributing? The repository's <code>docs/DEVELOPMENT.md</code> and
+      <code>AGENTS.md</code> cover the workspace layout, cargo aliases, scoped builds, profiling, and the release process.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/tui-keybindings.html
+++ b/docs/guide/tui-keybindings.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keybinding Reference — easy-review docs</title>
+  <meta name="description" content="The complete keyboard reference for the er terminal UI: navigation, diff modes, actions, comments, GitHub sync, AI views, tabs, and general keys.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Terminal UI</p>
+    <h1>Keybinding Reference</h1>
+    <p class="lead">
+      The complete key map for the <code>er</code> terminal UI, grouped by task. Bottom-bar hints show a subset; this is
+      the full list. Hint groups are configurable — see <a href="configuration.html">Configuration</a>.
+    </p>
+
+    <h2>Navigation</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
+        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line (within hunks)</td></tr>
+        <tr><td><kbd>h</kbd> / <kbd>l</kbd></td><td>Scroll left / right</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Diff modes</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>1</kbd></td><td>Branch diff (vs base branch)</td></tr>
+        <tr><td><kbd>2</kbd></td><td>Unstaged changes</td></tr>
+        <tr><td><kbd>3</kbd></td><td>Staged changes</td></tr>
+        <tr><td><kbd>4</kbd></td><td>Commit history</td></tr>
+        <tr><td><kbd>5</kbd></td><td>Merge conflicts</td></tr>
+        <tr><td><kbd>6</kbd></td><td>Hidden / ignored files</td></tr>
+        <tr><td><kbd>8</kbd></td><td>Quiz mode (when a quiz exists)</td></tr>
+        <tr><td><kbd>Shift</kbd>+<kbd>R</kbd></td><td>Toggle sort by recency</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Actions</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>s</kbd></td><td>Stage / unstage the current file</td></tr>
+        <tr><td><kbd>Space</kbd></td><td>Toggle the current file as reviewed</td></tr>
+        <tr><td><kbd>u</kbd></td><td>Filter to unreviewed files</td></tr>
+        <tr><td><kbd>U</kbd></td><td>Jump to the next unreviewed file</td></tr>
+        <tr><td><kbd>q</kbd></td><td>Question on the current line (private, yellow)</td></tr>
+        <tr><td><kbd>Q</kbd></td><td>Question on the current hunk</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Comment on the current line (GitHub, cyan)</td></tr>
+        <tr><td><kbd>C</kbd></td><td>Comment on the current hunk</td></tr>
+        <tr><td><kbd>y</kbd></td><td>Copy the current hunk to the clipboard</td></tr>
+        <tr><td><kbd>e</kbd></td><td>Open the current file in <code>$EDITOR</code></td></tr>
+        <tr><td><kbd>r</kbd></td><td>Refresh the diff</td></tr>
+        <tr><td><kbd>w</kbd></td><td>Toggle watch mode</td></tr>
+        <tr><td><kbd>W</kbd></td><td>Toggle the watched-files section</td></tr>
+        <tr><td><kbd>/</kbd></td><td>Search files by name</td></tr>
+        <tr><td><kbd>f</kbd></td><td>Filter files (glob, status, size)</td></tr>
+        <tr><td><kbd>F</kbd></td><td>Filter presets &amp; history</td></tr>
+        <tr><td><kbd>Enter</kbd></td><td>Expand a compacted file</td></tr>
+        <tr><td><kbd>z</kbd></td><td>Clean AI artifacts for the current file</td></tr>
+        <tr><td><kbd>Z</kbd></td><td>Clean all AI artifacts</td></tr>
+        <tr><td><kbd>S</kbd></td><td>Open settings</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Comments (in comment focus mode)</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>Tab</kbd></td><td>Toggle comment focus mode</td></tr>
+        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Navigate between comments</td></tr>
+        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment</td></tr>
+        <tr><td><kbd>d</kbd></td><td>Delete the focused comment</td></tr>
+        <tr><td><kbd>R</kbd></td><td>Toggle resolved</td></tr>
+      </tbody>
+    </table>
+
+    <h2>GitHub sync <span class="pill tui">requires gh</span></h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>G</kbd></td><td>Pull PR comments from GitHub</td></tr>
+        <tr><td><kbd>P</kbd></td><td>Push local comments to GitHub</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Git push (from staged mode)</td></tr>
+      </tbody>
+    </table>
+
+    <h2>AI views</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>v</kbd> / <kbd>V</kbd></td><td>Cycle AI view mode forward / backward</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Tabs &amp; repositories</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>]</kbd> / <kbd>[</kbd></td><td>Next / previous tab</td></tr>
+        <tr><td><kbd>x</kbd></td><td>Close the current tab</td></tr>
+        <tr><td><kbd>t</kbd></td><td>Worktree picker</td></tr>
+        <tr><td><kbd>o</kbd></td><td>Directory browser</td></tr>
+      </tbody>
+    </table>
+
+    <h2>General</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>Esc</kbd></td><td>Clear search / filter (innermost first)</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>q</kbd></td><td>Quit</td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout note">
+      <span class="ico">◆</span>
+      <div><p>Some keys are mode-dependent: <kbd>r</kbd> refreshes the diff normally but replies to a comment in comment
+      focus mode, and <kbd>R</kbd> toggles resolved there. The status bar always reflects what is available right now.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/guide/tui.html
+++ b/docs/guide/tui.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terminal UI Overview — easy-review docs</title>
+  <meta name="description" content="The er terminal UI: launching, command-line flags, the three-panel layout, AI view modes, watch mode, and how it fits beside an AI coding assistant.">
+  <link rel="stylesheet" href="assets/docs.css">
+</head>
+<body>
+  <main class="content">
+    <p class="eyebrow">Terminal UI</p>
+    <h1>The <code>er</code> Terminal UI</h1>
+    <p class="lead">
+      <code>er</code> is a single, dependency-free binary that renders a fast, keyboard-driven review UI in your
+      terminal. It starts in under a second and is designed to sit in a split pane next to an AI coding assistant. This
+      page covers what is specific to the terminal app; the shared concepts live under
+      <a href="concepts.html">Core Concepts</a>.
+    </p>
+
+    <h2>Launching</h2>
+    <p>Run <code>er</code> from inside any git repository. Common invocations:</p>
+    <pre><code>er                                        <span class="cmt"># review the current branch diff</span>
+er --pr 42                                <span class="cmt"># open a GitHub PR by number</span>
+er https://github.com/owner/repo/pull/42  <span class="cmt"># open a PR by URL</span>
+er ~/projects/api ~/projects/frontend     <span class="cmt"># open multiple repos as tabs</span>
+er --filter '*.rs'                        <span class="cmt"># pre-filter the file list</span></code></pre>
+    <table>
+      <thead><tr><th>Flag / argument</th><th>Effect</th></tr></thead>
+      <tbody>
+        <tr><td><code>--pr &lt;n&gt;</code></td><td>Open pull request <em>n</em> in the current repo</td></tr>
+        <tr><td>a PR URL</td><td>Open that pull request (any repo)</td></tr>
+        <tr><td>one or more paths</td><td>Open each repository / worktree as a tab</td></tr>
+        <tr><td><code>--filter &lt;expr&gt;</code></td><td>Apply a <a href="reviewing.html#filtering">filter</a> at startup</td></tr>
+        <tr><td><code>--help</code></td><td>Show all options</td></tr>
+      </tbody>
+    </table>
+    <div class="callout warn">
+      <span class="ico">▲</span>
+      <div><p><code>er</code> renders via crossterm/ratatui and needs a <strong>real terminal</strong> (such as a tmux
+      pane), not a headless pipe.</p></div>
+    </div>
+
+    <h2>The layout</h2>
+    <p>The screen has a top bar, three columns, and a bottom bar.</p>
+    <table>
+      <thead><tr><th>Region</th><th>Shows</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Top bar</strong></td><td>The diff modes (with the active one highlighted), any detected PR with its CI summary, comment and finding counts, and the watch indicator.</td></tr>
+        <tr><td><strong>Left — file list</strong></td><td>Every changed file with a status dot, AI risk indicator, and comment/finding badges. In history mode this becomes the commit list.</td></tr>
+        <tr><td><strong>Center — diff</strong></td><td>The unified diff with syntax highlighting, inline comments and findings, and a sticky file-path header.</td></tr>
+        <tr><td><strong>Right — context panel</strong></td><td>File details, the AI summary, or the PR overview depending on context.</td></tr>
+        <tr><td><strong>Bottom bar</strong></td><td>Key hints (configurable) and comment input when you are typing a note.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Working beside an AI assistant</h2>
+    <p>
+      The intended workflow is a split terminal: Claude Code (or your tool of choice) on one side, <code>er</code> on the
+      other, in tmux, Ghostty, or any terminal that splits panes. As the assistant edits, stages, and commits,
+      <code>er</code>'s <a href="concepts.html#watch-mode-keeps-the-diff-live">watch mode</a> keeps the diff live. Run
+      <code>/er-review</code> in the assistant and the findings appear in <code>er</code> automatically.
+    </p>
+
+    <h2>AI view modes</h2>
+    <p>
+      Press <kbd>v</kbd> (forward) or <kbd>V</kbd> (backward) to cycle how much AI context is shown — from a plain diff,
+      through inline findings, to a side panel with the summary and risk breakdown, to a dedicated AI review layout. This
+      is the terminal's way of dialing AI density up and down. See <a href="ai-review.html">AI Review</a>.
+    </p>
+
+    <h2>Syntax highlighting</h2>
+    <p>
+      The terminal uses <code>syntect</code> for highlighting, with a content-hash cache so unchanged lines are never
+      re-highlighted between frames. The active theme (set in <a href="configuration.html">configuration</a>) selects a
+      matching highlight palette.
+    </p>
+
+    <h2>Debug mode</h2>
+    <p>Run with <code>ER_DEBUG=1</code> to write a debug log and show the memory budget in the status bar:</p>
+    <pre><code>ER_DEBUG=1 er   <span class="cmt"># writes /tmp/er_debug.log (overwritten each git diff)</span></code></pre>
+
+    <div class="callout tip">
+      <span class="ico">✦</span>
+      <div><p>Ready to memorize the keyboard? The <a href="tui-keybindings.html">Keybinding Reference</a> is the complete,
+      grouped list of every key.</p></div>
+    </div>
+  </main>
+  <script src="assets/docs.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -413,6 +413,7 @@
         <a href="#features" class="text-sm text-text-dim hover:text-text transition">Features</a>
         <a href="#demo" class="text-sm text-text-dim hover:text-text transition">Demo</a>
         <a href="#install" class="text-sm text-text-dim hover:text-text transition">Install</a>
+        <a href="guide/index.html" class="text-sm text-accent hover:text-text transition">Docs</a>
         <a href="https://github.com/VilfredSikker/easy-review" target="_blank" class="flex items-center gap-1.5 text-sm text-text-dim hover:text-text transition">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
           <span class="hidden sm:inline">GitHub</span>


### PR DESCRIPTION
## What

Adds an extensive, **static** documentation site under [`docs/guide/`](../tree/claude/docs-terminal-desktop-setup-9s1s18/docs/guide). It walks users through every feature of easy-review, covers both technical and non-technical aspects, and documents the **terminal UI** and the **desktop app** separately while keeping their shared behavior in one **Core Concepts** section.

No build step, no framework — pure HTML/CSS/JS that deploys directly on GitHub Pages (it sits beside the existing `docs/index.html` landing page and reuses its theme). Served from the site root under `/guide/`.

## Structure

**Getting Started**
- `index.html` — Introduction / docs home
- `installation.html` — Install the TUI + build the desktop app
- `quick-start.html` — First review end to end

**Core Concepts** (shared by both apps)
- `concepts.html` — How `er` works (the mental model)
- `diff-modes.html` — The six diff modes + PR mode
- `reviewing.html` — Navigation, reviewed tracking, filters, search, tabs
- `comments.html` — Questions vs GitHub comments, replies, staleness
- `ai-review.html` — Sidecar loop, risk levels, experts, professor, staleness, AI Hub
- `github.html` — PR review, CI/reviewer status, two-way comment sync
- `configuration.html` — Full TOML reference
- `storage.html` — Managed storage layout, sidecar files, repo-local mode
- `skills.html` — Full `/er-*` Claude Code skills catalog

**Terminal UI**
- `tui.html` — Overview, flags, layout, AI views
- `tui-keybindings.html` — Complete grouped key reference

**Desktop App**
- `desktop.html` — Overview + how it relates to the TUI
- `desktop-features.html` — Arena, AI Hub, browser annotations, terminal drawer, export, references, split/word diff, settings, shortcuts

**Help**
- `troubleshooting.html` — Troubleshooting + FAQ

## Shared chrome

`assets/docs.css` + `assets/docs.js` provide a sidebar nav, an on-this-page TOC, prev/next links, heading anchors, and code copy buttons. Each page is content-only; the JS injects the navigation, so adding a page is a one-line edit to the `NAV` array.

## Notes / verification

- All internal links and cross-page anchors were verified to resolve.
- Content is grounded in `README.md`, `CLAUDE.md`, `AGENTS.md`, `config.toml.example`, `docs/config-reference.md`, the `skills/` directory, and a sweep of the `desktop-ui/` Svelte source. Desktop-specific pages note that the desktop app is in active development.
- The landing page nav and the README now link to the docs.

## Reviewer checks
- Confirm GitHub Pages source includes the `docs/` folder (the new site is at `/guide/`).
- Spot-check desktop feature descriptions against current behavior, since that surface is moving quickly.

https://claude.ai/code/session_01Fq8y2Mq3YnWVzxTHgTSL8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq8y2Mq3YnWVzxTHgTSL8F)_