### PR TITLE
Add comments/findings/questions visibility toggles to diff settings

### DIFF
--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -1500,6 +1500,41 @@
                 </span>
                 Split
               </button>
+              <div class="border-t border-ink-600 my-1"></div>
+              <div class="px-3 pt-2 pb-1 text-[11px] uppercase tracking-wide text-fg-3">Annotations</div>
+              <button
+                class="w-full text-left px-3 py-2 text-sm text-ink-100 hover:bg-ink-700 flex items-center gap-2"
+                onclick={() => app.setCommentVisibility({ hideComments: !app.commentVisibility.hideComments })}
+              >
+                <span class="w-3 inline-flex items-center justify-center">
+                  {#if !app.commentVisibility.hideComments}
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
+                  {/if}
+                </span>
+                Comments
+              </button>
+              <button
+                class="w-full text-left px-3 py-2 text-sm text-ink-100 hover:bg-ink-700 flex items-center gap-2"
+                onclick={() => app.setCommentVisibility({ hideFindings: !app.commentVisibility.hideFindings })}
+              >
+                <span class="w-3 inline-flex items-center justify-center">
+                  {#if !app.commentVisibility.hideFindings}
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
+                  {/if}
+                </span>
+                Findings
+              </button>
+              <button
+                class="w-full text-left px-3 py-2 text-sm text-ink-100 hover:bg-ink-700 flex items-center gap-2"
+                onclick={() => app.setCommentVisibility({ hideQuestions: !app.commentVisibility.hideQuestions })}
+              >
+                <span class="w-3 inline-flex items-center justify-center">
+                  {#if !app.commentVisibility.hideQuestions}
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
+                  {/if}
+                </span>
+                Questions
+              </button>
             </div>
           {/if}
         </div>

--- a/desktop-ui/src/lib/diffAnnotations.test.ts
+++ b/desktop-ui/src/lib/diffAnnotations.test.ts
@@ -16,7 +16,14 @@ import {
 } from "./diffAnnotations";
 import type { FileSnapshot, FlatFinding, HunkSnapshot, LineSnapshot, ThreadSnapshot } from "./types";
 
-const VIS_OFF: CommentVisibility = { hideAll: false, hideResolved: false, hideOutdated: false };
+const VIS_OFF: CommentVisibility = {
+  hideAll: false,
+  hideResolved: false,
+  hideOutdated: false,
+  hideComments: false,
+  hideFindings: false,
+  hideQuestions: false,
+};
 
 function mkLine(opts: Partial<LineSnapshot> & Pick<LineSnapshot, "kind">): LineSnapshot {
   return {
@@ -316,17 +323,17 @@ describe("threadsForLine", () => {
     const { ai, files } = buildFixture();
     const idx = buildAnnotationIndex(ai, files, "branch", VIS_OFF);
 
-    const all = threadsForLine(idx, FILE, 0, 13, hunkLines, { hideAll: false, hideResolved: false, hideOutdated: false });
+    const all = threadsForLine(idx, FILE, 0, 13, hunkLines, VIS_OFF);
     // baseThread (t1), resolvedThread (t2), staleThread (t3); tOwned excluded.
     expect(all.map((t) => t.id).sort()).toEqual(["t1", "t2", "t3"]);
 
-    const hideResolved = threadsForLine(idx, FILE, 0, 13, hunkLines, { hideAll: false, hideResolved: true, hideOutdated: false });
+    const hideResolved = threadsForLine(idx, FILE, 0, 13, hunkLines, { ...VIS_OFF, hideResolved: true });
     expect(hideResolved.map((t) => t.id).sort()).toEqual(["t1", "t3"]);
 
-    const hideOutdated = threadsForLine(idx, FILE, 0, 13, hunkLines, { hideAll: false, hideResolved: false, hideOutdated: true });
+    const hideOutdated = threadsForLine(idx, FILE, 0, 13, hunkLines, { ...VIS_OFF, hideOutdated: true });
     expect(hideOutdated.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
 
-    const hideAll = threadsForLine(idx, FILE, 0, 13, hunkLines, { hideAll: true, hideResolved: false, hideOutdated: false });
+    const hideAll = threadsForLine(idx, FILE, 0, 13, hunkLines, { ...VIS_OFF, hideAll: true });
     expect(hideAll.length).toBe(0);
   });
 

--- a/desktop-ui/src/lib/diffAnnotations.ts
+++ b/desktop-ui/src/lib/diffAnnotations.ts
@@ -70,7 +70,23 @@ export interface CommentVisibility {
   hideAll: boolean;
   hideResolved: boolean;
   hideOutdated: boolean;
+  /** Hide GitHub comment threads (kind === "comment"). */
+  hideComments: boolean;
+  /** Hide AI findings. */
+  hideFindings: boolean;
+  /** Hide personal question threads (kind === "question"). */
+  hideQuestions: boolean;
 }
+
+/** All annotations visible — the default visibility used as a fallback. */
+export const ALL_VISIBLE: CommentVisibility = {
+  hideAll: false,
+  hideResolved: false,
+  hideOutdated: false,
+  hideComments: false,
+  hideFindings: false,
+  hideQuestions: false,
+};
 
 /** Minimal AiSnapshot subset used by the helpers. */
 type AiInput = Pick<AiSnapshot, "threads" | "findings">;
@@ -107,7 +123,15 @@ export function annotationVersion(
       for (const t of hunk.threads) h = (h * 31 + hashStr(t.id) + (t.resolved ? 1 : 0)) | 0;
     }
   }
-  h = (h * 31 + (vis.hideAll ? 1 : 0) + (vis.hideResolved ? 2 : 0) + (vis.hideOutdated ? 4 : 0)) | 0;
+  h =
+    (h * 31 +
+      (vis.hideAll ? 1 : 0) +
+      (vis.hideResolved ? 2 : 0) +
+      (vis.hideOutdated ? 4 : 0) +
+      (vis.hideComments ? 8 : 0) +
+      (vis.hideFindings ? 16 : 0) +
+      (vis.hideQuestions ? 32 : 0)) |
+    0;
   h = (h * 31 + hashStr(mode)) | 0;
   h = (h * 31 + hashStr(agentFilter)) | 0;
   h = (h * 31 + hashStr(severityFilter)) | 0;
@@ -122,9 +146,11 @@ export function buildAnnotationIndex(
   agentFilter: AgentFilter = ALL_REVIEWERS,
   severityFilter: FindingSeverityFilter = "all",
 ): AnnotationIndex {
-  const visibleFindings = filterByAgent(ai.findings, agentFilter).filter(
-    (f) => severityFilter === "all" || f.severity === severityFilter,
-  );
+  const visibleFindings = visibility.hideFindings
+    ? []
+    : filterByAgent(ai.findings, agentFilter).filter(
+        (f) => severityFilter === "all" || f.severity === severityFilter,
+      );
   const findingsByFileLine = new Map<string, FlatFinding[]>();
   const findingsByFile = new Map<string, FlatFinding[]>();
   for (const f of visibleFindings) {
@@ -311,6 +337,8 @@ function visibleThreads(
   return threads.filter(
     (t) =>
       !findingThreadIds.has(t.id) &&
+      !(vis.hideComments && t.kind === "comment") &&
+      !(vis.hideQuestions && t.kind === "question") &&
       !(vis.hideResolved && t.resolved) &&
       !(vis.hideOutdated && t.stale),
   );
@@ -322,7 +350,7 @@ export function threadsForLine(
   hunkIndex: number,
   line: number,
   _hunkLines: LineSnapshot[],
-  vis: CommentVisibility = { hideAll: false, hideResolved: false, hideOutdated: false },
+  vis: CommentVisibility = ALL_VISIBLE,
 ): ThreadSnapshot[] {
   const threads = idx.threadsByHunk.get(`${filePath}#${hunkIndex}`) ?? [];
   return visibleThreads(threads, idx.findingThreadIds, vis).filter(
@@ -335,7 +363,7 @@ export function lineHasAnchorRangeHighlight(
   filePath: string,
   line: number,
   side: "old" | "new" | null,
-  vis: CommentVisibility = { hideAll: false, hideResolved: false, hideOutdated: false },
+  vis: CommentVisibility = ALL_VISIBLE,
 ): boolean {
   const ranges = idx.threadRangesByFile.get(filePath);
   if (!ranges) return false;
@@ -356,7 +384,7 @@ export function fallbackThreadsForHunk(
   hunkIndex: number,
   _hunk: { new_start: number; new_count: number },
   renderedLineNums: Set<number>,
-  vis: CommentVisibility = { hideAll: false, hideResolved: false, hideOutdated: false },
+  vis: CommentVisibility = ALL_VISIBLE,
 ): ThreadSnapshot[] {
   const threads = idx.threadsByHunk.get(`${filePath}#${hunkIndex}`) ?? [];
   return visibleThreads(threads, idx.findingThreadIds, vis).filter((t) => {

--- a/desktop-ui/src/lib/diffRenderModel.test.ts
+++ b/desktop-ui/src/lib/diffRenderModel.test.ts
@@ -138,6 +138,9 @@ const VIS_DEFAULT: CommentVisibility = {
   hideAll: false,
   hideResolved: false,
   hideOutdated: false,
+  hideComments: false,
+  hideFindings: false,
+  hideQuestions: false,
 };
 
 function mkInputs(
@@ -477,7 +480,7 @@ describe("getFileBlock — caching", () => {
     });
     const f = file({ path: "a.ts", hunks: [h1] });
     const a = getFileBlock(mkInputs(f, [f], emptyAi(), "unified", VIS_DEFAULT));
-    const visHide: CommentVisibility = { hideAll: true, hideResolved: false, hideOutdated: false };
+    const visHide: CommentVisibility = { ...VIS_DEFAULT, hideAll: true };
     const b = getFileBlock(mkInputs(f, [f], emptyAi(), "unified", visHide));
     expect(a).not.toBe(b);
     expect(a.modelKey).not.toBe(b.modelKey);
@@ -615,7 +618,7 @@ describe("getCrossFileModel — identity & cache invalidation", () => {
     const a = mkCross([f0], emptyAi(), { snapshotKey: "vis" });
     const b = mkCross([f0], emptyAi(), {
       snapshotKey: "vis",
-      vis: { hideAll: false, hideResolved: true, hideOutdated: false },
+      vis: { ...VIS_DEFAULT, hideResolved: true },
     });
     expect(a.identity).not.toBe(b.identity);
   });

--- a/desktop-ui/src/lib/diffRenderModel.ts
+++ b/desktop-ui/src/lib/diffRenderModel.ts
@@ -310,7 +310,14 @@ function lineNumOf(line: LineSnapshot): number | null {
 }
 
 function visBits(v: CommentVisibility): number {
-  return (v.hideAll ? 1 : 0) | (v.hideResolved ? 2 : 0) | (v.hideOutdated ? 4 : 0);
+  return (
+    (v.hideAll ? 1 : 0) |
+    (v.hideResolved ? 2 : 0) |
+    (v.hideOutdated ? 4 : 0) |
+    (v.hideComments ? 8 : 0) |
+    (v.hideFindings ? 16 : 0) |
+    (v.hideQuestions ? 32 : 0)
+  );
 }
 
 /** Line count for cache invalidation when hunks grow (lazy load, poll refresh). */

--- a/desktop-ui/src/lib/stores/app.svelte.ts
+++ b/desktop-ui/src/lib/stores/app.svelte.ts
@@ -37,6 +37,12 @@ export interface CommentVisibility {
   hideAll: boolean;
   hideResolved: boolean;
   hideOutdated: boolean;
+  /** Hide GitHub comment threads (kind === "comment"). */
+  hideComments: boolean;
+  /** Hide AI findings. */
+  hideFindings: boolean;
+  /** Hide personal question threads (kind === "question"). */
+  hideQuestions: boolean;
 }
 
 function loadDiffViewMode(): DiffViewMode {
@@ -51,7 +57,14 @@ function loadCompactLines(): boolean {
 }
 
 function loadCommentVisibility(): CommentVisibility {
-  const defaults = { hideAll: false, hideResolved: true, hideOutdated: true };
+  const defaults: CommentVisibility = {
+    hideAll: false,
+    hideResolved: true,
+    hideOutdated: true,
+    hideComments: false,
+    hideFindings: false,
+    hideQuestions: false,
+  };
   if (typeof localStorage === "undefined") return defaults;
   try {
     return { ...defaults, ...JSON.parse(localStorage.getItem(COMMENT_VISIBILITY_KEY) ?? "{}") };


### PR DESCRIPTION
## What

Adds three new toggles to the desktop diff view settings (the gear dropdown shown next to the layout Unified/Split options):

- **Show/hide Comments**
- **Show/hide Findings**
- **Show/hide Questions**

They live under a new **Annotations** section in the same dropdown, below the existing Layout (Unified/Split) options. A checkmark indicates the annotation type is currently visible; clicking toggles it.

## How

- `CommentVisibility` gains three independent flags: `hideComments`, `hideFindings`, `hideQuestions` (in both `diffAnnotations.ts` and the app store).
- Threads carry `kind: "comment" | "question"`, so `visibleThreads` now filters comment vs question threads independently. Findings (`FlatFinding`) are gated in `buildAnnotationIndex` — when hidden, the finding index is built empty so nothing renders inline or as fallback.
- The new flags are folded into `annotationVersion` and the render-model `visBits` cache keys so toggling busts the annotation/render caches and re-renders.
- State persists through the existing `er.commentVisibility` localStorage entry via `setCommentVisibility`; defaults keep all three visible.

## Notes

- The existing CommentsCard buttons (Hide all / resolved / outdated) are unchanged and continue to work alongside these.
- Tests in `diffAnnotations.test.ts` / `diffRenderModel.test.ts` updated for the widened interface; the full suite passes (`bun test`).

https://claude.ai/code/session_015tFCJtSUkVMkbNisr7p9CR

---
_Generated by [Claude Code](https://claude.ai/code/session_015tFCJtSUkVMkbNisr7p9CR)_