### PR TITLE
Notes sidepanel: bulk Ask AI / Promote, scrollable findings, parent-first preview

### DIFF
--- a/desktop-ui/src/lib/components/AiReviewCard.svelte
+++ b/desktop-ui/src/lib/components/AiReviewCard.svelte
@@ -308,7 +308,7 @@
   </div>
 
   {#if open}
-    <div class="mt-4 pt-3 border-t border-hairline space-y-1.5 mb-3">
+    <div class="mt-4 pt-3 border-t border-hairline mb-3">
       <div class="flex items-center gap-1.5 mb-2 text-[10px] mono">
         <button onclick={() => filter = "all"} class="px-2 py-0.5 rounded {filter === 'all' ? 'bg-hairline text-fg' : 'text-fg-3 hover:bg-hover'}">all</button>
         <button onclick={() => filter = "high"} class="px-2 py-0.5 rounded flex items-center gap-1 {filter === 'high' ? 'bg-hairline text-risk-high' : 'text-fg-3 hover:bg-hover'}"><span class="w-1.5 h-1.5 rounded-full bg-risk-high"></span>high</button>
@@ -316,6 +316,7 @@
         <button onclick={() => filter = "low"} class="px-2 py-0.5 rounded flex items-center gap-1 {filter === 'low' ? 'bg-hairline text-risk-low' : 'text-fg-3 hover:bg-hover'}"><span class="w-1.5 h-1.5 rounded-full bg-risk-low"></span>low</button>
       </div>
 
+      <div class="findings-list space-y-1.5">
       {#each filtered as finding (finding.id)}
         {@const dotClass = finding.severity === "high" ? "bg-risk-high" : finding.severity === "med" ? "bg-risk-med" : "bg-risk-low"}
         {@const label = findingAgentLabel(finding)}
@@ -350,6 +351,7 @@
           </button>
         </div>
       {/each}
+      </div>
     </div>
   {/if}
 
@@ -404,6 +406,11 @@
 
   .summary-expanded {
     max-height: 20rem;
+    overflow-y: auto;
+  }
+
+  .findings-list {
+    max-height: 22rem;
     overflow-y: auto;
   }
 </style>

--- a/desktop-ui/src/lib/components/QuestionsCard.svelte
+++ b/desktop-ui/src/lib/components/QuestionsCard.svelte
@@ -22,8 +22,23 @@
     return i === -1 ? p : p.slice(i + 1);
   }
 
-  function previewBody(thread: AiSnapshot["threads"][number]): string {
-    return thread.replies.at(-1)?.body_markdown ?? thread.root.body_markdown;
+  function latestReply(
+    thread: AiSnapshot["threads"][number],
+  ): AiSnapshot["threads"][number]["replies"][number] | undefined {
+    return thread.replies.at(-1);
+  }
+
+  async function askAll() {
+    for (const t of questionThreads) {
+      await app.cmd("ask_ai", { threadId: t.id, prompt: "" });
+    }
+  }
+
+  async function promoteAll() {
+    for (const t of questionThreads) {
+      if (t.promoted_to) continue;
+      await app.cmd("promote_to_comment", { id: t.id });
+    }
   }
 </script>
 
@@ -51,7 +66,14 @@
             <span>{basename(thread.file)}{thread.line > 0 ? `:${threadLineRefSuffix(thread)}` : ""}</span>
             <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="ml-auto opacity-0 group-hover:opacity-100 transition text-accent"><path d="M7 17L17 7M7 7h10v10"/></svg>
           </div>
-          <MarkdownText text={previewBody(thread)} className="text-fg-2 text-left" />
+          <MarkdownText text={thread.root.body_markdown} className="text-fg-2 text-left" />
+          {#if latestReply(thread)}
+            {@const reply = latestReply(thread)}
+            <div class="mt-1 pl-2 border-l border-hairline">
+              <div class="text-[10px] font-mono text-muted mb-0.5">{reply?.author ?? "reply"} replied</div>
+              <MarkdownText text={reply?.body_markdown ?? ""} className="text-fg-3 text-left" />
+            </div>
+          {/if}
         </button>
         <button
           type="button"
@@ -72,10 +94,7 @@
       variant="primary"
       class="flex items-center justify-center gap-1.5 normal-case"
       disabled={questionThreads.length === 0}
-      onclick={() => {
-        const t = questionThreads[questionThreads.length - 1];
-        if (t) app.cmd("ask_ai", { threadId: t.id, prompt: "" });
-      }}
+      onclick={askAll}
     >
       <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z"/></svg>
       Ask AI
@@ -84,10 +103,7 @@
       variant="secondary"
       class="flex items-center justify-center gap-1.5 normal-case"
       disabled={questionThreads.length === 0}
-      onclick={() => {
-        const t = questionThreads[questionThreads.length - 1];
-        if (t) app.cmd("promote_to_comment", { id: t.id });
-      }}
+      onclick={promoteAll}
     >
       <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
       Promote to comment

--- a/desktop-ui/src/lib/components/QuestionsCard.svelte
+++ b/desktop-ui/src/lib/components/QuestionsCard.svelte
@@ -56,6 +56,7 @@
 
   <div class="space-y-1 mb-3">
     {#each questionThreads as thread (thread.id)}
+      {@const reply = latestReply(thread)}
       <div class="relative group">
         <button
           onclick={() => navigateToThread(thread)}
@@ -67,11 +68,10 @@
             <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="ml-auto opacity-0 group-hover:opacity-100 transition text-accent"><path d="M7 17L17 7M7 7h10v10"/></svg>
           </div>
           <MarkdownText text={thread.root.body_markdown} className="text-fg-2 text-left" />
-          {#if latestReply(thread)}
-            {@const reply = latestReply(thread)}
+          {#if reply}
             <div class="mt-1 pl-2 border-l border-hairline">
-              <div class="text-[10px] font-mono text-muted mb-0.5">{reply?.author ?? "reply"} replied</div>
-              <MarkdownText text={reply?.body_markdown ?? ""} className="text-fg-3 text-left" />
+              <div class="text-[10px] font-mono text-muted mb-0.5">{reply.author} replied</div>
+              <MarkdownText text={reply.body_markdown} className="text-fg-3 text-left" />
             </div>
           {/if}
         </button>


### PR DESCRIPTION
## Summary

Desktop app changes to the Notes sidepanel (`QuestionsCard`) and AI Review findings (`AiReviewCard`).

### Notes sidepanel (`QuestionsCard.svelte`)
- **Ask AI** now answers *all* questions instead of only the last one.
- **Promote to comment** now promotes *all* questions to comments instead of only the last one. Questions already promoted (`promoted_to` set) are skipped to avoid duplicates.
- Each question now shows the **parent question** as the main text, with the **latest reply nested underneath** it (previously the card showed only the latest reply, hiding the original question).

### AI Review findings (`AiReviewCard.svelte`)
- The findings list is now height-limited (`max-height: 22rem`) and scrollable, so a long list no longer pushes the rest of the panel off-screen.

## Notes
- `ask_ai` spawns a background subprocess per thread and returns immediately; `promote_to_comment` is awaited per question so snapshots apply sequentially.

https://claude.ai/code/session_019exoMRTZrCZKjSqFMa6s3F

---
_Generated by [Claude Code](https://claude.ai/code/session_019exoMRTZrCZKjSqFMa6s3F)_