### PR TITLE
Render GFM tables in desktop markdown

### DIFF
--- a/desktop-ui/src/lib/components/ui/MarkdownText.svelte
+++ b/desktop-ui/src/lib/components/ui/MarkdownText.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onExternalLinkClick } from "$lib/openExternalUrl";
+  import { parseMarkdown, renderInline as inline } from "$lib/markdown";
 
   interface Props {
     text: string;
@@ -7,94 +8,7 @@
   }
   const { text, className = "" }: Props = $props();
 
-  type Node =
-    | { t: "p"; v: string }
-    | { t: "h"; l: number; v: string }
-    | { t: "ul"; items: string[] }
-    | { t: "ol"; items: string[] }
-    | { t: "bq"; v: string }
-    | { t: "code"; lang: string; v: string };
-
-  function parse(md: string): Node[] {
-    const lines = md.replace(/\r\n/g, "\n").split("\n");
-    const out: Node[] = [];
-    let i = 0;
-    while (i < lines.length) {
-      const line = lines[i];
-      if (!line.trim()) {
-        i++;
-        continue;
-      }
-      const hm = line.match(/^(#{1,6})\s+(.*)$/);
-      if (hm) {
-        out.push({ t: "h", l: hm[1].length, v: hm[2] });
-        i++;
-        continue;
-      }
-      const cm = line.match(/^```(\w+)?\s*$/);
-      if (cm) {
-        const lang = cm[1] ?? "";
-        i++;
-        const code: string[] = [];
-        while (i < lines.length && !lines[i].startsWith("```")) code.push(lines[i++]);
-        if (i < lines.length) i++;
-        out.push({ t: "code", lang, v: code.join("\n") });
-        continue;
-      }
-      if (line.startsWith("> ")) {
-        const q: string[] = [];
-        while (i < lines.length && lines[i].startsWith("> ")) q.push(lines[i++].slice(2));
-        out.push({ t: "bq", v: q.join("\n") });
-        continue;
-      }
-      const um = line.match(/^\s*[-*]\s+(.+)$/);
-      if (um) {
-        const items: string[] = [];
-        while (i < lines.length) {
-          const m = lines[i].match(/^\s*[-*]\s+(.+)$/);
-          if (!m) break;
-          items.push(m[1]);
-          i++;
-        }
-        out.push({ t: "ul", items });
-        continue;
-      }
-      const om = line.match(/^\s*\d+\.\s+(.+)$/);
-      if (om) {
-        const items: string[] = [];
-        while (i < lines.length) {
-          const m = lines[i].match(/^\s*\d+\.\s+(.+)$/);
-          if (!m) break;
-          items.push(m[1]);
-          i++;
-        }
-        out.push({ t: "ol", items });
-        continue;
-      }
-      const p: string[] = [line];
-      i++;
-      while (i < lines.length && lines[i].trim()) {
-        if (/^(#{1,6})\s+/.test(lines[i]) || /^```/.test(lines[i])) break;
-        p.push(lines[i++]);
-      }
-      out.push({ t: "p", v: p.join("\n") });
-    }
-    return out;
-  }
-
-  const nodes = $derived(parse(text || ""));
-
-  function inline(s: string): string {
-    const escaped = s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-    return escaped
-      .replace(/`([^`]+)`/g, "<code>$1</code>")
-      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-      .replace(/\*([^*]+)\*/g, "<em>$1</em>")
-      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" rel="noreferrer">$1</a>');
-  }
+  const nodes = $derived(parseMarkdown(text || ""));
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -121,6 +35,27 @@
       <blockquote>{@html inline(n.v)}</blockquote>
     {:else if n.t === "code"}
       <pre><code class={n.lang ? `language-${n.lang}` : ""}>{n.v}</code></pre>
+    {:else if n.t === "table"}
+      <div class="md-table-wrap">
+        <table>
+          <thead>
+            <tr>
+              {#each n.header as cell, c}
+                <th style={n.align[c] ? `text-align:${n.align[c]}` : ""}>{@html inline(cell)}</th>
+              {/each}
+            </tr>
+          </thead>
+          <tbody>
+            {#each n.rows as row}
+              <tr>
+                {#each n.header as _, c}
+                  <td style={n.align[c] ? `text-align:${n.align[c]}` : ""}>{@html inline(row[c] ?? "")}</td>
+                {/each}
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
     {/if}
   {/each}
 </div>
@@ -169,4 +104,31 @@
     word-break: break-word;
   }
   .markdown-text :global(a) { text-decoration: underline; }
+  .markdown-text :global(.md-table-wrap) {
+    margin: 0.45rem 0;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+  .markdown-text :global(table) {
+    border-collapse: collapse;
+    font-size: 0.9em;
+    width: max-content;
+    max-width: 100%;
+  }
+  .markdown-text :global(th),
+  .markdown-text :global(td) {
+    border: 1px solid color-mix(in srgb, var(--color-fg-3) 25%, transparent);
+    padding: 0.28rem 0.55rem;
+    text-align: left;
+    vertical-align: top;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+  .markdown-text :global(th) {
+    font-weight: 600;
+    background: color-mix(in srgb, var(--color-fg-3) 12%, transparent);
+  }
+  .markdown-text :global(tbody tr:nth-child(even) td) {
+    background: color-mix(in srgb, var(--color-fg-3) 6%, transparent);
+  }
 </style>

--- a/desktop-ui/src/lib/markdown.test.ts
+++ b/desktop-ui/src/lib/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { parseMarkdown, renderInline, type MarkdownNode } from "./markdown";
 
 function tableOf(nodes: MarkdownNode[]) {
@@ -44,6 +44,12 @@ describe("parseMarkdown tables", () => {
     expect(nodes[0]).toEqual({ t: "p", v: "this | is not | a table" });
   });
 
+  it("does not treat prose above a dashed rule as a table (column count must match)", () => {
+    const md = ["a | b", "-----", "c | d"].join("\n");
+    const nodes = parseMarkdown(md);
+    expect(nodes.every((n) => n.t !== "table")).toBe(true);
+  });
+
   it("ends the table at a blank line and resumes normal parsing", () => {
     const md = ["| a | b |", "| --- | --- |", "| 1 | 2 |", "", "after"].join("\n");
     const nodes = parseMarkdown(md);
@@ -54,5 +60,11 @@ describe("parseMarkdown tables", () => {
 
   it("renders inline markup inside cells", () => {
     expect(renderInline("**bold** and `code`")).toBe("<strong>bold</strong> and <code>code</code>");
+  });
+
+  it("escapes quotes so a link URL cannot break out of the href attribute", () => {
+    const html = renderInline('[hi](https://e.com"onmouseover="alert(1))');
+    expect(html).not.toContain('"onmouseover="');
+    expect(html).toContain("&quot;onmouseover=");
   });
 });

--- a/desktop-ui/src/lib/markdown.test.ts
+++ b/desktop-ui/src/lib/markdown.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseMarkdown, renderInline, type MarkdownNode } from "./markdown";
+
+function tableOf(nodes: MarkdownNode[]) {
+  const t = nodes.find((n) => n.t === "table");
+  if (!t || t.t !== "table") throw new Error("no table node");
+  return t;
+}
+
+describe("parseMarkdown tables", () => {
+  it("parses a basic GFM table", () => {
+    const md = ["| Term | Meaning |", "| --- | --- |", "| type | A keyword |", "| as const | Seals an array |"].join("\n");
+    const t = tableOf(parseMarkdown(md));
+    expect(t.header).toEqual(["Term", "Meaning"]);
+    expect(t.rows).toEqual([
+      ["type", "A keyword"],
+      ["as const", "Seals an array"],
+    ]);
+  });
+
+  it("reads alignment from the delimiter row", () => {
+    const md = ["| L | C | R |", "| :--- | :--: | ---: |", "| a | b | c |"].join("\n");
+    const t = tableOf(parseMarkdown(md));
+    expect(t.align).toEqual(["left", "center", "right"]);
+  });
+
+  it("supports tables without outer pipes", () => {
+    const md = ["a | b", "--- | ---", "1 | 2"].join("\n");
+    const t = tableOf(parseMarkdown(md));
+    expect(t.header).toEqual(["a", "b"]);
+    expect(t.rows).toEqual([["1", "2"]]);
+  });
+
+  it("honors escaped pipes inside cells", () => {
+    const md = ["| a | b |", "| --- | --- |", "| x \\| y | z |"].join("\n");
+    const t = tableOf(parseMarkdown(md));
+    expect(t.rows[0]).toEqual(["x | y", "z"]);
+  });
+
+  it("does not treat a pipe line without a delimiter row as a table", () => {
+    const md = "this | is not | a table";
+    const nodes = parseMarkdown(md);
+    expect(nodes.every((n) => n.t !== "table")).toBe(true);
+    expect(nodes[0]).toEqual({ t: "p", v: "this | is not | a table" });
+  });
+
+  it("ends the table at a blank line and resumes normal parsing", () => {
+    const md = ["| a | b |", "| --- | --- |", "| 1 | 2 |", "", "after"].join("\n");
+    const nodes = parseMarkdown(md);
+    const t = tableOf(nodes);
+    expect(t.rows).toEqual([["1", "2"]]);
+    expect(nodes[nodes.length - 1]).toEqual({ t: "p", v: "after" });
+  });
+
+  it("renders inline markup inside cells", () => {
+    expect(renderInline("**bold** and `code`")).toBe("<strong>bold</strong> and <code>code</code>");
+  });
+});

--- a/desktop-ui/src/lib/markdown.ts
+++ b/desktop-ui/src/lib/markdown.ts
@@ -71,11 +71,12 @@ export function parseMarkdown(md: string): MarkdownNode[] {
       out.push({ t: "code", lang, v: code.join("\n") });
       continue;
     }
-    // GFM table: a row containing a pipe followed by a delimiter row.
+    // GFM table: a row containing a pipe followed by a delimiter row whose
+    // column count matches the header (else it's prose above a `---` rule).
     if (line.includes("|") && i + 1 < lines.length) {
       const align = parseDelimiterRow(lines[i + 1]);
-      if (align) {
-        const header = splitRow(line);
+      const header = align ? splitRow(line) : [];
+      if (align && align.length === header.length) {
         i += 2;
         const rows: string[][] = [];
         while (i < lines.length && lines[i].trim() && lines[i].includes("|")) {
@@ -132,7 +133,8 @@ export function renderInline(s: string): string {
   const escaped = s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
   return escaped
     .replace(/`([^`]+)`/g, "<code>$1</code>")
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")

--- a/desktop-ui/src/lib/markdown.ts
+++ b/desktop-ui/src/lib/markdown.ts
@@ -1,0 +1,141 @@
+export type MarkdownNode =
+  | { t: "p"; v: string }
+  | { t: "h"; l: number; v: string }
+  | { t: "ul"; items: string[] }
+  | { t: "ol"; items: string[] }
+  | { t: "bq"; v: string }
+  | { t: "code"; lang: string; v: string }
+  | { t: "table"; align: ("left" | "center" | "right" | null)[]; header: string[]; rows: string[][] };
+
+/** Split a GFM table row into its cells, honoring escaped pipes (`\|`). */
+function splitRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  const cells: string[] = [];
+  let cur = "";
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "\\" && s[i + 1] === "|") {
+      cur += "|";
+      i++;
+    } else if (ch === "|") {
+      cells.push(cur.trim());
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  cells.push(cur.trim());
+  return cells;
+}
+
+/** A delimiter row is the second line of a GFM table, e.g. `| --- | :--: |`. */
+function parseDelimiterRow(line: string): ("left" | "center" | "right" | null)[] | null {
+  if (!line.includes("-")) return null;
+  const cells = splitRow(line);
+  const align: ("left" | "center" | "right" | null)[] = [];
+  for (const cell of cells) {
+    const m = cell.match(/^(:?)-+(:?)$/);
+    if (!m) return null;
+    const left = m[1] === ":";
+    const right = m[2] === ":";
+    align.push(left && right ? "center" : right ? "right" : left ? "left" : null);
+  }
+  return align.length ? align : null;
+}
+
+export function parseMarkdown(md: string): MarkdownNode[] {
+  const lines = md.replace(/\r\n/g, "\n").split("\n");
+  const out: MarkdownNode[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+    const hm = line.match(/^(#{1,6})\s+(.*)$/);
+    if (hm) {
+      out.push({ t: "h", l: hm[1].length, v: hm[2] });
+      i++;
+      continue;
+    }
+    const cm = line.match(/^```(\w+)?\s*$/);
+    if (cm) {
+      const lang = cm[1] ?? "";
+      i++;
+      const code: string[] = [];
+      while (i < lines.length && !lines[i].startsWith("```")) code.push(lines[i++]);
+      if (i < lines.length) i++;
+      out.push({ t: "code", lang, v: code.join("\n") });
+      continue;
+    }
+    // GFM table: a row containing a pipe followed by a delimiter row.
+    if (line.includes("|") && i + 1 < lines.length) {
+      const align = parseDelimiterRow(lines[i + 1]);
+      if (align) {
+        const header = splitRow(line);
+        i += 2;
+        const rows: string[][] = [];
+        while (i < lines.length && lines[i].trim() && lines[i].includes("|")) {
+          rows.push(splitRow(lines[i]));
+          i++;
+        }
+        out.push({ t: "table", align, header, rows });
+        continue;
+      }
+    }
+    if (line.startsWith("> ")) {
+      const q: string[] = [];
+      while (i < lines.length && lines[i].startsWith("> ")) q.push(lines[i++].slice(2));
+      out.push({ t: "bq", v: q.join("\n") });
+      continue;
+    }
+    const um = line.match(/^\s*[-*]\s+(.+)$/);
+    if (um) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = lines[i].match(/^\s*[-*]\s+(.+)$/);
+        if (!m) break;
+        items.push(m[1]);
+        i++;
+      }
+      out.push({ t: "ul", items });
+      continue;
+    }
+    const om = line.match(/^\s*\d+\.\s+(.+)$/);
+    if (om) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = lines[i].match(/^\s*\d+\.\s+(.+)$/);
+        if (!m) break;
+        items.push(m[1]);
+        i++;
+      }
+      out.push({ t: "ol", items });
+      continue;
+    }
+    const p: string[] = [line];
+    i++;
+    while (i < lines.length && lines[i].trim()) {
+      if (/^(#{1,6})\s+/.test(lines[i]) || /^```/.test(lines[i])) break;
+      p.push(lines[i++]);
+    }
+    out.push({ t: "p", v: p.join("\n") });
+  }
+  return out;
+}
+
+/** Render inline markdown (bold, italic, code, links) to safe HTML. */
+export function renderInline(s: string): string {
+  const escaped = s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" rel="noreferrer">$1</a>');
+}


### PR DESCRIPTION
## Problem

AI replies that include a markdown table rendered as raw pipe-and-dash text instead of a real table (see the "words you just learned" reply). The desktop markdown renderer (`MarkdownText.svelte`) had no table handling, so table lines fell through to the paragraph branch.

## Change

- **Extracted** the markdown parser out of `MarkdownText.svelte` into a standalone, testable `desktop-ui/src/lib/markdown.ts` (`parseMarkdown` + `renderInline`). The Svelte component now imports from it.
- **Added GFM table support**: a `table` node is recognized when a pipe-containing line is followed by a delimiter row (`| --- | :--: |`). Handles:
  - column alignment (left/center/right) from the delimiter row
  - tables with or without outer pipes
  - escaped pipes inside cells (`\|`)
  - inline markup (bold/italic/code/links) inside cells
- **Rendered** as a styled `<table>` (header shading, zebra body rows, horizontal scroll on overflow) using existing theme tokens.
- **Tests**: new co-located `markdown.test.ts` (7 cases). Full desktop-ui suite passes (311), `svelte-check` reports 0 errors.

This only touches the desktop UI — the renderer shown in the screenshot.

https://claude.ai/code/session_01VsRutfFu12t981CTNJPjr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsRutfFu12t981CTNJPjr2)_