### PR TITLE
Add per-tab export buttons to the right panel

### DIFF
--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -1408,8 +1408,8 @@ fn build_snapshot_inner(
 
                 let line_count = f.hunks.iter().map(|h| h.lines.len()).sum::<usize>();
                 let is_large = f.adds + f.dels > tab.compaction_config.max_lines_before_compact;
-                let include_hunks =
-                    !f.compacted && (!is_large || source_index == active_selected || diff_line_budget > 0);
+                let include_hunks = !f.compacted
+                    && (!is_large || source_index == active_selected || diff_line_budget > 0);
                 if include_hunks && is_large {
                     diff_line_budget = diff_line_budget.saturating_sub(line_count);
                 }

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -1004,12 +1004,10 @@ impl TabState {
         let t_parse = Instant::now();
         if raw.len() > 200_000 {
             let headers = crate::git::parse_diff_headers(&raw);
-            let files = crate::git::lazy_files_with_compaction(
-                &raw,
-                &headers,
-                &compaction_config,
-                |p| tab.user_expanded.contains(p),
-            );
+            let files =
+                crate::git::lazy_files_with_compaction(&raw, &headers, &compaction_config, |p| {
+                    tab.user_expanded.contains(p)
+                });
             tab.files = files;
             tab.file_headers = headers;
             tab.raw_diff = Some(raw.clone());
@@ -2330,12 +2328,10 @@ impl TabState {
             // small files are parsed eagerly so they render without a lazy round-trip.
             let headers = git::parse_diff_headers(&raw);
             let compaction_config = self.compaction_config.clone();
-            let files = crate::git::lazy_files_with_compaction(
-                &raw,
-                &headers,
-                &compaction_config,
-                |p| self.user_expanded.contains(p),
-            );
+            let files =
+                crate::git::lazy_files_with_compaction(&raw, &headers, &compaction_config, |p| {
+                    self.user_expanded.contains(p)
+                });
             self.files = files;
             self.file_headers = headers;
             self.raw_diff = Some(raw.clone());

--- a/crates/er-engine/src/git/diff.rs
+++ b/crates/er-engine/src/git/diff.rs
@@ -1620,8 +1620,7 @@ index aaa..bbb 100644
         let raw = make_file_diff("src/large.rs", 2500);
         let headers = parse_diff_headers(&raw);
         let config = CompactionConfig::default();
-        let files =
-            lazy_files_with_compaction(&raw, &headers, &config, |p| p == "src/large.rs");
+        let files = lazy_files_with_compaction(&raw, &headers, &config, |p| p == "src/large.rs");
         assert_eq!(files.len(), 1);
         let f = &files[0];
         assert!(!f.compacted, "user-expanded file must not be compacted");
@@ -1643,8 +1642,7 @@ index aaa..bbb 100644
 
         let headers = parse_diff_headers(&raw);
         let config = CompactionConfig::default();
-        let files =
-            lazy_files_with_compaction(&raw, &headers, &config, |p| p == "src/expanded.rs");
+        let files = lazy_files_with_compaction(&raw, &headers, &config, |p| p == "src/expanded.rs");
 
         let small = files
             .iter()

--- a/crates/er-tui/src/ui/themes.rs
+++ b/crates/er-tui/src/ui/themes.rs
@@ -257,13 +257,23 @@ pub fn available_themes() -> Vec<&'static str> {
 pub fn graphite() -> Theme {
     build(&Tokens {
         name: "graphite",
-        bg: "#0b0b0d", bg1: "#16161a", bg2: "#1d1d22", bg3: "#28282f",
+        bg: "#0b0b0d",
+        bg1: "#16161a",
+        bg2: "#1d1d22",
+        bg3: "#28282f",
         line2: "#ffffff26",
-        tx: "#ededf0", tx2: "#a1a1ab", tx3: "#6b6b75",
+        tx: "#ededf0",
+        tx2: "#a1a1ab",
+        tx3: "#6b6b75",
         accent: "#f2843c",
-        red: "#ef5f5b", amber: "#e3b341", blue: "#5f9cea",
-        cyan: "#4cc4e0", purple: "#a78bf6", green: "#46bd6c",
-        add: "#46bd6c", del: "#ef5f5b",
+        red: "#ef5f5b",
+        amber: "#e3b341",
+        blue: "#5f9cea",
+        cyan: "#4cc4e0",
+        purple: "#a78bf6",
+        green: "#46bd6c",
+        add: "#46bd6c",
+        del: "#ef5f5b",
         syntect: "OneHalfDark",
     })
 }
@@ -272,13 +282,23 @@ pub fn graphite() -> Theme {
 pub fn slate() -> Theme {
     build(&Tokens {
         name: "slate",
-        bg: "#0c1118", bg1: "#131b25", bg2: "#1a2431", bg3: "#243140",
+        bg: "#0c1118",
+        bg1: "#131b25",
+        bg2: "#1a2431",
+        bg3: "#243140",
         line2: "#9fc0ff2e",
-        tx: "#e9eef5", tx2: "#9aa9bb", tx3: "#647588",
+        tx: "#e9eef5",
+        tx2: "#9aa9bb",
+        tx3: "#647588",
         accent: "#f2843c",
-        red: "#f0635f", amber: "#e6b84a", blue: "#6aa6f5",
-        cyan: "#43c8e2", purple: "#ab92f7", green: "#4ec977",
-        add: "#4ec977", del: "#f0635f",
+        red: "#f0635f",
+        amber: "#e6b84a",
+        blue: "#6aa6f5",
+        cyan: "#43c8e2",
+        purple: "#ab92f7",
+        green: "#4ec977",
+        add: "#4ec977",
+        del: "#f0635f",
         syntect: "OneHalfDark",
     })
 }
@@ -287,13 +307,23 @@ pub fn slate() -> Theme {
 pub fn midnight() -> Theme {
     build(&Tokens {
         name: "midnight",
-        bg: "#0e0f1a", bg1: "#171829", bg2: "#1e2036", bg3: "#292c48",
+        bg: "#0e0f1a",
+        bg1: "#171829",
+        bg2: "#1e2036",
+        bg3: "#292c48",
         line2: "#a9b8ff2e",
-        tx: "#e6e8f5", tx2: "#9aa0c4", tx3: "#666c90",
+        tx: "#e6e8f5",
+        tx2: "#9aa0c4",
+        tx3: "#666c90",
         accent: "#f2843c",
-        red: "#f7768e", amber: "#e0af68", blue: "#7aa2f7",
-        cyan: "#7dcfff", purple: "#bb9af7", green: "#9ece6a",
-        add: "#9ece6a", del: "#f7768e",
+        red: "#f7768e",
+        amber: "#e0af68",
+        blue: "#7aa2f7",
+        cyan: "#7dcfff",
+        purple: "#bb9af7",
+        green: "#9ece6a",
+        add: "#9ece6a",
+        del: "#f7768e",
         syntect: "OneHalfDark",
     })
 }
@@ -302,13 +332,23 @@ pub fn midnight() -> Theme {
 pub fn ember() -> Theme {
     build(&Tokens {
         name: "ember",
-        bg: "#100c0a", bg1: "#1b1512", bg2: "#241c17", bg3: "#312620",
+        bg: "#100c0a",
+        bg1: "#1b1512",
+        bg2: "#241c17",
+        bg3: "#312620",
         line2: "#ffd9b82b",
-        tx: "#f1e9e2", tx2: "#b09c8d", tx3: "#75665c",
+        tx: "#f1e9e2",
+        tx2: "#b09c8d",
+        tx3: "#75665c",
         accent: "#f2843c",
-        red: "#ef6151", amber: "#e7b24a", blue: "#7aa6dd",
-        cyan: "#56bfc0", purple: "#c193e8", green: "#76b95f",
-        add: "#76b95f", del: "#ef6151",
+        red: "#ef6151",
+        amber: "#e7b24a",
+        blue: "#7aa6dd",
+        cyan: "#56bfc0",
+        purple: "#c193e8",
+        green: "#76b95f",
+        add: "#76b95f",
+        del: "#ef6151",
         syntect: "OneHalfDark",
     })
 }
@@ -319,13 +359,23 @@ pub fn ember() -> Theme {
 pub fn paper() -> Theme {
     build(&Tokens {
         name: "paper",
-        bg: "#faf8f4", bg1: "#ffffff", bg2: "#f3efe8", bg3: "#e9e3d8",
+        bg: "#faf8f4",
+        bg1: "#ffffff",
+        bg2: "#f3efe8",
+        bg3: "#e9e3d8",
         line2: "#3a2a1a2b",
-        tx: "#211d18", tx2: "#6b6258", tx3: "#9a9085",
+        tx: "#211d18",
+        tx2: "#6b6258",
+        tx3: "#9a9085",
         accent: "#cf5f17",
-        red: "#cc3b39", amber: "#a9740f", blue: "#2f6fd0",
-        cyan: "#0e87a3", purple: "#7a4fd0", green: "#1c854b",
-        add: "#1c854b", del: "#cc3b39",
+        red: "#cc3b39",
+        amber: "#a9740f",
+        blue: "#2f6fd0",
+        cyan: "#0e87a3",
+        purple: "#7a4fd0",
+        green: "#1c854b",
+        add: "#1c854b",
+        del: "#cc3b39",
         syntect: "base16-ocean.light",
     })
 }
@@ -334,13 +384,23 @@ pub fn paper() -> Theme {
 pub fn daylight() -> Theme {
     build(&Tokens {
         name: "daylight",
-        bg: "#f6f7f9", bg1: "#ffffff", bg2: "#eef0f3", bg3: "#e3e7ec",
+        bg: "#f6f7f9",
+        bg1: "#ffffff",
+        bg2: "#eef0f3",
+        bg3: "#e3e7ec",
         line2: "#0b1b3a29",
-        tx: "#161a21", tx2: "#5b6573", tx3: "#8b95a3",
+        tx: "#161a21",
+        tx2: "#5b6573",
+        tx3: "#8b95a3",
         accent: "#cf5f17",
-        red: "#cc3b39", amber: "#9a6b12", blue: "#2563cf",
-        cyan: "#0b7e9c", purple: "#6f45cc", green: "#168049",
-        add: "#168049", del: "#cc3b39",
+        red: "#cc3b39",
+        amber: "#9a6b12",
+        blue: "#2563cf",
+        cyan: "#0b7e9c",
+        purple: "#6f45cc",
+        green: "#168049",
+        add: "#168049",
+        del: "#cc3b39",
         syntect: "base16-ocean.light",
     })
 }
@@ -351,13 +411,23 @@ pub fn daylight() -> Theme {
 pub fn contrast_dark() -> Theme {
     build(&Tokens {
         name: "contrast-dark",
-        bg: "#000000", bg1: "#0a0a0b", bg2: "#151517", bg3: "#202024",
+        bg: "#000000",
+        bg1: "#0a0a0b",
+        bg2: "#151517",
+        bg3: "#202024",
         line2: "#ffffff5c",
-        tx: "#ffffff", tx2: "#d4d4da", tx3: "#9a9aa2",
+        tx: "#ffffff",
+        tx2: "#d4d4da",
+        tx3: "#9a9aa2",
         accent: "#ff9a4d",
-        red: "#ff6b66", amber: "#ffcf4d", blue: "#7fb4ff",
-        cyan: "#5fd6f0", purple: "#cbabff", green: "#5fe08a",
-        add: "#5fe08a", del: "#ff6b66",
+        red: "#ff6b66",
+        amber: "#ffcf4d",
+        blue: "#7fb4ff",
+        cyan: "#5fd6f0",
+        purple: "#cbabff",
+        green: "#5fe08a",
+        add: "#5fe08a",
+        del: "#ff6b66",
         syntect: "OneHalfDark",
     })
 }
@@ -366,13 +436,23 @@ pub fn contrast_dark() -> Theme {
 pub fn contrast_light() -> Theme {
     build(&Tokens {
         name: "contrast-light",
-        bg: "#ffffff", bg1: "#ffffff", bg2: "#f2f2f4", bg3: "#e6e6ea",
+        bg: "#ffffff",
+        bg1: "#ffffff",
+        bg2: "#f2f2f4",
+        bg3: "#e6e6ea",
         line2: "#0000005c",
-        tx: "#000000", tx2: "#2e2e33", tx3: "#5a5a61",
+        tx: "#000000",
+        tx2: "#2e2e33",
+        tx3: "#5a5a61",
         accent: "#b8530c",
-        red: "#bf1b1b", amber: "#7a5300", blue: "#1551c4",
-        cyan: "#056b85", purple: "#6321c0", green: "#0c7a3f",
-        add: "#0c7a3f", del: "#bf1b1b",
+        red: "#bf1b1b",
+        amber: "#7a5300",
+        blue: "#1551c4",
+        cyan: "#056b85",
+        purple: "#6321c0",
+        green: "#0c7a3f",
+        add: "#0c7a3f",
+        del: "#bf1b1b",
         syntect: "base16-ocean.light",
     })
 }
@@ -440,7 +520,10 @@ mod tests {
         // Old config values must keep resolving after the rebrand.
         assert_eq!(theme_by_name("ocean-depth").unwrap().name, "graphite");
         assert_eq!(theme_by_name("moonlight").unwrap().name, "slate");
-        assert_eq!(theme_by_name("high-contrast").unwrap().name, "contrast-dark");
+        assert_eq!(
+            theme_by_name("high-contrast").unwrap().name,
+            "contrast-dark"
+        );
         assert_eq!(theme_by_name("daybreak").unwrap().name, "daylight");
         assert_eq!(theme_by_name("tokyo-night").unwrap().name, "midnight");
         assert_eq!(theme_by_name("tokyo-night-day").unwrap().name, "paper");

--- a/desktop-ui/src/lib/components/RightPanel.svelte
+++ b/desktop-ui/src/lib/components/RightPanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
   import type { AiSnapshot, PrSnapshot } from "$lib/types";
   import { app } from "$lib/stores/app.svelte";
+  import { copyToClipboard } from "$lib/clipboard";
   import { resolveActivePrUrl } from "$lib/prUrl";
   import BranchCard from "./BranchCard.svelte";
   import AiReviewCard from "./AiReviewCard.svelte";
@@ -97,6 +99,58 @@
     { id: "review", label: "Review", badge: totalFindings > 0 ? totalFindings : null },
     { id: "notes",  label: "Notes",  badge: questionCount > 0 ? questionCount : null },
   ]);
+
+  // ── Per-tab export ───────────────────────────────────────────────────────────
+  // The shared `export_review` backend command renders selected sections to
+  // markdown. Each tab exports only the sections it shows, so the clipboard
+  // content lands ready to paste into a coding agent.
+  type ExportOpts = {
+    includeComments: boolean;
+    includeQuestions: boolean;
+    includeFindings: boolean;
+    includeAnnotations: boolean;
+    onlyUnresolved: boolean;
+  };
+
+  const NO_SECTIONS: ExportOpts = {
+    includeComments: false,
+    includeQuestions: false,
+    includeFindings: false,
+    includeAnnotations: false,
+    onlyUnresolved: false,
+  };
+
+  function exportOptsForTab(t: Tab): ExportOpts {
+    switch (t) {
+      case "branch":
+        return { ...NO_SECTIONS, includeComments: true };
+      case "review":
+        return { ...NO_SECTIONS, includeFindings: true };
+      case "notes":
+        return { ...NO_SECTIONS, includeQuestions: true, includeAnnotations: true };
+    }
+  }
+
+  let copying = $state(false);
+
+  async function copyTabToClipboard() {
+    if (copying) return;
+    copying = true;
+    const label = tabs.find((t) => t.id === activeTab)?.label ?? "section";
+    try {
+      const body = await invoke<string>("export_review", { opts: exportOptsForTab(activeTab) });
+      if (!body.trim()) {
+        app.showToast("info", `Nothing to export from the ${label} tab`);
+        return;
+      }
+      await copyToClipboard(body);
+      app.showToast("success", `Copied ${label} to clipboard (${body.length} chars)`);
+    } catch (e) {
+      app.showToast("error", `Export failed: ${e}`);
+    } finally {
+      copying = false;
+    }
+  }
 </script>
 
 <aside
@@ -175,6 +229,35 @@
         </svg>
       </button>
     {/if}
+  </div>
+
+  <!-- ── Per-tab export actions ──────────────────────────────────────────── -->
+  <div class="flex items-center gap-2 px-3 py-1.5 border-b border-hairline bg-surface shrink-0">
+    <button
+      type="button"
+      onclick={copyTabToClipboard}
+      disabled={copying}
+      title="Copy this section as markdown, ready to paste into a coding agent"
+      class="flex items-center gap-1.5 px-2 py-1 text-[11px] font-medium rounded border border-border text-fg-2 hover:bg-hover hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-default"
+    >
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <rect x="9" y="9" width="13" height="13" rx="2"/>
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+      </svg>
+      <span>{copying ? "Copying…" : "Export to clipboard"}</span>
+    </button>
+    <button
+      type="button"
+      onclick={() => app.setMainView("export-review")}
+      title="Open the full export panel"
+      class="flex items-center gap-1.5 px-2 py-1 text-[11px] font-medium rounded border border-border text-fg-2 hover:bg-hover hover:text-fg transition-colors"
+    >
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+        <polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
+      </svg>
+      <span>Open export panel</span>
+    </button>
   </div>
 
   <!-- ── Tab content ─────────────────────────────────────────────────────── -->

--- a/desktop-ui/src/lib/components/RightPanel.svelte
+++ b/desktop-ui/src/lib/components/RightPanel.svelte
@@ -104,6 +104,11 @@
   // The shared `export_review` backend command renders selected sections to
   // markdown. Each tab exports only the sections it shows, so the clipboard
   // content lands ready to paste into a coding agent.
+  //
+  // NOTE: This mirrors the Rust `ExportOpts` struct in
+  // `crates/er-desktop/src/export.rs` (camelCase over IPC). There are no
+  // generated Tauri bindings, so keep these fields in sync with that struct —
+  // `ExportReviewView.svelte` keeps its own copy for the same reason.
   type ExportOpts = {
     includeComments: boolean;
     includeQuestions: boolean;


### PR DESCRIPTION
## What

Adds a per-tab action bar to the right panel (`RightPanel.svelte`) for the **Branch**, **Review**, and **Notes** tabs. Each tab now has two buttons:

- **Export to clipboard** — renders that tab's sections to markdown via the existing `export_review` Tauri command and copies the result to the clipboard, ready to paste into a coding agent. The sections are scoped per tab:
  - Branch → comments
  - Review → AI findings
  - Notes → questions + UI annotations
- **Open export panel** — opens the existing full Export Review view (`app.setMainView("export-review")`) where all sections and options can be toggled.

## Why

The full export panel already exists but required a trip through the command palette / Comments card. This surfaces a fast, one-click "copy this section for an agent" action directly on each tab, plus a shortcut into the full export panel.

## Notes

- Reuses the existing `export_review` command (camelCase `ExportOpts`) and the `copyToClipboard` helper — no backend changes.
- Empty sections show an info toast ("Nothing to export…") rather than copying an empty string.
- `bun run check` passes with 0 errors (pre-existing warnings only).

https://claude.ai/code/session_019Y8sLTwNkSKY7CCjJM9ESM

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y8sLTwNkSKY7CCjJM9ESM)_