### PR TITLE
Fix batch review submit on local branch with explicit PR number

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -2328,7 +2328,15 @@ pub fn submit_github_review(
                 return Err("No PR info for this tab".to_string());
             }
         } else {
-            let pr_info = github::get_pr_info(&repo_root).map_err(|e| e.to_string())?;
+            // Prefer the tab's explicit PR number (set when a local PR review was
+            // opened) over branch detection. `get_pr_info` alone re-runs `gh pr
+            // view` for the current branch and bails when no PR is detected, even
+            // though the tab already knows which PR these comments belong to —
+            // which is why individual pushes (which use `local_pr_target`) work
+            // but the batch review submit failed with "No PR associated with
+            // current branch".
+            let pr_info = er_engine::sync::local_pr_target(&repo_root, tab.pr_number)
+                .map_err(|e| e.to_string())?;
             (pr_info.0, pr_info.1, pr_info.2)
         };
         if event == "APPROVE" {


### PR DESCRIPTION
## Problem

On a local branch, clicking **"post all comments as review"** failed with:

```
submit_github_review: No PR associated with current branch
```

…even though pushing each comment **individually** worked fine.

## Root cause

`submit_github_review` (in `crates/er-desktop/src/commands.rs`) resolved the PR for local (non-remote) tabs by calling `github::get_pr_info(&repo_root)` directly. That helper always re-runs `gh pr view` for the *current branch* and bails with `No PR associated with current branch` when branch detection fails — ignoring the `pr_number` the tab already carries (set when a local PR review is opened, e.g. via a PR URL).

The individual comment push paths (`push_all_comments_to_github`, `push_github_comment_thread`) already resolve this correctly through `sync::local_pr_target`, which **prefers the tab's explicit PR number** over branch detection. That asymmetry is exactly why one-at-a-time pushes succeeded while the batch submit failed.

## Fix

Use `er_engine::sync::local_pr_target(&repo_root, tab.pr_number)` for the local path in `submit_github_review`, so the batch review submit uses the same PR resolution as the individual pushes.

## Notes

- One-line behavioral change plus an explanatory comment; no API changes.
- Couldn't run `cargo check -p er-desktop` to completion in this environment — the desktop crate needs GTK system libs (`gdk-3.0`) that aren't installed here. The change is a direct mirror of the already-working individual-push path and `er_engine::sync::local_pr_target` is a public fn.

https://claude.ai/code/session_017jvWAqLwQrRDDSwfvySQpU

---
_Generated by [Claude Code](https://claude.ai/code/session_017jvWAqLwQrRDDSwfvySQpU)_