### PR TITLE
Add justfile task runner for build/run/test/lint commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ environment gotchas, and a map of the desktop app, which spans three layers.
 
 ## Build / Test / Lint / Run
 
+A [`just`](https://just.systems) front-end wraps these (`just` to list, e.g.
+`just run`, `just test`, `just lint`, `just ci`). It delegates to the same
+scripts/aliases below, so either form works.
+
 | Task | Command |
 |------|---------|
 | Build TUI (dev) | `./scripts/er-tui.sh build -p er-tui` or `cargo tui-build` (needs `.cargo/bin` on `PATH`; see `.envrc`) |

--- a/justfile
+++ b/justfile
@@ -21,8 +21,8 @@ alias t := test
 alias f := fmt
 alias l := lint
 
-# Default: show the grouped recipe list.
-default:
+# Bare `just` lists every recipe. The `_` prefix hides this entry from the list itself.
+_default:
     @just --list
 
 # ─────────────────────────────── run (local / dev) ───────────────────────────────

--- a/justfile
+++ b/justfile
@@ -1,0 +1,164 @@
+# easy-review (`er`) — task runner. https://just.systems
+#
+# `just`            list all recipes (grouped)
+# `just <recipe>`   run one
+#
+# This file is a thin front-end over the existing wrapper scripts and cargo
+# aliases — it does not reinvent them. The scripts are the single source of
+# truth for the split target dirs (`target/tui` vs `target/desktop`, so a
+# desktop/Tauri build never bloats the TUI's incremental cache) and the
+# auto cargo-gc. See AGENTS.md "Build / Test / Lint / Run" and CLAUDE.md.
+#
+# Env passthrough still works, e.g.  ER_DEBUG=1 just run   |   just dev --logs arena
+# Pass extra args after the recipe name where it takes `*ARGS`.
+
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+# Short aliases
+alias r := run
+alias b := build
+alias t := test
+alias f := fmt
+alias l := lint
+
+# Default: show the grouped recipe list.
+default:
+    @just --list
+
+# ─────────────────────────────── run (local / dev) ───────────────────────────────
+
+# Run the TUI from the current git repo (dev build). Needs a real terminal.
+[group('run')]
+run *ARGS:
+    ./scripts/er-tui.sh run -p er-tui -- {{ARGS}}
+
+# Run the desktop app in dev mode (Tauri + Vite). `just dev --logs arena` for log groups.
+[group('run')]
+dev *ARGS:
+    ./scripts/tauri-dev.sh {{ARGS}}
+
+# Run only the desktop frontend (Vite dev server, no Tauri shell).
+[group('run')]
+dev-ui:
+    cd desktop-ui && bun run dev
+
+# Launch Storybook for the desktop UI components.
+[group('run')]
+storybook:
+    cd desktop-ui && bun run storybook
+
+# ─────────────────────────────────── build ───────────────────────────────────────
+
+# Build the `er` TUI (debug).
+[group('build')]
+build:
+    ./scripts/er-tui.sh build -p er-tui
+
+# Build the `er` TUI (release, optimized).
+[group('build')]
+build-release:
+    ./scripts/er-tui.sh build --release -p er-tui
+
+# Build the desktop frontend bundle (Vite).
+[group('build')]
+build-ui:
+    cd desktop-ui && bun run build
+
+# Build the headless engine the way CI does (no UI features, then +highlight).
+[group('build')]
+build-engine-headless:
+    cargo build -p er-engine --no-default-features
+    cargo build -p er-engine --no-default-features --features highlight
+
+# ──────────────────────────────── production ─────────────────────────────────────
+
+# Install the `er` binary to ~/.cargo/bin (release). The TUI "production" artifact.
+[group('production')]
+install:
+    ./scripts/er-tui.sh install --path crates/er-tui
+
+# Build the production desktop bundle (.app / install). The desktop "production" artifact.
+[group('production')]
+build-desktop *ARGS:
+    ./scripts/tauri-build.sh {{ARGS}}
+
+# ──────────────────────────────────── test ───────────────────────────────────────
+
+# Test the TUI + engine (scoped to target/tui — fast, no Tauri build).
+[group('test')]
+test:
+    ./scripts/er-tui.sh test -p er-engine -p er-tui
+
+# Test the desktop (Tauri) backend.
+[group('test')]
+test-desktop:
+    cargo test -p er-desktop
+
+# Test the desktop frontend (bun).
+[group('test')]
+test-ui:
+    cd desktop-ui && bun test src
+
+# Test the entire workspace (slow — compiles Tauri into target/).
+[group('test')]
+test-all:
+    cargo test --workspace
+
+# ─────────────────────────────── format & lint ───────────────────────────────────
+
+# Format all Rust code.
+[group('lint')]
+fmt:
+    cargo fmt --all
+
+# Check formatting without writing (CI gate).
+[group('lint')]
+fmt-check:
+    cargo fmt --all -- --check
+
+# Clippy across the whole workspace, warnings = errors.
+[group('lint')]
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Type-check the workspace without producing binaries.
+[group('lint')]
+check:
+    cargo check --all-targets
+
+# Type-check the desktop frontend (svelte-check).
+[group('lint')]
+check-ui:
+    cd desktop-ui && bun run check
+
+# All static checks: rustfmt, clippy, and the frontend type-check.
+[group('lint')]
+lint: fmt-check clippy check-ui
+
+# ───────────────────────────────── aggregates ────────────────────────────────────
+
+# Mirror the GitHub CI gate: format, clippy, tests, headless engine builds.
+[group('ci')]
+ci: fmt-check clippy test build-engine-headless
+
+# Fast local pre-commit gate: format the tree, clippy, then TUI/engine tests.
+[group('ci')]
+verify: fmt clippy test
+
+# ──────────────────────────────── maintenance ────────────────────────────────────
+
+# Reclaim disk from bloated cargo target dirs. `just gc --force` also prunes target/desktop.
+[group('maint')]
+gc *ARGS:
+    ./scripts/cargo-gc.sh {{ARGS}}
+
+# Generate sample .er/ AI-review fixtures in the current repo (for testing the overlay).
+[group('maint')]
+fixtures:
+    bash scripts/generate-test-fixtures.sh
+
+# Remove all cargo build artifacts (target/, target/tui, target/desktop).
+[group('maint')]
+clean:
+    cargo clean
+    rm -rf target/tui target/desktop


### PR DESCRIPTION
## What

Adds a [`just`](https://just.systems) `justfile` at the repo root that gathers every command line behind one discoverable entrypoint. `just` (no args) prints the grouped index; `just <recipe>` runs one.

## Why

The commands were spread across `scripts/`, `.cargo/config.toml` aliases, `desktop-ui/package.json`, and the CI workflow. This pulls them into a single self-documenting place without changing how anything builds.

## Recipes (`just --list`)

| Group | Recipes |
|-------|---------|
| **run** | `run` (TUI), `dev` (desktop), `dev-ui` (Vite), `storybook` |
| **build** | `build`, `build-release`, `build-ui`, `build-engine-headless` |
| **production** | `install` (TUI binary), `build-desktop` (.app bundle) |
| **test** | `test` (TUI+engine), `test-desktop`, `test-ui`, `test-all` |
| **lint** | `fmt`, `fmt-check`, `clippy`, `check`, `check-ui`, `lint` |
| **ci** | `ci` (mirrors the GitHub gate), `verify` (fast pre-commit) |
| **maint** | `gc`, `fixtures`, `clean` |

Short aliases: `r`, `b`, `t`, `f`, `l`.

## Design

- **Delegates, doesn't duplicate.** Rust recipes call the existing `scripts/er-tui.sh` / `scripts/tauri-*.sh` / `scripts/cargo-gc.sh` wrappers, preserving the `target/tui` vs `target/desktop` split and auto cargo-gc described in AGENTS.md. The bare `cargo`/`bun` recipes match CI and `package.json` exactly.
- Extra args forward through `*ARGS` (e.g. `just run --pr 123`, `just dev --logs arena`, `just gc --force`). Env passthrough still works (`ER_DEBUG=1 just run`).
- Adds a one-line pointer in AGENTS.md so the command table references `just`.

## Validation

Built `just` 1.53 locally and confirmed the file parses (`--summary` resolves all 25 recipes), groups/aliases render in `--list`, dependency chains expand (`lint`, `ci`), arg forwarding works, and the `gc` recipe runs through its script. No source/build logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011QVDCwkRYNdRdVUtDimyZb)_