### PR TITLE
Make AI arena runs tab-independent (background runs)

### DIFF
--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -119,6 +119,8 @@ fn upstream_url_for_proxy(uri: &tauri::http::Uri, upstream_scheme: &str) -> Stri
 
 const PROXY_HTML_SIZE_LIMIT: usize = 10 * 1024 * 1024; // 10 MB
 
+// `app` is only used inside the `#[cfg(target_os = "macos")]` block below.
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 fn reveal_main_window(
     window: &tauri::WebviewWindow,
     app: &tauri::AppHandle,
@@ -149,6 +151,8 @@ fn reveal_main_window(
     Ok(())
 }
 
+// Only reachable from the macOS `Reopen` run event.
+#[cfg(target_os = "macos")]
 fn reveal_main_window_from_handle(app: &tauri::AppHandle, reason: &str) {
     match app.get_webview_window("main") {
         Some(window) => {
@@ -1552,7 +1556,7 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error building tauri application");
 
-    tauri_app.run(move |handle, event| {
+    tauri_app.run(move |_handle, event| {
         match event {
             tauri::RunEvent::ExitRequested { .. } => {
                 if let Ok(guard) = persist_app.lock() {
@@ -1572,7 +1576,7 @@ fn main() {
                 log::info!(
                     "macOS reopen event received; has_visible_windows={has_visible_windows}"
                 );
-                reveal_main_window_from_handle(handle, "macos_reopen");
+                reveal_main_window_from_handle(_handle, "macos_reopen");
             }
             _ => {}
         }

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -373,6 +373,10 @@ pub struct AppSnapshot {
     /// Recent arena runs for the active tab (newest first).
     #[serde(default)]
     pub arena_runs: Vec<ArenaRunSummaryWire>,
+    /// Active arena runs across ALL tabs (tab-independent background runs).
+    /// Lets the UI keep a run visible/controllable after switching branches.
+    #[serde(default)]
+    pub background_arena_runs: Vec<ArenaRunSummaryWire>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1774,6 +1778,7 @@ fn build_snapshot_inner(
             let branch = app.arena_branch_ref();
             app.arena_list_summaries(Some(&branch)).unwrap_or_default()
         },
+        background_arena_runs: app.background_arena_runs(),
     };
     if crate::profile_log::profile_enabled() {
         let total_lines: usize = out

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -13,6 +13,45 @@ use std::sync::Arc;
 use super::App;
 use super::TabState;
 
+/// Load a run's summary, memoized by `run.json` mtime+size.
+///
+/// `App::background_arena_runs` runs inside the desktop's per-poll
+/// `build_snapshot`, so re-reading + parsing every active run's `run.json`
+/// each tick would violate the "per-poll disk reads are mtime-cached"
+/// convention. When the file is unchanged we reuse the parsed summary after a
+/// single `stat`; a changed mtime/size (new finding, completion) re-parses.
+/// Status is intentionally not authoritative here — callers overlay the live
+/// registry status, which can lead the on-disk value.
+fn load_run_summary_cached(paths: &ArenaPaths) -> Option<crate::arena::ArenaRunSummary> {
+    type Key = Option<(std::time::SystemTime, u64)>;
+    type SummaryCache =
+        std::collections::HashMap<std::path::PathBuf, (Key, crate::arena::ArenaRunSummary)>;
+    static CACHE: std::sync::LazyLock<std::sync::Mutex<SummaryCache>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+    let json = paths.run_json();
+    let key: Key = std::fs::metadata(&json)
+        .ok()
+        .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
+
+    let mut cache = match CACHE.lock() {
+        Ok(g) => g,
+        Err(_) => return load_run(paths).ok().map(|r| r.summary()),
+    };
+    if let Some((cached_key, summary)) = cache.get(&json) {
+        if *cached_key == key {
+            return Some(summary.clone());
+        }
+    }
+    let summary = load_run(paths).ok()?.summary();
+    // Bounded: one entry per run.json path; drop everything if it grows.
+    if cache.len() > 256 {
+        cache.clear();
+    }
+    cache.insert(json, (key, summary.clone()));
+    Some(summary)
+}
+
 impl TabState {
     /// Arena uses the same diff as AI review ([`raw_diff_for_review`]); optional path filter.
     pub fn raw_diff_for_arena(
@@ -172,11 +211,15 @@ impl App {
         for run_id in self.arena_registry.active_run_ids() {
             let er_dir = self.arena_er_dir_for_run(&run_id);
             let paths = ArenaPaths::for_run(&er_dir, &run_id);
-            if let Ok(mut run) = load_run(&paths) {
+            // `build_snapshot` calls this every poll; memoize the disk read by
+            // run.json mtime so we don't re-parse each active run every tick.
+            if let Some(mut summary) = load_run_summary_cached(&paths) {
+                // Status is the registry's live value, not the (possibly older)
+                // on-disk one — overlay it after the cached disk read.
                 if let Some(live) = self.arena_registry.get_status(&run_id) {
-                    run.status = live;
+                    summary.status = live;
                 }
-                out.push(run.summary());
+                out.push(summary);
             }
         }
         out.sort_by_key(|r| std::cmp::Reverse(r.created_at.clone()));

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -595,8 +595,7 @@ mod tests {
     fn arena_override_finding_resolves_nonactive_tab() {
         let ta = tempfile::tempdir().unwrap();
         let tb = tempfile::tempdir().unwrap();
-        let mut app =
-            app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let mut app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
         let er_b = app.tabs[1].er_dir();
         let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-ov");
         crate::arena::save_run(&paths, &sample_run("arena-ov")).unwrap();

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -34,21 +34,26 @@ fn load_run_summary_cached(paths: &ArenaPaths) -> Option<crate::arena::ArenaRunS
         .ok()
         .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
 
-    let mut cache = match CACHE.lock() {
-        Ok(g) => g,
-        Err(_) => return load_run(paths).ok().map(|r| r.summary()),
-    };
-    if let Some((cached_key, summary)) = cache.get(&json) {
-        if *cached_key == key {
-            return Some(summary.clone());
+    // Fast path: reuse the cached summary if run.json is unchanged. The lock is
+    // released before the disk read below so a slow read on one run can't block
+    // the cache for the others.
+    if let Ok(cache) = CACHE.lock() {
+        if let Some((cached_key, summary)) = cache.get(&json) {
+            if *cached_key == key {
+                return Some(summary.clone());
+            }
         }
     }
+    // Slow path: parse without holding the lock, then record. A concurrent miss
+    // may parse twice (benign); the per-poll caller is single-threaded anyway.
     let summary = load_run(paths).ok()?.summary();
-    // Bounded: one entry per run.json path; drop everything if it grows.
-    if cache.len() > 256 {
-        cache.clear();
+    if let Ok(mut cache) = CACHE.lock() {
+        // Bounded: one entry per run.json path; drop everything if it grows.
+        if cache.len() > 256 {
+            cache.clear();
+        }
+        cache.insert(json, (key, summary.clone()));
     }
-    cache.insert(json, (key, summary.clone()));
     Some(summary)
 }
 
@@ -689,6 +694,68 @@ mod tests {
             app.background_arena_runs()[0].finding_count,
             2,
             "changed run.json must invalidate the mtime-keyed summary cache"
+        );
+    }
+
+    // ── Remaining mutating wrappers resolve a non-active tab's er_dir ─────
+
+    #[test]
+    fn arena_cancel_resolves_nonactive_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let mut app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-cancel");
+        crate::arena::save_run(&paths, &sample_run("arena-cancel")).unwrap();
+        app.arena_registry.insert_active_for_test(
+            "arena-cancel",
+            crate::arena::RunStatus::Running { round: 1 },
+        );
+
+        // Active tab is A; cancel must persist to B's run.json.
+        app.arena_cancel("arena-cancel").unwrap();
+        let reloaded = load_run(&paths).unwrap();
+        assert_eq!(reloaded.status, crate::arena::RunStatus::Cancelled);
+    }
+
+    #[test]
+    fn arena_delete_resolves_nonactive_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let mut app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-del");
+        crate::arena::save_run(&paths, &sample_run("arena-del")).unwrap();
+        assert!(paths.root.is_dir());
+
+        // Active tab is A; delete must remove the run dir under B.
+        app.arena_delete("arena-del").unwrap();
+        assert!(
+            !paths.root.is_dir(),
+            "delete must target the run's own er_dir, not the active tab's"
+        );
+    }
+
+    #[test]
+    fn arena_accept_findings_resolves_nonactive_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let mut app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-acc");
+        crate::arena::save_run(&paths, &sample_run("arena-acc")).unwrap();
+
+        // Active tab is A; the import must write review.json under B's er_dir.
+        app.arena_accept_findings("arena-acc", None).unwrap();
+        assert!(
+            Path::new(&er_b).join("review.json").is_file(),
+            "accept must import into the run's own er_dir, not the active tab's"
+        );
+        assert!(
+            !Path::new(&app.tabs[0].er_dir())
+                .join("review.json")
+                .is_file(),
+            "active tab A must be untouched by accepting a run that lives on B"
         );
     }
 }

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -140,13 +140,57 @@ impl App {
         Ok(run_ids)
     }
 
+    /// Resolve the storage `er_dir` for a run independent of the active tab.
+    ///
+    /// Arena supervisor threads run in the background regardless of which tab is
+    /// in view, so per-run operations must address a run by its own `er_dir`,
+    /// not `self.tab().er_dir()`. Resolution order:
+    /// (a) invert `active_arena_runs` (run_id → er_dir);
+    /// (b) scan each tab's `er_dir` for an on-disk `arena/<run_id>` dir;
+    /// (c) fall back to the active tab (covers a brand-new run before lookup).
+    fn arena_er_dir_for_run(&self, run_id: &str) -> std::path::PathBuf {
+        for (er, ids) in &self.active_arena_runs {
+            if ids.iter().any(|id| id == run_id) {
+                return std::path::PathBuf::from(er);
+            }
+        }
+        for tab in &self.tabs {
+            let er = tab.er_dir();
+            if ArenaPaths::for_run(Path::new(&er), run_id).root.is_dir() {
+                return std::path::PathBuf::from(er);
+            }
+        }
+        std::path::PathBuf::from(self.tab().er_dir())
+    }
+
+    /// Active arena runs across ALL tabs (tab-independent background runs).
+    ///
+    /// Driven by the registry's globally-tracked active run ids, so it surfaces
+    /// in-flight runs regardless of which tab is in view. Newest first.
+    pub fn background_arena_runs(&self) -> Vec<crate::arena::ArenaRunSummary> {
+        let mut out = Vec::new();
+        for run_id in self.arena_registry.active_run_ids() {
+            let er_dir = self.arena_er_dir_for_run(&run_id);
+            let paths = ArenaPaths::for_run(&er_dir, &run_id);
+            if let Ok(mut run) = load_run(&paths) {
+                if let Some(live) = self.arena_registry.get_status(&run_id) {
+                    run.status = live;
+                }
+                out.push(run.summary());
+            }
+        }
+        out.sort_by_key(|r| std::cmp::Reverse(r.created_at.clone()));
+        out
+    }
+
     pub fn arena_accept_findings(
         &mut self,
         run_id: &str,
         finding_ids: Option<Vec<String>>,
     ) -> Result<usize> {
-        let er_path = self.tab().er_dir();
-        let paths = ArenaPaths::for_run(Path::new(&er_path), run_id);
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let er_path = er_dir.to_string_lossy().into_owned();
+        let paths = ArenaPaths::for_run(&er_dir, run_id);
         let mut run = load_run(&paths)?;
         let ids = finding_ids.as_deref();
         let n = import_arena_findings_to_review(&er_path, &mut run, ids)?;
@@ -160,14 +204,14 @@ impl App {
         if !self.arena_registry.cancel(run_id) {
             anyhow::bail!("no active arena run {run_id}");
         }
-        let er_path = self.tab().er_dir();
-        let paths = ArenaPaths::for_run(Path::new(&er_path), run_id);
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let er_key = er_dir.to_string_lossy().into_owned();
+        let paths = ArenaPaths::for_run(&er_dir, run_id);
         if let Ok(mut run) = load_run(&paths) {
             run.status = crate::arena::RunStatus::Cancelled;
             run.completed_at = Some(super::chrono_now());
             let _ = crate::arena::save_run(&paths, &run);
         }
-        let er_key = self.tab().er_dir();
         if let Some(ids) = self.active_arena_runs.get_mut(&er_key) {
             ids.retain(|id| id != run_id);
             if ids.is_empty() {
@@ -192,14 +236,14 @@ impl App {
     }
 
     pub fn arena_progress(&self, run_id: &str) -> Result<ArenaProgressState> {
-        let er_path = self.tab().er_dir();
-        let paths = ArenaPaths::for_run(Path::new(&er_path), run_id);
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let paths = ArenaPaths::for_run(&er_dir, run_id);
         Ok(parse_progress_state(&paths))
     }
 
     pub fn arena_get_snapshot(&self, run_id: &str) -> Result<ArenaRunSnapshot> {
-        let er_path = self.tab().er_dir();
-        let paths = ArenaPaths::for_run(Path::new(&er_path), run_id);
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let paths = ArenaPaths::for_run(&er_dir, run_id);
         let mut run = load_run(&paths)?;
         if let Some(live) = self.arena_registry.get_status(run_id) {
             run.status = live;
@@ -238,9 +282,9 @@ impl App {
         if self.arena_registry.is_active(run_id) {
             anyhow::bail!("cannot delete active arena run {run_id}; cancel it first");
         }
-        let er_path = self.tab().er_dir();
-        let er_key = er_path.clone();
-        delete_run_dir(Path::new(&er_path), run_id)?;
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let er_key = er_dir.to_string_lossy().into_owned();
+        delete_run_dir(&er_dir, run_id)?;
         if let Some(ids) = self.active_arena_runs.get_mut(&er_key) {
             ids.retain(|id| id != run_id);
             if ids.is_empty() {
@@ -259,8 +303,8 @@ impl App {
         verdict: Verdict,
         note: String,
     ) -> Result<crate::arena::ArenaFinding> {
-        let er_path = self.tab().er_dir();
-        let paths = ArenaPaths::for_run(Path::new(&er_path), run_id);
+        let er_dir = self.arena_er_dir_for_run(run_id);
+        let paths = ArenaPaths::for_run(&er_dir, run_id);
         let mut run = load_run(&paths)?;
         let f = run
             .findings
@@ -368,5 +412,140 @@ mod tests {
             arena.contains("feature"),
             "arena should use branch-view diff"
         );
+    }
+
+    // ── Tab-independent run resolution (background runs) ──────────────────
+
+    fn app_with_two_tabs(root_a: &str, root_b: &str) -> App {
+        use crate::paths::ErRoot;
+        let mut a = TabState::new_for_test(vec![]);
+        a.er_root = ErRoot::RepoLocal(root_a.to_string());
+        a.repo_root = root_a.to_string();
+        let mut b = TabState::new_for_test(vec![]);
+        b.er_root = ErRoot::RepoLocal(root_b.to_string());
+        b.repo_root = root_b.to_string();
+        let mut app = App::new_for_test(vec![]);
+        app.tabs = vec![a, b];
+        app.active_tab = 0; // tab A is in view; runs may belong to tab B
+        app
+    }
+
+    fn sample_run(id: &str) -> crate::arena::ArenaRun {
+        use crate::ai::RiskLevel;
+        use crate::arena::{
+            ArenaConfig, ArenaFinding, ArenaRun, ArenaRunKind, CostEstimate, RunStatus,
+        };
+        use std::collections::BTreeMap;
+        ArenaRun {
+            id: id.to_string(),
+            title: None,
+            branch_ref: "feature".into(),
+            base_branch: "main".into(),
+            scope: ArenaScope::Branch,
+            diff_hash: "abc".into(),
+            created_at: "2026-06-17T00:00:00Z".into(),
+            completed_at: None,
+            status: RunStatus::Complete,
+            config: ArenaConfig {
+                reviewers: vec![ReviewerRef {
+                    provider_id: "anthropic".into(),
+                    model_id: "sonnet".into(),
+                    agent_kind: None,
+                }],
+                rounds: 3,
+                arbiter: ReviewerRef {
+                    provider_id: "anthropic".into(),
+                    model_id: "opus".into(),
+                    agent_kind: None,
+                },
+                auto_accept_threshold: 0.75,
+                scope: ArenaScope::Branch,
+                files: None,
+                run_kind: ArenaRunKind::Models,
+                agent_kind: None,
+                effort: None,
+            },
+            reviewers: vec![],
+            accepted_finding_ids: vec![],
+            findings: vec![ArenaFinding {
+                id: "f1".into(),
+                file: "src/a.rs".into(),
+                line: Some(1),
+                title: "t".into(),
+                body: "b".into(),
+                severity_by_round: BTreeMap::from([(1, RiskLevel::High)]),
+                raised_by: vec!["r1".into()],
+                verdict: Verdict::Kept,
+                confidence: 0.9,
+                rationale: "ok".into(),
+                rounds: vec![],
+                merge_candidates: vec![],
+                merged_children: vec![],
+                evidence: vec![],
+                override_: None,
+                accepted_at: None,
+            }],
+            cost_estimate: CostEstimate {
+                tokens_in: 0,
+                tokens_out: 0,
+                usd: 0.0,
+            },
+        }
+    }
+
+    #[test]
+    fn arena_er_dir_for_run_resolves_via_active_map() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let mut app =
+            app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        app.active_arena_runs
+            .entry(er_b.clone())
+            .or_default()
+            .push("arena-x".to_string());
+        assert_eq!(
+            app.arena_er_dir_for_run("arena-x"),
+            std::path::PathBuf::from(&er_b)
+        );
+    }
+
+    #[test]
+    fn arena_er_dir_for_run_falls_back_to_disk_scan() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-y");
+        std::fs::create_dir_all(&paths.root).unwrap();
+        assert_eq!(
+            app.arena_er_dir_for_run("arena-y"),
+            std::path::PathBuf::from(&er_b)
+        );
+    }
+
+    #[test]
+    fn arena_er_dir_for_run_falls_back_to_active_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_a = app.tabs[0].er_dir();
+        assert_eq!(
+            app.arena_er_dir_for_run("missing"),
+            std::path::PathBuf::from(&er_a)
+        );
+    }
+
+    #[test]
+    fn arena_get_snapshot_reads_run_from_nonactive_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-z");
+        crate::arena::save_run(&paths, &sample_run("arena-z")).unwrap();
+        // Active tab is A; before the fix this resolved A's er_dir and errored.
+        let snap = app.arena_get_snapshot("arena-z").unwrap();
+        assert_eq!(snap.run.id, "arena-z");
     }
 }

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -497,8 +497,7 @@ mod tests {
     fn arena_er_dir_for_run_resolves_via_active_map() {
         let ta = tempfile::tempdir().unwrap();
         let tb = tempfile::tempdir().unwrap();
-        let mut app =
-            app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let mut app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
         let er_b = app.tabs[1].er_dir();
         app.active_arena_runs
             .entry(er_b.clone())

--- a/crates/er-engine/src/app/state/arena.rs
+++ b/crates/er-engine/src/app/state/arena.rs
@@ -590,4 +590,106 @@ mod tests {
         let snap = app.arena_get_snapshot("arena-z").unwrap();
         assert_eq!(snap.run.id, "arena-z");
     }
+
+    #[test]
+    fn arena_override_finding_resolves_nonactive_tab() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let mut app =
+            app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "arena-ov");
+        crate::arena::save_run(&paths, &sample_run("arena-ov")).unwrap();
+
+        // Active tab is A; the mutating wrapper must still resolve B's er_dir.
+        let f = app
+            .arena_override_finding("arena-ov", "f1", Verdict::Kept, "looks fine".into())
+            .unwrap();
+        assert_eq!(f.id, "f1");
+        // The override must have been persisted under tab B's er_dir.
+        let reloaded = load_run(&paths).unwrap();
+        assert!(
+            reloaded.findings[0].override_.is_some(),
+            "override should persist to the run's own er_dir, not the active tab's"
+        );
+    }
+
+    // ── background_arena_runs (the headline tab-independent surface) ──────
+
+    #[test]
+    fn background_arena_runs_surfaces_nonactive_tab_run_with_live_status() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        // On disk the run is Complete; the registry says it is mid-flight.
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "bg-run");
+        crate::arena::save_run(&paths, &sample_run("bg-run")).unwrap();
+        app.arena_registry
+            .insert_active_for_test("bg-run", crate::arena::RunStatus::Running { round: 2 });
+
+        // Active tab is A, but the run lives under tab B.
+        let runs = app.background_arena_runs();
+        assert_eq!(runs.len(), 1, "run on a non-active tab must surface");
+        assert_eq!(runs[0].id, "bg-run");
+        assert_eq!(
+            runs[0].status,
+            crate::arena::RunStatus::Running { round: 2 },
+            "live registry status must override the (older) on-disk status"
+        );
+    }
+
+    #[test]
+    fn background_arena_runs_sorts_newest_first() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+
+        let mut older = sample_run("old");
+        older.created_at = "2026-06-17T00:00:00Z".into();
+        let mut newer = sample_run("new");
+        newer.created_at = "2026-06-17T12:00:00Z".into();
+        crate::arena::save_run(&ArenaPaths::for_run(Path::new(&er_b), "old"), &older).unwrap();
+        crate::arena::save_run(&ArenaPaths::for_run(Path::new(&er_b), "new"), &newer).unwrap();
+        app.arena_registry
+            .insert_active_for_test("old", crate::arena::RunStatus::Running { round: 1 });
+        app.arena_registry
+            .insert_active_for_test("new", crate::arena::RunStatus::Running { round: 1 });
+
+        let ids: Vec<String> = app
+            .background_arena_runs()
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        assert_eq!(ids, vec!["new".to_string(), "old".to_string()]);
+    }
+
+    #[test]
+    fn background_arena_runs_reparses_when_runjson_changes() {
+        let ta = tempfile::tempdir().unwrap();
+        let tb = tempfile::tempdir().unwrap();
+        let app = app_with_two_tabs(ta.path().to_str().unwrap(), tb.path().to_str().unwrap());
+        let er_b = app.tabs[1].er_dir();
+        let paths = ArenaPaths::for_run(Path::new(&er_b), "cache-run");
+        app.arena_registry
+            .insert_active_for_test("cache-run", crate::arena::RunStatus::Running { round: 1 });
+
+        // First read: one finding, populates the mtime cache.
+        crate::arena::save_run(&paths, &sample_run("cache-run")).unwrap();
+        assert_eq!(app.background_arena_runs()[0].finding_count, 1);
+
+        // Rewrite run.json with a second finding; the size/mtime change must
+        // invalidate the cached summary so the new count is re-parsed.
+        let mut run = sample_run("cache-run");
+        let mut second = run.findings[0].clone();
+        second.id = "f2".into();
+        run.findings.push(second);
+        crate::arena::save_run(&paths, &run).unwrap();
+        assert_eq!(
+            app.background_arena_runs()[0].finding_count,
+            2,
+            "changed run.json must invalidate the mtime-keyed summary cache"
+        );
+    }
 }

--- a/crates/er-engine/src/arena/registry.rs
+++ b/crates/er-engine/src/arena/registry.rs
@@ -153,6 +153,22 @@ impl ArenaRegistry {
             .ok()
             .is_some_and(|m| m.contains_key(run_id))
     }
+
+    /// Register a run as active with a given status, without spawning a
+    /// supervisor thread. Test-only: lets unit tests exercise the
+    /// active-run-driven paths (e.g. `App::background_arena_runs`).
+    #[cfg(test)]
+    pub fn insert_active_for_test(&self, run_id: &str, status: RunStatus) {
+        self.insert(
+            run_id.to_string(),
+            ArenaRunHandle {
+                cancel: Arc::new(AtomicBool::new(false)),
+                children: Arc::new(Mutex::new(Vec::new())),
+                status: Arc::new(Mutex::new(status)),
+                join: None,
+            },
+        );
+    }
 }
 
 pub fn new_run_id() -> String {

--- a/desktop-ui/src/lib/stores/arena.svelte.ts
+++ b/desktop-ui/src/lib/stores/arena.svelte.ts
@@ -108,7 +108,14 @@ class ArenaStore {
     return this.summaries.filter((s) => s.branch_ref === branch);
   }
 
+  /** Active arena runs across ALL tabs (tab-independent background runs). */
+  get backgroundRuns(): ArenaRunSummary[] {
+    return app.snapshot?.background_arena_runs ?? [];
+  }
+
   get hasLiveRun(): boolean {
+    // A background run on any tab keeps the indicator alive after switching branches.
+    if (this.backgroundRuns.length > 0) return true;
     const id = app.snapshot?.active_arena_run ?? this.liveRunId;
     if (!id) return false;
     const sum = this.summaries.find((s) => s.id === id);
@@ -406,7 +413,8 @@ class ArenaStore {
   }
 
   showRunningProgress() {
-    const active = app.snapshot?.active_arena_run ?? this.liveRunId;
+    const active =
+      app.snapshot?.active_arena_run ?? this.liveRunId ?? this.backgroundRuns[0]?.id ?? null;
     if (!active) return;
     this.liveRunId = active;
     this.runningOpen = true;
@@ -507,7 +515,7 @@ class ArenaStore {
 
   closeOverlay() {
     this.overlayOpen = false;
-    const active = app.snapshot?.active_arena_run;
+    const active = app.snapshot?.active_arena_run ?? this.backgroundRuns[0]?.id;
     if (active && this.hasLiveRun) {
       this.liveRunId = active;
       this.runningOpen = true;
@@ -536,7 +544,9 @@ class ArenaStore {
   }
 
   syncFromSnapshot() {
-    const active = app.snapshot?.active_arena_run ?? null;
+    // Fall back to a background run on another tab so a live run survives a branch switch.
+    const active =
+      app.snapshot?.active_arena_run ?? this.backgroundRuns[0]?.id ?? null;
     if (active === this.liveRunId) return;
 
     if (!active && this.liveRunId && (this.runningOpen || this.runningMinimized)) {

--- a/desktop-ui/src/lib/stores/arena.svelte.ts
+++ b/desktop-ui/src/lib/stores/arena.svelte.ts
@@ -114,8 +114,11 @@ class ArenaStore {
   }
 
   get hasLiveRun(): boolean {
-    // A background run on any tab keeps the indicator alive after switching branches.
-    if (this.backgroundRuns.length > 0) return true;
+    // A background run on any tab keeps the indicator alive after switching
+    // branches — but only while it is genuinely active. Gating on status
+    // (rather than list length) avoids a stale indicator in the brief window
+    // where a run is Complete on disk but not yet pruned from active_run_ids().
+    if (this.backgroundRuns.some((s) => isArenaRunActive(s.status))) return true;
     const id = app.snapshot?.active_arena_run ?? this.liveRunId;
     if (!id) return false;
     const sum = this.summaries.find((s) => s.id === id);

--- a/desktop-ui/src/lib/stores/arena.svelte.ts
+++ b/desktop-ui/src/lib/stores/arena.svelte.ts
@@ -515,7 +515,10 @@ class ArenaStore {
 
   closeOverlay() {
     this.overlayOpen = false;
-    const active = app.snapshot?.active_arena_run ?? this.backgroundRuns[0]?.id;
+    const active =
+      app.snapshot?.active_arena_run ??
+      this.liveRunId ??
+      this.backgroundRuns[0]?.id;
     if (active && this.hasLiveRun) {
       this.liveRunId = active;
       this.runningOpen = true;
@@ -544,9 +547,15 @@ class ArenaStore {
   }
 
   syncFromSnapshot() {
-    // Fall back to a background run on another tab so a live run survives a branch switch.
+    // Prefer the run we're already tracking; only adopt a background run on
+    // another tab when nothing is tracked yet (keeps a live run visible across
+    // a branch switch without hijacking it to the newest run when several run
+    // concurrently).
     const active =
-      app.snapshot?.active_arena_run ?? this.backgroundRuns[0]?.id ?? null;
+      app.snapshot?.active_arena_run ??
+      this.liveRunId ??
+      this.backgroundRuns[0]?.id ??
+      null;
     if (active === this.liveRunId) return;
 
     if (!active && this.liveRunId && (this.runningOpen || this.runningMinimized)) {

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -400,6 +400,8 @@ export interface AppSnapshot {
   arena_enabled?: boolean;
   active_arena_run?: string | null;
   arena_runs?: import("./types/arena").ArenaRunSummary[];
+  /** Active arena runs across all tabs (tab-independent background runs). */
+  background_arena_runs?: import("./types/arena").ArenaRunSummary[];
 }
 
 export interface InboxTargetSnapshot {


### PR DESCRIPTION
## Problem

An AI arena run could only be tracked while its branch/tab stayed in view. Switching to another tab/branch froze the live-run panel and made the run appear abandoned.

**Root cause:** The arena supervisor thread already runs in the background independent of the active tab — but every *per-run* `App` method resolved the run's storage directory from `self.tab().er_dir()` (the **active** tab). After switching tabs, `er_dir()` differs, so `arena_get` / `arena_progress` read the wrong path and errored out. The run kept running; we just lost the ability to address and display it. The snapshot's `active_arena_run` / `arena_runs` were also active-tab scoped, so the indicator disappeared on other tabs.

## Fix

**Backend (`er-engine`)**
- New `App::arena_er_dir_for_run(run_id)` resolves a run's `er_dir` independent of the active tab: (a) invert `active_arena_runs`, (b) scan each tab's on-disk `arena/<run_id>` dir, (c) fall back to the active tab.
- Routed `arena_progress`, `arena_get_snapshot`, `arena_accept_findings`, `arena_cancel`, `arena_delete`, `arena_override_finding` through it. `arena_cancel`/`arena_delete` now also clean `active_arena_runs` under the **resolved** key (previously keyed on the active tab, leaking stale entries).
- New `App::background_arena_runs()` — registry-driven (`active_run_ids()`), lists active runs across all tabs, newest first.

**Desktop (`er-desktop`)**
- New `background_arena_runs` field on the snapshot, populated from `App::background_arena_runs()` (reuses `ArenaRunSummaryWire`).

**Frontend (`desktop-ui`)**
- `arena` store exposes `backgroundRuns`; the live-run indicator/panel now stays alive and re-openable across branch switches (`hasLiveRun`, `syncFromSnapshot`, `showRunningProgress`, `closeOverlay`).

## Tests
Added resolution-precedence tests (active map → disk scan → active-tab fallback) and a regression test that `arena_get_snapshot` reads a run saved under a non-active tab. `cargo test -p er-engine arena_` passes; `cargo clippy -p er-engine` is clean.

> **Note:** `er-desktop` (Tauri/GTK) and `svelte-check` could not be compiled/run in the CI sandbox (missing `gdk-3.0` system libs; a vite/svelte-check version incompatibility hitting all files identically). The desktop change is a single additive snapshot field of an existing wire type, and the TS edits were verified against the `ArenaRunSummary` type. Worth a local `cargo build -p er-desktop` + `pnpm --dir desktop-ui check` before merge.

## Out of scope
Investigated arena runtime performance per request: it's LLM-latency bound (4 sequential model inferences deep — 3 rounds + arbiter; reviewers within a round already run in parallel), with no orchestration low-hanging fruit. Real levers (fewer rounds, faster arbiter, effort tuning, speculative execution) are deferred to a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBCFroc2m6mfSds1wWxdHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBCFroc2m6mfSds1wWxdHQ)_