### PR TITLE
docs: add product visuals + landing-page Guide & AI Arena

### DIFF
--- a/docs/guide/ai-review.html
+++ b/docs/guide/ai-review.html
@@ -54,6 +54,63 @@
     <p>Findings render as inline banners attached to the relevant lines, color-coded by the agent that produced them.
     See <a href="storage.html">Review Storage</a> for the complete file list and where it lives on disk.</p>
 
+    <figure class="fig">
+      <div class="shot">
+        <div class="chrome">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">er — AI review</span>
+          <span class="right c-orange">⚠ 3 findings</span>
+        </div>
+        <div class="body">
+          <div class="diff">
+            <div class="dhead"><span>src/auth/token.rs</span><span class="c-muted">v · AI view ON</span></div>
+            <div class="code">
+              <div class="dl del"><span class="ln">14</span><span class="tx c-red">−   fn verify(t: Token) -&gt; bool {</span></div>
+              <div class="dl add"><span class="ln">14</span><span class="tx c-green">+   async fn verify(t: Token) -&gt; Result&lt;()&gt; {</span></div>
+              <div class="card ai">
+                <div class="hd"><span class="c-orange">⚠ Security</span><span class="c-muted">P0 · high</span></div>
+                <div class="c-dim">Expiry is never checked — an expired token still verifies.</div>
+              </div>
+              <div class="dl add"><span class="ln">15</span><span class="tx c-green">+       self.store.save(&t).await?;</span></div>
+              <div class="card ai">
+                <div class="hd"><span class="c-orange">⚠ Performance</span><span class="c-muted">P2 · low</span></div>
+                <div class="c-dim">Blocking store write on the hot path — consider batching.</div>
+              </div>
+              <div class="dl"><span class="ln">16</span><span class="tx c-muted">        Ok(())</span></div>
+              <div class="card ai">
+                <div class="hd"><span class="c-blue">🎓 Professor</span><span class="c-muted">teaching</span></div>
+                <div class="c-dim"><code>Result&lt;()&gt;</code> lets the caller decide how to handle failure — see the error-handling chapter.</div>
+              </div>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="grp">
+              <div class="t">AI summary</div>
+              <div class="c-dim">Risk · <span class="c-red bold">High</span></div>
+              <div class="bar"><i style="width:84%;background:var(--red)"></i></div>
+            </div>
+            <div class="grp">
+              <div class="t">Findings · 3</div>
+              <div class="row"><span class="c-red">●</span><span class="c-dim">1 · P0 high</span></div>
+              <div class="row"><span class="c-yellow">●</span><span class="c-dim">1 · P2 low</span></div>
+              <div class="row"><span class="c-blue">●</span><span class="c-dim">1 · professor</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Experts run</div>
+              <div class="row"><span class="chip c-red">security</span><span class="chip c-blue">performance</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Checklist</div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">Error handling</span></div>
+              <div class="row"><span class="c-muted">○</span><span class="c-muted">Token expiry</span></div>
+              <div class="row"><span class="c-muted">○</span><span class="c-muted">Tests</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <figcaption>Findings appear as inline banners on the lines they touch — color-coded by agent (Security/Performance in orange, <strong>Professor</strong> in blue) — beside an AI summary panel with the risk rating, finding counts, and checklist. Press <kbd>v</kbd> to dial how much of this is shown.</figcaption>
+    </figure>
+
     <h2>Severity model</h2>
     <p>All the review skills share one severity scale and a “what not to flag” list:</p>
     <table>

--- a/docs/guide/assets/docs.css
+++ b/docs/guide/assets/docs.css
@@ -438,3 +438,301 @@ kbd {
   }
   .content { margin-left: 0; padding: 2rem 1.25rem 4rem; max-width: 100%; }
 }
+
+/* ============================================================
+   Product figures — CSS-rendered TUI / desktop mockups
+   Faithful to the er UI in the Graphite (dark) theme. No images,
+   no build step — every figure is markup over these tokens.
+   ============================================================ */
+.fig { margin: 1.8rem 0; }
+.fig figcaption {
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+.fig figcaption strong, .fig figcaption b { color: var(--text-dim); font-weight: 600; }
+.fig figcaption code {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.04em 0.32em;
+  font-size: 0.85em;
+  color: var(--cyan);
+}
+
+/* ── Window frame ─────────────────────────────────────────── */
+.shot {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  box-shadow: 0 14px 44px -18px rgba(0, 0, 0, 0.75);
+}
+.shot .chrome {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.shot .chrome .dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.shot .chrome .dot.r { background: rgba(248, 113, 113, 0.65); }
+.shot .chrome .dot.y { background: rgba(250, 204, 21, 0.65); }
+.shot .chrome .dot.g { background: rgba(74, 222, 128, 0.65); }
+.shot .chrome .ttl { margin-left: 0.5rem; color: var(--text-muted); font-size: 0.68rem; }
+.shot .chrome .right { margin-left: auto; font-size: 0.68rem; }
+
+/* ── er top bar (mode tabs + status) ──────────────────────── */
+/* Note: named .erbar (not .topbar) to avoid colliding with the
+   site chrome's fixed .topbar, which would yank it to page top. */
+.shot .erbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.35rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(26, 26, 36, 0.45);
+  flex-wrap: wrap;
+}
+.shot .modes { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.shot .mode { color: var(--text-muted); }
+.shot .mode.on {
+  color: var(--accent);
+  background: rgba(167, 139, 250, 0.14);
+  border: 1px solid rgba(167, 139, 250, 0.28);
+  border-radius: 4px;
+  padding: 0 0.4rem;
+}
+.shot .stat { display: flex; align-items: center; gap: 0.7rem; }
+
+/* ── Body columns ─────────────────────────────────────────── */
+.shot .body { display: flex; align-items: stretch; }
+.shot .tree { width: 12.5rem; flex-shrink: 0; border-right: 1px solid var(--border); padding: 0.55rem 0.5rem; }
+.shot .diff { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.shot .panel { width: 13rem; flex-shrink: 0; border-left: 1px solid var(--border); padding: 0.6rem 0.7rem; }
+
+.shot .lbl {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+.shot .meta-foot { margin-top: 0.6rem; padding-top: 0.45rem; border-top: 1px solid var(--border); color: var(--text-muted); }
+
+/* ── File rows ────────────────────────────────────────────── */
+.shot .f {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.14rem 0.4rem;
+  border-radius: 4px;
+  color: var(--text-dim);
+}
+.shot .f.sel { background: rgba(167, 139, 250, 0.12); color: var(--accent); }
+.shot .f .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shot .f .b { margin-left: auto; flex-shrink: 0; }
+.shot .f .b + .b { margin-left: 0; }
+
+/* ── Color helpers (scoped to figures) ────────────────────── */
+.shot .c-green  { color: var(--green); }
+.shot .c-red    { color: var(--red); }
+.shot .c-yellow { color: var(--yellow); }
+.shot .c-cyan   { color: var(--cyan); }
+.shot .c-blue   { color: var(--blue); }
+.shot .c-accent { color: var(--accent); }
+.shot .c-orange { color: var(--orange); }
+.shot .c-muted  { color: var(--text-muted); }
+.shot .c-dim    { color: var(--text-dim); }
+.shot .c-txt    { color: var(--text); }
+.shot .bold     { font-weight: 700; }
+
+/* ── Diff lines ───────────────────────────────────────────── */
+.shot .dhead {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.3rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  background: rgba(26, 26, 36, 0.3);
+}
+.shot .code { padding: 0.3rem 0; overflow: hidden; }
+.shot .dl { display: flex; padding: 0.03rem 0.7rem; white-space: pre; overflow: hidden; }
+.shot .dl .ln {
+  width: 1.7rem;
+  text-align: right;
+  margin-right: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.5;
+  user-select: none;
+  flex-shrink: 0;
+}
+.shot .dl .tx { overflow: hidden; text-overflow: ellipsis; }
+.shot .dl.add { background: rgba(74, 222, 128, 0.09); }
+.shot .dl.del { background: rgba(248, 113, 113, 0.09); }
+.shot .dl.hunk { color: var(--blue); background: rgba(96, 165, 250, 0.07); font-weight: 600; }
+
+/* ── Inline comment / finding cards ───────────────────────── */
+/* Reset the site's .card (full border, hover lift) before styling. */
+.shot .card {
+  margin: 0.2rem 0.7rem;
+  padding: 0.3rem 0.5rem;
+  border: 0;
+  border-radius: 0 5px 5px 0;
+  background: transparent;
+  transition: none;
+}
+.shot .card:hover { transform: none; }
+.shot .card .hd { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.1rem; }
+.shot .card .reply { color: var(--text-muted); font-size: 0.66rem; margin-top: 0.18rem; }
+.shot .card.gh { background: rgba(34, 211, 238, 0.06); border-left: 2px solid var(--cyan); }
+.shot .card.q  { background: rgba(250, 204, 21, 0.06); border-left: 2px solid var(--yellow); }
+.shot .card.ai { background: rgba(209, 134, 22, 0.08); border-left: 2px solid var(--orange); }
+.shot .card.stale { opacity: 0.42; }
+
+/* ── Bottom hint bar ──────────────────────────────────────── */
+.shot .bottom {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.32rem 0.7rem;
+  border-top: 1px solid var(--border);
+  background: rgba(26, 26, 36, 0.7);
+  color: var(--text-dim);
+}
+.shot .bottom b { color: var(--text); font-weight: 500; }
+.shot .bottom .sep { color: var(--text-muted); }
+
+/* ── Right panel widgets ──────────────────────────────────── */
+.shot .grp { margin-bottom: 0.7rem; }
+.shot .grp .t {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.6rem;
+  margin-bottom: 0.28rem;
+}
+.shot .grp .row { display: flex; gap: 0.4rem; align-items: center; }
+.shot .bar { height: 4px; background: var(--border); border-radius: 999px; overflow: hidden; margin-top: 0.28rem; }
+.shot .bar > i { display: block; height: 100%; border-radius: 999px; }
+.shot .chip {
+  display: inline-block;
+  padding: 0 0.4rem;
+  border-radius: 4px;
+  font-size: 0.64rem;
+  border: 1px solid var(--border);
+}
+
+/* ── Desktop variant: tab strip + split diff ──────────────── */
+.shot .tabstrip {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.35rem 0.5rem 0;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.shot .tab {
+  padding: 0.25rem 0.65rem;
+  border-radius: 6px 6px 0 0;
+  color: var(--text-dim);
+  border: 1px solid transparent;
+  border-bottom: none;
+  font-size: 0.66rem;
+}
+.shot .tab.on { background: var(--surface); color: var(--text); border-color: var(--border); }
+.shot .ctxbar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.shot .toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.shot .toggle span { padding: 0.05rem 0.5rem; color: var(--text-dim); }
+.shot .toggle span.on { background: rgba(167, 139, 250, 0.16); color: var(--accent); }
+.shot .split { display: flex; }
+.shot .split > .col { flex: 1; min-width: 0; }
+.shot .split > .col + .col { border-left: 1px solid var(--border); }
+
+/* word-diff token highlight */
+.shot .w-add { background: rgba(74, 222, 128, 0.28); border-radius: 2px; }
+.shot .w-del { background: rgba(248, 113, 113, 0.28); border-radius: 2px; }
+
+/* ── Arena funnel diagram ─────────────────────────────────── */
+.arena {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  padding: 1.1rem 1rem;
+  font-family: var(--mono);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow-x: auto;
+}
+.arena .stage {
+  flex: 1;
+  min-width: 8rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 0.5rem;
+}
+.arena .stage .n {
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+}
+.arena .stage .k {
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-top: 0.3rem;
+}
+.arena .stage .sub { font-size: 0.66rem; color: var(--text-dim); margin-top: 0.4rem; line-height: 1.4; }
+.arena .arrow {
+  align-self: center;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  padding: 0 0.1rem;
+}
+.arena .pill-row { display: flex; flex-wrap: wrap; gap: 0.25rem; justify-content: center; margin-top: 0.45rem; }
+.arena .ag {
+  font-size: 0.6rem;
+  padding: 0.02rem 0.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.arena .ag.sec { color: var(--red); border-color: rgba(248,113,113,0.4); }
+.arena .ag.perf { color: var(--blue); border-color: rgba(96,165,250,0.4); }
+.arena .ag.test { color: var(--green); border-color: rgba(74,222,128,0.4); }
+.arena .ag.rel { color: var(--cyan); border-color: rgba(34,211,238,0.4); }
+
+/* ── Figure responsiveness ────────────────────────────────── */
+@media (max-width: 820px) {
+  .shot .panel { display: none; }
+}
+@media (max-width: 600px) {
+  .shot .tree { width: 9rem; }
+  .shot { font-size: 0.66rem; }
+  .arena { flex-direction: column; gap: 0.4rem; }
+  .arena .arrow { transform: rotate(90deg); }
+}

--- a/docs/guide/comments.html
+++ b/docs/guide/comments.html
@@ -55,6 +55,44 @@
       where the code is.
     </p>
 
+    <figure class="fig">
+      <div class="shot">
+        <div class="chrome">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">src/auth/login.rs</span>
+          <span class="right c-cyan">💬 3</span>
+        </div>
+        <div class="diff">
+          <div class="code">
+            <div class="dl add"><span class="ln">22</span><span class="tx c-green">+       let token = self.issue_token(&user)?;</span></div>
+            <div class="card gh">
+              <div class="hd"><span class="c-cyan">💬 @reviewer</span><span class="c-muted">GitHub · 1h ago</span></div>
+              <div class="c-dim">Should we validate the token format before issuing?</div>
+              <div class="reply">↳ @author: good call — added a format check in the next commit</div>
+            </div>
+            <div class="dl add"><span class="ln">23</span><span class="tx c-green">+       let session = Session::new(user, token);</span></div>
+            <div class="card q">
+              <div class="hd"><span class="c-yellow">? private question</span><span class="c-muted">local only</span></div>
+              <div class="c-dim">What happens if the token expires mid-session?</div>
+            </div>
+            <div class="dl add"><span class="ln">24</span><span class="tx c-green">+       self.store.save(&session).await?;</span></div>
+            <div class="card gh stale">
+              <div class="hd"><span class="c-cyan">💬 @bob</span><span class="c-yellow">⚠ stale</span></div>
+              <div class="c-dim">Line moved — this comment may be misplaced.</div>
+            </div>
+          </div>
+          <div class="bottom">
+            <span><b>c</b>/<b>C</b> GitHub comment</span><span class="sep">·</span>
+            <span><b>q</b>/<b>Q</b> question</span><span class="sep">·</span>
+            <span><b>r</b> reply</span><span class="sep">·</span>
+            <span><b>d</b> delete</span><span class="sep">·</span>
+            <span><b>Tab</b> focus comments</span>
+          </div>
+        </div>
+      </div>
+      <figcaption>Two streams, never confused: <span style="color:var(--cyan)">cyan</span> GitHub comments (with single-level replies) sync to the PR, while <span style="color:var(--yellow)">yellow</span> private questions stay local for your AI. A comment whose target line vanished is dimmed and marked <strong>stale</strong>.</figcaption>
+    </figure>
+
     <h2>Comment focus mode</h2>
     <p>
       To act on existing notes rather than the diff, enter <strong>comment focus mode</strong> with <kbd>Tab</kbd>. Now

--- a/docs/guide/desktop-features.html
+++ b/docs/guide/desktop-features.html
@@ -35,6 +35,42 @@
       The arena runs multiple AI reviewers over the same diff and reconciles their findings — think of it as a panel of
       reviewers rather than a single pass.
     </p>
+
+    <figure class="fig">
+      <div class="arena">
+        <div class="stage">
+          <div class="n c-cyan">14</div>
+          <div class="k">Proposed</div>
+          <div class="sub">findings from<br>4 reviewers</div>
+          <div class="pill-row">
+            <span class="ag sec">Security</span>
+            <span class="ag perf">Performance</span>
+            <span class="ag test">Testing</span>
+            <span class="ag rel">Reliability</span>
+          </div>
+        </div>
+        <div class="arrow">→</div>
+        <div class="stage">
+          <div class="n c-yellow">11</div>
+          <div class="k">Challenged</div>
+          <div class="sub">fresh skeptics<br>try to refute</div>
+        </div>
+        <div class="arrow">→</div>
+        <div class="stage">
+          <div class="n c-accent">R2</div>
+          <div class="k">Arbiter</div>
+          <div class="sub">rules each:<br>keep · drop · merge</div>
+        </div>
+        <div class="arrow">→</div>
+        <div class="stage">
+          <div class="n c-green">6</div>
+          <div class="k">Final</div>
+          <div class="sub"><span class="c-green">6 kept</span> · <span class="c-muted">8 dropped</span></div>
+        </div>
+      </div>
+      <figcaption>The arena <strong>funnel</strong>: reviewers propose findings, fresh same-lens skeptics try to refute them across rounds, and an arbiter rules each one kept, dropped, or merged. The desktop app also renders a <em>bracket</em> of how verdicts flowed and a <em>matrix</em> of reviewers against findings.</figcaption>
+    </figure>
+
     <ul>
       <li><strong>Configure a run</strong> — pick reviewers (models and/or specialized agents like Security, Performance,
       Testing), choose a scope (full branch, unstaged, staged, or selected files), set the number of rounds, and pick an

--- a/docs/guide/desktop.html
+++ b/docs/guide/desktop.html
@@ -35,6 +35,75 @@
 
     <h2>The layout</h2>
     <p>The window is organized into several regions:</p>
+
+    <figure class="fig">
+      <div class="shot">
+        <div class="tabstrip">
+          <span class="tab">er-engine</span>
+          <span class="tab on">er-tui · feat/auth</span>
+          <span class="tab c-blue">PR #42</span>
+        </div>
+        <div class="ctxbar">
+          <span class="c-accent bold">feat/auth-refactor</span>
+          <span class="c-muted">→ main</span>
+          <span class="c-yellow">+42 −8</span>
+          <span style="margin-left:auto"></span>
+          <span class="toggle"><span class="on">Local Branch</span><span>PR Diff</span></span>
+          <span class="toggle"><span class="on">Split</span><span>Unified</span></span>
+        </div>
+        <div class="body">
+          <div class="tree">
+            <div class="lbl">Files · 7</div>
+            <div class="f sel"><span class="c-red">●</span><span class="nm">auth/login.rs</span><span class="b c-orange">⚠1</span></div>
+            <div class="f"><span class="c-yellow">●</span><span class="nm">api/handler.rs</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">ui/panel.rs</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">config.rs</span><span class="b c-cyan">💬1</span></div>
+          </div>
+          <div class="diff">
+            <div class="dhead"><span>src/auth/login.rs · side-by-side</span><span class="c-muted">word diff</span></div>
+            <div class="split">
+              <div class="col code">
+                <div class="dl del"><span class="ln">20</span><span class="tx c-red">pub fn <span class="w-del">login</span>(self, <span class="w-del">user: &str</span>)</span></div>
+                <div class="dl"><span class="ln">21</span><span class="tx c-muted">  self.check(user)</span></div>
+              </div>
+              <div class="col code">
+                <div class="dl add"><span class="ln">20</span><span class="tx c-green">pub <span class="w-add">async</span> fn <span class="w-add">login</span>(self, <span class="w-add">creds: Credentials</span>)</span></div>
+                <div class="dl"><span class="ln">21</span><span class="tx c-muted">  self.check(creds).await</span></div>
+              </div>
+            </div>
+            <div class="code" style="border-top:1px solid var(--border)">
+              <div class="card ai">
+                <div class="hd"><span class="c-orange">⚠ Security</span><span class="c-muted">inline thread · Ask AI ↗</span></div>
+                <div class="c-dim">Token TTL not checked — promote to GitHub?</div>
+              </div>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="grp">
+              <div class="row"><span class="chip c-accent">Branch</span><span class="chip">Review</span><span class="chip">Notes</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">CI checks</div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">Build · Tests</span></div>
+              <div class="row"><span class="c-yellow">⟳</span><span class="c-dim">Deploy</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Arena · last run</div>
+              <div class="row"><span class="c-green">6 kept</span><span class="c-muted">/ 14</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="bottom">
+          <span><b>⌘K</b> commands</span><span class="sep">·</span>
+          <span><b>⌘A</b> AI hub</span><span class="sep">·</span>
+          <span><b>⌘F</b> find usages</span><span class="sep">·</span>
+          <span><b>d</b> split ↔ unified</span><span class="sep">·</span>
+          <span><b>⌘T</b> terminal drawer</span>
+        </div>
+      </div>
+      <figcaption>The desktop app — persistent tabs, a branch context bar with a Local&nbsp;↔&nbsp;PR toggle, a side-by-side split diff with intra-line <span style="color:var(--green)">word-diff</span> highlighting, inline AI threads with “Ask AI” / “promote to GitHub”, and a three-tab right panel (Branch · Review · Notes).</figcaption>
+    </figure>
+
     <table>
       <thead><tr><th>Region</th><th>Purpose</th></tr></thead>
       <tbody>

--- a/docs/guide/diff-modes.html
+++ b/docs/guide/diff-modes.html
@@ -17,6 +17,34 @@
       branch context bar.
     </p>
 
+    <figure class="fig">
+      <div class="shot">
+        <div class="chrome">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">er — diff modes</span>
+        </div>
+        <div class="erbar">
+          <div class="modes">
+            <span class="c-accent bold">er</span><span class="c-muted">·</span>
+            <span class="mode on">1 Branch</span>
+            <span class="mode">2 Unstaged</span>
+            <span class="mode">3 Staged</span>
+            <span class="mode">4 History</span>
+            <span class="mode">5 Conflicts</span>
+            <span class="mode">6 Hidden</span>
+            <span class="c-muted">·</span><span class="c-blue">PR #42</span>
+          </div>
+          <div class="stat"><span class="c-green">● WATCH</span></div>
+        </div>
+        <div class="bottom">
+          <span><b>1</b>–<b>6</b> switch mode</span><span class="sep">·</span>
+          <span><b>Shift+R</b> sort by recency</span><span class="sep">·</span>
+          <span class="c-muted">enabled modes are numbered in order — disabling one closes the gap</span>
+        </div>
+      </div>
+      <figcaption>The mode bar lives along the top. The active mode (<strong>1 Branch</strong>) is highlighted; a detected pull request appears to the right. Press a number to switch instantly.</figcaption>
+    </figure>
+
     <h2>The six modes at a glance</h2>
     <table>
       <thead><tr><th>Key</th><th>Mode</th><th>Shows</th></tr></thead>

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -18,6 +18,86 @@
       terminal UI or a full desktop application.
     </p>
 
+    <figure class="fig">
+      <div class="shot">
+        <div class="chrome">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">er — easy-review</span>
+          <span class="right c-green">● WATCH</span>
+        </div>
+        <div class="erbar">
+          <div class="modes">
+            <span class="c-accent bold">er</span><span class="c-muted">·</span>
+            <span class="mode on">1 Branch</span>
+            <span class="mode">2 Unstaged</span>
+            <span class="mode">3 Staged</span>
+            <span class="mode">4 History</span>
+            <span class="c-muted">·</span><span class="c-blue">PR #42</span>
+            <span class="c-green">✓3</span><span class="c-red">✗1</span>
+          </div>
+          <div class="stat"><span class="c-cyan">💬 4</span><span class="c-orange">⚠ 3</span></div>
+        </div>
+        <div class="body">
+          <div class="tree">
+            <div class="lbl">Files · 7</div>
+            <div class="f sel"><span class="c-red">●</span><span class="nm">src/auth/login.rs</span><span class="b c-orange">⚠1</span><span class="b c-cyan">💬2</span></div>
+            <div class="f"><span class="c-yellow">●</span><span class="nm">src/api/handler.rs</span><span class="b c-orange">⚠1</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">src/ui/panel.rs</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">src/config.rs</span><span class="b c-cyan">💬1</span></div>
+            <div class="f"><span class="c-muted">·</span><span class="nm c-muted">Cargo.toml</span></div>
+            <div class="meta-foot">Reviewed: <span class="c-green">1</span>/7</div>
+          </div>
+          <div class="diff">
+            <div class="dhead"><span>src/auth/login.rs</span><span class="c-yellow">+42 −8</span></div>
+            <div class="code">
+              <div class="dl hunk"><span class="ln">@@</span><span class="tx">@@ -20,6 +20,18 @@ impl AuthService {</span></div>
+              <div class="dl del"><span class="ln">20</span><span class="tx c-red">−   pub fn login(&self, user: &str) -&gt; bool {</span></div>
+              <div class="dl add"><span class="ln">20</span><span class="tx c-green">+   pub async fn login(&self, creds: Credentials) -&gt; Result&lt;Session&gt; {</span></div>
+              <div class="dl add"><span class="ln">21</span><span class="tx c-green">+       let user = self.validate(&creds).await?;</span></div>
+              <div class="card gh">
+                <div class="hd"><span class="c-cyan">💬 @reviewer</span><span class="c-muted">2h ago</span></div>
+                <div class="c-dim">Validate token format before issuing?</div>
+                <div class="reply">↳ @author: added a format check</div>
+              </div>
+              <div class="dl add"><span class="ln">22</span><span class="tx c-green">+       let token = self.issue_token(&user)?;</span></div>
+              <div class="card ai">
+                <div class="hd"><span class="c-orange">⚠ Security</span><span class="c-muted">AI finding · P1</span></div>
+                <div class="c-dim">Token TTL not checked — expired tokens still validate.</div>
+              </div>
+              <div class="dl add"><span class="ln">23</span><span class="tx c-green">+       Ok(Session::new(user, token))</span></div>
+            </div>
+            <div class="bottom">
+              <span><b>j/k</b> files</span><span class="sep">·</span>
+              <span><b>n/N</b> hunks</span><span class="sep">·</span>
+              <span><b>c</b> comment</span><span class="sep">·</span>
+              <span><b>q</b> question</span><span class="sep">·</span>
+              <span><b>v</b> AI view</span><span class="sep">·</span>
+              <span><b>U</b> next unreviewed</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="grp">
+              <div class="t">AI summary</div>
+              <div class="c-dim">Risk · <span class="c-yellow bold">Medium</span></div>
+              <div class="bar"><i class="c-yellow" style="width:62%;background:var(--yellow)"></i></div>
+            </div>
+            <div class="grp">
+              <div class="t">Findings · 3</div>
+              <div class="row"><span class="c-red">●</span><span class="c-dim">1 high</span></div>
+              <div class="row"><span class="c-yellow">●</span><span class="c-dim">2 medium</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Checklist</div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">Error handling</span></div>
+              <div class="row"><span class="c-muted">○</span><span class="c-muted">Auth flow</span></div>
+              <div class="row"><span class="c-muted">○</span><span class="c-muted">Tests</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <figcaption>One screen, the whole review: diff modes, file list with risk dots, a syntax-highlighted diff with inline comments and AI findings, and a live PR/AI panel — updating as your assistant writes code.</figcaption>
+    </figure>
+
     <div class="callout note">
       <span class="ico">◆</span>
       <div>

--- a/docs/guide/tui.html
+++ b/docs/guide/tui.html
@@ -43,6 +43,108 @@ er --filter '*.rs'                        <span class="cmt"># pre-filter the fil
 
     <h2>The layout</h2>
     <p>The screen has a top bar, three columns, and a bottom bar.</p>
+
+    <figure class="fig">
+      <div class="shot">
+        <div class="chrome">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="ttl">er — easy-review · feat/auth-refactor</span>
+          <span class="right c-green">● WATCH</span>
+        </div>
+        <div class="erbar">
+          <div class="modes">
+            <span class="c-accent bold">er</span>
+            <span class="c-muted">·</span>
+            <span class="mode on">1 Branch</span>
+            <span class="mode">2 Unstaged</span>
+            <span class="mode">3 Staged</span>
+            <span class="mode">4 History</span>
+            <span class="c-muted">·</span>
+            <span class="c-blue">PR #42</span>
+            <span class="c-green">✓3</span><span class="c-red">✗1</span>
+          </div>
+          <div class="stat">
+            <span class="c-cyan">💬 4</span>
+            <span class="c-orange">⚠ 3</span>
+          </div>
+        </div>
+        <div class="body">
+          <div class="tree">
+            <div class="lbl">Files · 7</div>
+            <div class="f sel"><span class="c-red">●</span><span class="nm">src/auth/login.rs</span><span class="b c-orange">⚠1</span><span class="b c-cyan">💬2</span></div>
+            <div class="f"><span class="c-yellow">●</span><span class="nm">src/api/handler.rs</span><span class="b c-orange">⚠1</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">src/ui/panel.rs</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">src/config.rs</span><span class="b c-cyan">💬1</span></div>
+            <div class="f"><span class="c-green">●</span><span class="nm">src/github.rs</span></div>
+            <div class="f"><span class="c-muted">·</span><span class="nm c-muted">Cargo.toml</span></div>
+            <div class="f"><span class="c-muted">·</span><span class="nm c-muted">src/auth/legacy.rs</span></div>
+            <div class="meta-foot">Reviewed: <span class="c-green">1</span>/7</div>
+          </div>
+          <div class="diff">
+            <div class="dhead"><span>src/auth/login.rs</span><span class="c-yellow">+42 −8</span></div>
+            <div class="code">
+              <div class="dl"><span class="ln">18</span><span class="tx"><span class="c-blue">use</span> crate::config::AuthConfig;</span></div>
+              <div class="dl hunk"><span class="ln">@@</span><span class="tx">@@ -20,6 +20,18 @@ impl AuthService {</span></div>
+              <div class="dl del"><span class="ln">20</span><span class="tx c-red">−   pub fn login(&self, user: &str) -&gt; bool {</span></div>
+              <div class="dl add"><span class="ln">20</span><span class="tx c-green">+   pub async fn login(&self, creds: Credentials) -&gt; Result&lt;Session&gt; {</span></div>
+              <div class="dl add"><span class="ln">21</span><span class="tx c-green">+       let user = self.validate(&creds).await?;</span></div>
+              <div class="card gh">
+                <div class="hd"><span class="c-cyan">💬 @reviewer</span><span class="c-muted">2h ago</span></div>
+                <div class="c-dim">Should this validate the token format before issuing?</div>
+                <div class="reply">↳ @author: Good point — added a format check</div>
+              </div>
+              <div class="dl add"><span class="ln">22</span><span class="tx c-green">+       let token = self.issue_token(&user)?;</span></div>
+              <div class="card ai">
+                <div class="hd"><span class="c-orange">⚠ Security</span><span class="c-muted">AI finding · P1</span></div>
+                <div class="c-dim">Token TTL not checked — expired tokens still validate.</div>
+              </div>
+              <div class="dl add"><span class="ln">23</span><span class="tx c-green">+       Ok(Session::new(user, token))</span></div>
+              <div class="card q">
+                <div class="hd"><span class="c-yellow">? private question</span></div>
+                <div class="c-dim">What happens if the store write fails mid-session?</div>
+              </div>
+              <div class="dl"><span class="ln">24</span><span class="tx c-muted">    }</span></div>
+            </div>
+            <div class="bottom">
+              <span><b>j/k</b> files</span><span class="sep">·</span>
+              <span><b>n/N</b> hunks</span><span class="sep">·</span>
+              <span><b>↑/↓</b> line</span><span class="sep">·</span>
+              <span><b>c</b> comment</span><span class="sep">·</span>
+              <span><b>q</b> question</span><span class="sep">·</span>
+              <span><b>v</b> AI view</span><span class="sep">·</span>
+              <span><b>Tab</b> focus</span><span class="sep">·</span>
+              <span><b>U</b> next unreviewed</span><span class="sep">·</span>
+              <span><b>G</b> pull</span><span class="sep">·</span>
+              <span><b>P</b> push</span>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="grp">
+              <div class="t">PR #42 · Refactor auth login</div>
+              <div class="c-muted">feat/auth-refactor → main</div>
+            </div>
+            <div class="grp">
+              <div class="t">CI checks</div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">Build · 2m14s</span></div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">Tests · 1m32s</span></div>
+              <div class="row"><span class="c-yellow">⟳</span><span class="c-dim">Deploy · running</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Reviewers</div>
+              <div class="row"><span class="c-green">✓</span><span class="c-dim">alice approved</span></div>
+              <div class="row"><span class="c-red">✗</span><span class="c-dim">bob changes req.</span></div>
+              <div class="row"><span class="c-muted">○</span><span class="c-dim">carol pending</span></div>
+            </div>
+            <div class="grp">
+              <div class="t">Labels</div>
+              <div class="row"><span class="chip c-red">bug</span><span class="chip c-blue">auth</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <figcaption>The <code>er</code> terminal UI — top bar with diff modes and PR status, the file list, a syntax-highlighted diff with inline GitHub comments (cyan), AI findings (orange) and private questions (yellow), and the PR context panel on the right.</figcaption>
+    </figure>
+
     <table>
       <thead><tr><th>Region</th><th>Shows</th></tr></thead>
       <tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -412,8 +412,9 @@
       <div class="flex items-center gap-6">
         <a href="#features" class="text-sm text-text-dim hover:text-text transition">Features</a>
         <a href="#demo" class="text-sm text-text-dim hover:text-text transition">Demo</a>
+        <a href="#arena" class="text-sm text-text-dim hover:text-text transition">AI Arena</a>
         <a href="#install" class="text-sm text-text-dim hover:text-text transition">Install</a>
-        <a href="guide/index.html" class="text-sm text-accent hover:text-text transition">Docs</a>
+        <a href="guide/index.html" class="text-sm text-accent hover:text-text transition">Guide</a>
         <a href="https://github.com/VilfredSikker/easy-review" target="_blank" class="flex items-center gap-1.5 text-sm text-text-dim hover:text-text transition">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
           <span class="hidden sm:inline">GitHub</span>
@@ -430,7 +431,7 @@
     <div class="max-w-4xl mx-auto text-center relative">
       <div class="fade-up fade-up-1 inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border text-xs text-text-dim font-mono mb-8">
         <span class="w-1.5 h-1.5 rounded-full bg-green animate-pulse"></span>
-        v1.4 — now open source
+        v1.5 — now open source
       </div>
 
       <h1 class="fade-up fade-up-2 text-4xl sm:text-5xl md:text-6xl font-body font-600 tracking-tight leading-[1.1] mb-6">
@@ -447,6 +448,18 @@
         <span class="text-text-muted">$</span>
         <span class="text-text">cargo install --git https://github.com/VilfredSikker/easy-review</span>
         <button onclick="navigator.clipboard.writeText('cargo install --git https://github.com/VilfredSikker/easy-review');this.textContent='✓';setTimeout(()=>this.textContent='⎘',1500)" class="text-text-muted hover:text-accent transition cursor-pointer ml-1" title="Copy">⎘</button>
+      </div>
+
+      <!-- Secondary CTAs -->
+      <div class="fade-up fade-up-5 flex flex-wrap items-center justify-center gap-3 mb-5">
+        <a href="guide/index.html" class="inline-flex items-center gap-2 bg-accent/15 border border-accent/30 text-accent rounded-lg px-4 py-2 text-sm font-medium hover:bg-accent/25 transition">
+          Read the Guide
+          <span aria-hidden="true">→</span>
+        </a>
+        <a href="#arena" class="inline-flex items-center gap-2 border border-border text-text-dim rounded-lg px-4 py-2 text-sm hover:text-text hover:border-border-bright transition">
+          Explore the AI Arena
+          <span aria-hidden="true">↓</span>
+        </a>
       </div>
 
       <p class="fade-up fade-up-5 text-xs text-text-muted font-mono">
@@ -623,9 +636,9 @@
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">q</span> question</span>
                 <span class="text-text-dim">·</span>
-                <span class="text-text-dim"><span class="text-text">a</span> AI</span>
+                <span class="text-text-dim"><span class="text-text">v</span> AI view</span>
                 <span class="text-text-dim">·</span>
-                <span class="text-text-dim"><span class="text-text">p</span> panel</span>
+                <span class="text-text-dim"><span class="text-text">V</span> back</span>
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">Tab</span> focus</span>
                 <span class="text-text-dim">·</span>
@@ -987,7 +1000,7 @@
                 <!-- toggle -->
                 <div class="flex items-center gap-2 mb-2 px-1">
                   <span class="text-text-muted text-xs">[</span>
-                  <span class="sc4-toggle text-xs font-mono font-bold">a</span>
+                  <span class="sc4-toggle text-xs font-mono font-bold">v</span>
                   <span class="text-text-muted text-xs">] AI:</span>
                   <span class="sc4-toggle text-xs font-bold">ON</span>
                 </div>
@@ -1049,7 +1062,7 @@
           <span class="font-mono text-xs text-orange uppercase tracking-widest">AI review</span>
           <h2 class="text-3xl sm:text-4xl font-body font-500 mt-3 mb-5 leading-tight">AI reads the diff<br>so you don't have<br>to guess</h2>
           <p class="text-text-dim leading-relaxed mb-6">
-            Run <span class="font-mono text-accent text-sm">/er-review</span> in Claude Code. Risk ratings and hunk-level findings appear inline. Press <span class="keycap">a</span> to toggle the AI layer. Press <span class="keycap">p</span> for the AI Summary panel. Run <span class="font-mono text-accent text-sm">/er-questions</span> standalone to get answers to your private questions without a full review.
+            Run <span class="font-mono text-accent text-sm">/er-review</span> in Claude Code. Risk ratings and hunk-level findings appear inline. Press <span class="keycap">v</span> to cycle AI views — from a plain diff, to findings inline, to a side panel with the summary and risk breakdown. Run <span class="font-mono text-accent text-sm">/er-questions</span> standalone to get answers to your private questions without a full review.
           </p>
           <ul class="space-y-3 text-sm text-text-dim mb-7">
             <li class="flex gap-3">
@@ -1058,7 +1071,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-orange mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">AI Summary panel</strong> — press <span class="keycap">p</span> to see risk rating, findings count, and a file-by-file risk breakdown side-by-side with your diff</span>
+              <span><strong class="text-text">AI Summary panel</strong> — cycle with <span class="keycap">v</span> to the panel view: risk rating, findings count, and a file-by-file risk breakdown side-by-side with your diff</span>
             </li>
             <li class="flex gap-3">
               <span class="text-orange mt-0.5 shrink-0">✓</span>
@@ -1067,8 +1080,8 @@
           </ul>
           <div class="flex flex-wrap gap-2 items-center">
             <span class="text-xs text-text-muted">Keys:</span>
-            <span class="keycap">a</span>
-            <span class="keycap">p</span>
+            <span class="keycap">v</span>
+            <span class="keycap">V</span>
             <span class="keycap">z</span>
             <span class="keycap">Z</span>
           </div>
@@ -1272,6 +1285,106 @@
     </div>
   </section>
 
+  <!-- ===== AI ARENA ===== -->
+  <section id="arena" class="py-24 px-6 border-t border-border/50 scroll-mt-20">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-center mb-4 reveal-up">
+        <span class="font-mono text-xs text-accent uppercase tracking-widest">AI Arena · Desktop</span>
+        <h2 class="text-3xl sm:text-4xl font-body font-500 mt-3">One diff. A panel of reviewers.</h2>
+        <p class="text-text-dim max-w-2xl mx-auto mt-5 leading-relaxed">
+          A single model's first pass misses things and over-flags others. The desktop app's <strong class="text-text">AI Arena</strong>
+          runs several reviewers over the same diff, has <em class="text-text-dim">fresh skeptics</em> challenge every finding across
+          rounds, and lets an arbiter rule each one <span class="text-green">kept</span>, <span class="text-text-muted">dropped</span>, or
+          merged — so what reaches you is the analysis that survived scrutiny.
+        </p>
+      </div>
+
+      <!-- Desktop window: the arena funnel -->
+      <div class="reveal-up bg-surface border border-border rounded-xl overflow-hidden glow-box mt-10">
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-border bg-surface-2">
+          <div class="w-3 h-3 rounded-full bg-red/60"></div>
+          <div class="w-3 h-3 rounded-full bg-yellow/60"></div>
+          <div class="w-3 h-3 rounded-full bg-green/60"></div>
+          <span class="ml-3 text-xs text-text-muted font-mono">er — review arena</span>
+          <span class="ml-auto text-xs font-mono text-yellow flex items-center gap-1.5">
+            <span class="spin">⟳</span> round 2 / 3
+          </span>
+        </div>
+
+        <!-- Funnel -->
+        <div class="p-6 sm:p-8 font-mono">
+          <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] gap-4 sm:gap-2 items-center text-center">
+            <!-- Proposed -->
+            <div>
+              <div class="text-4xl font-bold text-cyan leading-none">14</div>
+              <div class="text-[0.62rem] uppercase tracking-widest text-text-muted mt-2">Proposed</div>
+              <div class="text-xs text-text-dim mt-2 leading-snug">findings from<br>4 reviewers</div>
+              <div class="flex flex-wrap gap-1 justify-center mt-3">
+                <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full border border-red/40 text-red">Security</span>
+                <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full border border-blue/40 text-blue">Performance</span>
+                <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full border border-green/40 text-green">Testing</span>
+                <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full border border-cyan/40 text-cyan">Reliability</span>
+              </div>
+            </div>
+            <div class="text-text-muted text-xl rotate-90 sm:rotate-0 justify-self-center">→</div>
+            <!-- Challenged -->
+            <div>
+              <div class="text-4xl font-bold text-yellow leading-none">11</div>
+              <div class="text-[0.62rem] uppercase tracking-widest text-text-muted mt-2">Challenged</div>
+              <div class="text-xs text-text-dim mt-2 leading-snug">fresh skeptics<br>try to refute</div>
+            </div>
+            <div class="text-text-muted text-xl rotate-90 sm:rotate-0 justify-self-center">→</div>
+            <!-- Arbiter -->
+            <div>
+              <div class="text-4xl font-bold text-accent leading-none">⚖</div>
+              <div class="text-[0.62rem] uppercase tracking-widest text-text-muted mt-2">Arbiter</div>
+              <div class="text-xs text-text-dim mt-2 leading-snug">rules each:<br>keep · drop · merge</div>
+            </div>
+            <div class="text-text-muted text-xl rotate-90 sm:rotate-0 justify-self-center">→</div>
+            <!-- Final -->
+            <div>
+              <div class="text-4xl font-bold text-green leading-none">6</div>
+              <div class="text-[0.62rem] uppercase tracking-widest text-text-muted mt-2">Final</div>
+              <div class="text-xs mt-2 leading-snug"><span class="text-green">6 kept</span> <span class="text-text-muted">· 8 dropped</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Result layouts + cost gate -->
+        <div class="border-t border-border px-4 sm:px-6 py-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-mono">
+          <span class="text-text-muted">Result views:</span>
+          <span class="text-text-dim flex items-center gap-1.5"><span class="text-accent">◫</span> Bracket</span>
+          <span class="text-text-dim flex items-center gap-1.5"><span class="text-accent">▦</span> Matrix</span>
+          <span class="text-text-dim flex items-center gap-1.5"><span class="text-accent">▽</span> Funnel</span>
+          <span class="text-text-muted ml-auto">Est. cost <span class="text-text-dim">$0.42</span> · approval required before run</span>
+        </div>
+      </div>
+
+      <!-- Feature bullets -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-8">
+        <div class="reveal-up bg-surface border border-border rounded-lg px-5 py-4">
+          <div class="text-accent text-sm font-500 mb-1">Pick your panel</div>
+          <div class="text-xs text-text-dim leading-relaxed">Choose models and specialized agents — Security, Performance, Testing — set the number of rounds, and pick an arbiter.</div>
+        </div>
+        <div class="reveal-up bg-surface border border-border rounded-lg px-5 py-4" style="transition-delay: 80ms;">
+          <div class="text-accent text-sm font-500 mb-1">Cost gate</div>
+          <div class="text-xs text-text-dim leading-relaxed">A per-model estimate with an approval step before anything runs. A process-wide cap keeps concurrent runs in check.</div>
+        </div>
+        <div class="reveal-up bg-surface border border-border rounded-lg px-5 py-4" style="transition-delay: 160ms;">
+          <div class="text-accent text-sm font-500 mb-1">Three result views</div>
+          <div class="text-xs text-text-dim leading-relaxed">A bracket of how verdicts flowed, a matrix of reviewers against findings, and a funnel from proposed to final.</div>
+        </div>
+      </div>
+
+      <div class="text-center mt-8 reveal-up">
+        <a href="guide/desktop-features.html#arena" class="inline-flex items-center gap-2 text-sm text-accent hover:text-text transition">
+          How the arena works, in the Guide
+          <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- ===== SMALL THINGS THAT ADD UP ===== -->
   <section class="py-16 px-6 border-t border-border/50">
     <div class="max-w-5xl mx-auto">
@@ -1323,13 +1436,13 @@
         <div class="timeline-step" style="transition-delay: 400ms;">
           <div class="timeline-node key"><span class="font-mono text-xs text-accent font-bold">3</span></div>
           <h3 class="font-body font-500 text-base mb-1">Run <span class="font-mono text-accent text-sm">/er-review</span> in Claude Code</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Risk ratings, hunk-level findings, and a review checklist appear inline. Press <span class="keycap">a</span> to toggle the AI layer independently of your comments and panel.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Risk ratings, hunk-level findings, and a review checklist appear inline. Press <span class="keycap">v</span> to cycle how much AI context is shown — from a plain diff to findings inline to a side panel.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 600ms;">
           <div class="timeline-node"><span class="font-mono text-xs text-text-muted">4</span></div>
           <h3 class="font-body font-500 text-base mb-1">Comment and iterate</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Open the context panel with <span class="keycap">p</span> for a PR overview alongside your diff. Re-run <span class="font-mono text-accent text-sm">/er-review</span> — the AI reads your questions and updates its analysis.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Cycle with <span class="keycap">v</span> to a side panel for the AI summary and PR overview alongside your diff. Re-run <span class="font-mono text-accent text-sm">/er-review</span> — the AI reads your questions and updates its analysis.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 800ms;">


### PR DESCRIPTION
## In plain terms

**The problem.** The documentation guide was all words — tables, bullet lists, keybinding charts — and not a single picture of what `er` actually looks like. New users had to read a description of "a top bar, three columns, and a bottom bar" and imagine it. The marketing landing page also never mentioned the **AI Arena** (one of the most compelling desktop features) and buried the docs behind a single "Docs" link.

**Why it matters.** A review tool sells itself on how it looks and feels. Words can't show that the diff is syntax-highlighted, that comments sit inline on the exact line, or that AI findings are color-coded. People bounce when they can't picture the product.

**The fix.** Add faithful, **CSS-rendered mockups** of the real UI (no screenshots, no binary assets, no build step — just markup over the existing theme tokens) to seven guide pages, and give the landing page a proper AI Arena section plus prominent Guide entry points.

**TL;DR.** The docs now *show* the product instead of only describing it, and the landing page sells the AI Arena.

## What changed

**Guide site** (`docs/guide/`)
- New shared figure system in `assets/docs.css` (`.shot` window frame, `.erbar` mode bar, `.arena` funnel, diff lines, inline comment/finding cards, desktop split-diff, responsive rules).
- Mockups added to 7 pages: Introduction (hero), TUI Overview (full three-column layout), Diff Modes (mode bar), Comments (the two comment types + stale state), AI Review (findings + summary panel), Desktop Overview (split diff + word-diff window), Desktop Features (the arena funnel).

**Landing page** (`docs/index.html`)
- New **AI Arena** section: a desktop-framed funnel (proposed → challenged → arbiter → final) with reviewer pills, a cost gate, and the three result views, plus feature cards and a link into the guide.
- `AI Arena` + `Guide` nav links, two hero CTAs (*Read the Guide* / *Explore the AI Arena*), and the badge bumped to **v1.5**.
- Corrected the AI-view keybindings to `v` / `V` (the page previously claimed `a` = AI toggle and `p` = panel, which the keymap does not have — verified against `tui-keybindings.html`).

## Testing
Every figure was rendered and visually verified via Playwright at **desktop (1280px)** and **mobile (400px)** widths. Caught and fixed a class-collision bug where the figure mode bar reused the site chrome's fixed `.topbar` (it was flying to the top of the page) — renamed to `.erbar` and reset the inherited `.card` styles.

## Rollback
Docs-only, no code paths touched. Revert the single commit on this branch.

https://claude.ai/code/session_01SfAt1NCrYJcD4LKBLmqc2G