### PR TITLE
docs: add branching &amp; release workflow to project memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ er                    # run from any git repo
 
 No runtime dependencies beyond git. Single binary. (`gh` CLI optional for GitHub PR features.)
 
+## Branching & Release Workflow
+
+- **PRs to `main` are for bug fixes only.** Only point a PR at `main` when it is a bug fix.
+- **Everything else goes on a release branch.** New features and other non-bugfix work are developed on (and PR'd into) a release branch, not `main`.
+- **Release branches must include release notes.** Every release branch ships with release notes describing what changed.
+
 ## Architecture
 
 Rust + Ratatui TUI. Six modules + a standalone GitHub integration file:


### PR DESCRIPTION
Records our go-forward workflow in project memory (`CLAUDE.md`):

- **PRs to `main` are for bug fixes only.**
- **Everything else goes on a release branch** (developed on and PR'd into it).
- **Release branches ship with release notes.**

This PR is itself a process/docs change, so per the new policy it points at `main`. The next feature release is being assembled on `release/v0.4.0` (with `RELEASE_NOTES.md`), and the open feature PRs have been retargeted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXjaNKpykvTVNfE3ZUQ1Q)_