### PR TITLE
fix(desktop): make AI Review Arena follow the active theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ er                    # run from any git repo
 
 No runtime dependencies beyond git. Single binary. (`gh` CLI optional for GitHub PR features.)
 
+## Branching & Release Workflow
+
+- **PRs to `main` are for bug fixes only.** Only point a PR at `main` when it is a bug fix.
+- **Everything else goes on a release branch.** New features and other non-bugfix work are developed on (and PR'd into) a release branch, not `main`.
+- **Release branches must include release notes.** Every release branch ships with release notes describing what changed.
+
 ## Architecture
 
 Rust + Ratatui TUI. Six modules + a standalone GitHub integration file:

--- a/desktop-ui/src/app.css
+++ b/desktop-ui/src/app.css
@@ -97,44 +97,32 @@
   --color-syntax-string:  #86efac;
   --color-syntax-punct:   #6b6b6b;
   --color-syntax-comment: #5e5e5e;
-
-  /* Arena overlay (design-polish/Arena-design/tokens.css — DM Sans / JetBrains Mono) */
-  --color-arena-bg-app: #0c121f;
-  --color-arena-bg-0: #0e1420;
-  --color-arena-bg-1: #131927;
-  --color-arena-bg-2: #181f2e;
-  --color-arena-bg-3: #1e2536;
-  --color-arena-bg-4: #252c3e;
-  --color-arena-fg: #e6e8ed;
-  --color-arena-fg-muted: #aab0bd;
-  --color-arena-fg-subtle: #6d7384;
-  --color-arena-fg-faint: #4a5163;
-  --color-arena-orange: #ff7a2b;
-  --color-arena-periwinkle: #7f87ff;
-  --color-arena-ok: #4ec9a4;
-  --color-arena-warn: #ffc457;
-  --color-arena-err: #ff6b6b;
-  --color-arena-info: #5fb7ff;
 }
 
 :root {
-  --arena-bg-app: var(--color-arena-bg-app);
-  --arena-bg-0: var(--color-arena-bg-0);
-  --arena-bg-1: var(--color-arena-bg-1);
-  --arena-bg-2: var(--color-arena-bg-2);
-  --arena-bg-3: var(--color-arena-bg-3);
-  --arena-bg-4: var(--color-arena-bg-4);
-  --arena-fg: var(--color-arena-fg);
-  --arena-fg-muted: var(--color-arena-fg-muted);
-  --arena-fg-subtle: var(--color-arena-fg-subtle);
-  --arena-fg-faint: var(--color-arena-fg-faint);
-  --arena-orange: var(--color-arena-orange);
-  --arena-periwinkle: var(--color-arena-periwinkle);
-  --arena-ok: var(--color-arena-ok);
-  --arena-warn: var(--color-arena-warn);
-  --arena-err: var(--color-arena-err);
-  --arena-info: var(--color-arena-info);
-  --arena-border: rgba(255, 255, 255, 0.06);
+  /* Arena tokens alias the shared themed palette (the --color-ink-* surface
+   * ladder + semantic accents) so the arena card and overlay follow
+   * display.theme. applyTheme()/cssVarsFor() in themes.ts override those base
+   * tokens per theme, and the arena inherits the change for free — no per-theme
+   * arena values to maintain. (Categorical reviewer/agent identity colors are
+   * intentionally NOT themed; they stay distinct — see lib/arena/agents.ts.) */
+  --arena-bg-app: var(--color-ink-900);
+  --arena-bg-0: var(--color-ink-880);
+  --arena-bg-1: var(--color-ink-850);
+  --arena-bg-2: var(--color-ink-800);
+  --arena-bg-3: var(--color-ink-700);
+  --arena-bg-4: var(--color-ink-600);
+  --arena-fg: var(--color-ink-50);
+  --arena-fg-muted: var(--color-ink-200);
+  --arena-fg-subtle: var(--color-ink-300);
+  --arena-fg-faint: var(--color-ink-400);
+  --arena-orange: var(--color-emphasis);
+  --arena-periwinkle: var(--color-periwinkle);
+  --arena-ok: var(--color-success);
+  --arena-warn: var(--color-warning);
+  --arena-err: var(--color-error);
+  --arena-info: var(--color-info);
+  --arena-border: var(--color-hairline);
   --arena-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
   --arena-d-fast: 120ms;
   --arena-d-base: 200ms;

--- a/desktop-ui/src/lib/components/BackgroundTasks.svelte
+++ b/desktop-ui/src/lib/components/BackgroundTasks.svelte
@@ -109,7 +109,7 @@
 
   function dotColor(status: Pill["status"]): string {
     if (status === "running") return "bg-accent animate-pulse";
-    if (status === "queued") return "bg-arena-warn";
+    if (status === "queued") return "bg-warning";
     if (status === "done") return "bg-add-fg";
     return "bg-del-fg";
   }


### PR DESCRIPTION
## What

The **AI Review Arena** — the card in the AI review sidebar *and* every arena page (overlay, launcher, history list, process bracket/matrix/funnel, vote icons/legend, final truth, finding detail, running panel, agent picker) — was rendering with a fixed dark-navy palette regardless of `display.theme`. It ignored the shared theme-token system the rest of the desktop UI flows through, so switching to Slate, Paper, Daylight, Contrast, etc. left the arena unchanged.

## Why

Every arena component already consumes the `--arena-*` CSS custom properties. The problem was one layer down: in `app.css` those aliases pointed at a static `--color-arena-*` navy palette that `applyTheme()` / `cssVarsFor()` (in `lib/themes.ts`) never override. The themed tokens (`--color-ink-*` ladder and the semantic accents) *are* overridden per theme — the arena just wasn't wired to them.

## Fix

Repoint the `--arena-*` aliases at the existing themed tokens and drop the now-unused static `--color-arena-*` block:

| arena token | now aliases |
|---|---|
| `--arena-bg-app/0/1/2/3/4` | `--color-ink-900/880/850/800/700/600` (themed surface ladder) |
| `--arena-fg / -muted / -subtle / -faint` | `--color-ink-50/200/300/400` |
| `--arena-orange` | `--color-emphasis` |
| `--arena-periwinkle` | `--color-periwinkle` |
| `--arena-ok / -warn / -err / -info` | `--color-success / -warning / -error / -info` |
| `--arena-border` | `--color-hairline` |

Because those base tokens are already swapped per theme by `themes.ts`, the arena now inherits the active theme automatically — there are **no per-theme arena values to maintain**.

Categorical reviewer/agent **identity** colors (`lib/arena/agents.ts`, and the fallback reviewer palette in `ArenaRunningPanel.svelte`) are intentionally left as fixed distinct hues — they're chart-series-style identity colors, not theme chrome, and collapsing them onto the semantic palette would make different reviewers share a color.

## Testing

- `bun run build` — passes (CSS compiles, no Tailwind/Vite errors).
- Change is pure CSS-variable indirection; all referenced base tokens exist in the `@theme` block and are overridden by `cssVarsFor()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MniJGvhLsr1hJsgN9P3zcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MniJGvhLsr1hJsgN9P3zcE)_