### PR TITLE
Attach the Guide to the viewed diff (PR vs local branch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ er                    # run from any git repo
 
 No runtime dependencies beyond git. Single binary. (`gh` CLI optional for GitHub PR features.)
 
+## Branching & Release Workflow
+
+- **PRs to `main` are for bug fixes only.** Only point a PR at `main` when it is a bug fix.
+- **Everything else goes on a release branch.** New features and other non-bugfix work are developed on (and PR'd into) a release branch, not `main`.
+- **Release branches must include release notes.** Every release branch ships with release notes describing what changed.
+
 ## Architecture
 
 Rust + Ratatui TUI. Six modules + a standalone GitHub integration file:

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3008,16 +3008,29 @@ fn spawn_ai_review_with_diff(
     Ok(())
 }
 
-/// Generate a guided Tour with AI: captures the branch diff and spawns the
-/// er-tour agent, which writes `tour.json` into the branch bucket. The mtime
-/// poll reloads it automatically on completion, surfacing the Guide tab.
+/// Generate a guided Tour with AI: captures the current view's diff (PR or local
+/// branch) and spawns the er-tour agent, which writes the context-scoped tour
+/// sidecar (`tour.pr.json` for the PR diff, `tour.json` for the branch diff)
+/// into the branch bucket. The mtime poll reloads it automatically on
+/// completion, surfacing the Guide for that view.
 #[tauri::command]
 pub fn generate_tour(state: State<AppState>) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
-    // Tour always walks the branch diff (shares the branch bucket).
+    // The diff capture uses branch mechanics; for PR-associated tabs this
+    // resolves to the PR diff (vs base) automatically (see raw_diff_for_review).
     let scope = "branch".to_string();
 
-    let (repo_root, branch_label, base_branch, er_dir, pr_number, remote_repo, is_remote) = {
+    let (
+        repo_root,
+        branch_label,
+        base_branch,
+        er_dir,
+        pr_number,
+        remote_repo,
+        is_remote,
+        tour_file,
+        is_pr,
+    ) = {
         let tab = app.tab();
         let branch_label = tab
             .local_branch_view
@@ -3027,11 +3040,13 @@ pub fn generate_tour(state: State<AppState>) -> Result<AppSnapshot, String> {
             tab.repo_root.clone(),
             branch_label,
             tab.base_branch.clone(),
-            // tour.json lives in the branch bucket; resolve it regardless of mode.
+            // Tour sidecars live in the branch bucket; resolve it regardless of mode.
             tab.branch_bucket_er_dir().unwrap_or_else(|| tab.er_dir()),
             tab.pr_number,
             tab.remote_repo.clone(),
             tab.remote_repo.is_some(),
+            tab.tour_filename().to_string(),
+            tab.tour_context_is_pr(),
         )
     };
 
@@ -3052,7 +3067,9 @@ pub fn generate_tour(state: State<AppState>) -> Result<AppSnapshot, String> {
     std::fs::write(std::path::Path::new(&er_dir).join("diff-tmp"), &raw)
         .map_err(|e| format!("Failed to write diff-tmp: {e}"))?;
 
-    let prompt = er_engine::ai::prompts::build_tour_prompt_prepared_diff(&scope, &er_dir);
+    let scope_label = if is_pr { "PR diff" } else { "branch diff" };
+    let prompt =
+        er_engine::ai::prompts::build_tour_prompt_prepared_diff(scope_label, &er_dir, &tour_file);
     let target = er_engine::app::BackgroundTaskTarget {
         repo_root,
         er_dir: er_dir.clone(),

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -285,10 +285,14 @@ pub struct PillarSnapshot {
 #[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TourSnapshot {
-    /// True when a tour.json exists for this branch.
+    /// True when a guided tour exists for the current view context (PR vs branch).
     pub available: bool,
-    /// True when the tour matches the current diff (not stale).
+    /// True when the tour matches the current diff (not stale). When false and
+    /// `available` is true, the UI offers a "Re-run guide" affordance.
     pub fresh: bool,
+    /// Which diff the tour is attached to: `"pr"` or `"branch"`. Drives the
+    /// Diff/PR header toggle state and where the Diff toggle returns to.
+    pub scope: String,
     pub title: String,
     pub overview_markdown: String,
     pub pillars: Vec<PillarSnapshot>,
@@ -1445,7 +1449,12 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
 
     TourSnapshot {
         available: true,
-        fresh: !tab.ai.is_stale,
+        fresh: !tab.ai.tour_stale,
+        scope: if tab.tour_context_is_pr() {
+            "pr".to_string()
+        } else {
+            "branch".to_string()
+        },
         title: tour.title.clone(),
         overview_markdown: tour.overview.clone(),
         pillars,

--- a/crates/er-engine/src/ai/CLAUDE.md
+++ b/crates/er-engine/src/ai/CLAUDE.md
@@ -27,7 +27,7 @@ paths below use the repo-local `.er/` names, which are identical.
 |------|--------|---------|
 | `review.json` | `ErReview` | Per-file risk levels, findings, suggestions |
 | `order.json` | `ErOrder` | Suggested file review order with groupings |
-| `tour.json` | `ErTour` | Guided walkthrough: ordered "pillars" (foundation→importance) with descriptions + files. Read-only to `er`; written by the `er-tour` skill / desktop "Generate tour". Self-contained — never mutates `order.json`/`review.json`. |
+| `tour.json` / `tour.pr.json` | `ErTour` | Guided walkthrough ("Guide"): ordered "pillars" (foundation→importance) with descriptions + files. **Context-scoped**: `tour.json` is attached to the local branch diff, `tour.pr.json` to the PR diff. Both live in the branch bucket; `TabState::tour_filename()` / `tour_context_is_pr()` pick the one for the current view (`TabState::reload_context_tour` routes loading, remote PR tabs fall back to legacy `tour.json`). Read-only to `er`; written by the `er-tour` skill / desktop "Generate tour" (which targets the context filename). Self-contained — never mutates `order.json`/`review.json`. Staleness is tracked in `AiState::tour_stale` (independent of `is_stale`), driving the "Re-run guide" affordance. |
 | `summary.md` | (raw text) | Markdown summary of overall changes |
 | `checklist.json` | `ErChecklist` | Review checklist items |
 | `triage.json` | `TriageReview` | Fast branch scan / routing verdict |

--- a/crates/er-engine/src/ai/loader.rs
+++ b/crates/er-engine/src/ai/loader.rs
@@ -173,18 +173,9 @@ pub fn load_ai_state(er_dir: &str, current_diff_hash: &str, branch_scope: Option
         }
     }
 
-    // Load .er/tour.json (guided walkthrough — its own ordering/grouping).
-    // The tour is a separate, context-scoped view; track its staleness in
-    // `tour_stale` rather than the global `is_stale` so a stale tour never dims
-    // the review/findings overlays. `TabState::reload_ai_state` re-routes the
-    // tour to the PR- or branch-scoped sidecar and recomputes `tour_stale`.
-    let tour_path = Path::new(er_dir).join("tour.json");
-    if let Ok(content) = read_sidecar(&tour_path) {
-        if let Ok(tour) = serde_json::from_str::<ErTour>(&content) {
-            state.tour_stale = tour.diff_hash != current_diff_hash;
-            state.tour = Some(tour);
-        }
-    }
+    // The guided tour (`tour.json` / `tour.pr.json`) is context-scoped (branch
+    // vs PR) and is loaded by `TabState::reload_ai_state` → `reload_context_tour`,
+    // which knows the active view. It is intentionally not loaded here.
 
     // Load .er/summary.md
     let summary_path = Path::new(er_dir).join("summary.md");
@@ -298,6 +289,15 @@ pub fn load_ai_state(er_dir: &str, current_diff_hash: &str, branch_scope: Option
     state
 }
 
+/// Read and parse a guided-tour sidecar (`tour.json` / `tour.pr.json`) from a
+/// directory, honoring the shared sidecar size guard. Returns `None` if absent
+/// or malformed.
+pub fn load_tour_sidecar(dir: &str, name: &str) -> Option<ErTour> {
+    let path = Path::new(dir).join(name);
+    let content = read_sidecar(&path).ok()?;
+    serde_json::from_str::<ErTour>(&content).ok()
+}
+
 /// Get the mtime of the most recently modified .er-* file
 pub fn latest_er_mtime(er_dir: &str) -> Option<std::time::SystemTime> {
     let er_dir = Path::new(er_dir);
@@ -305,6 +305,9 @@ pub fn latest_er_mtime(er_dir: &str) -> Option<std::time::SystemTime> {
         "review.json",
         "order.json",
         "tour.json",
+        // PR-scoped guided tour — must be polled too, else a generated PR guide
+        // never auto-surfaces (the mtime poll drives `reload_ai_state`).
+        "tour.pr.json",
         "summary.md",
         "checklist.json",
         "feedback.json",
@@ -420,7 +423,7 @@ mod tests {
     }
 
     #[test]
-    fn load_ai_state_reads_tour_and_sets_freshness() {
+    fn load_tour_sidecar_parses_pillars_and_load_ai_state_ignores_tour() {
         let dir = tempfile::tempdir().unwrap();
         let er_dir = dir.path().to_str().unwrap();
         let tour = serde_json::json!({
@@ -444,22 +447,20 @@ mod tests {
         )
         .unwrap();
 
-        // Matching hash → fresh tour loaded. Tour staleness is tracked in
-        // `tour_stale`, independent of the global `is_stale`.
-        let state = load_ai_state(er_dir, "abc", None);
-        assert!(state.has_tour());
-        assert!(!state.is_stale);
-        assert!(!state.tour_stale);
-        let loaded = state.tour.as_ref().unwrap();
+        // The tour is context-scoped and loaded by TabState (via the size-guarded
+        // `load_tour_sidecar`), not by `load_ai_state`.
+        let loaded = load_tour_sidecar(er_dir, "tour.json").unwrap();
         assert_eq!(loaded.pillars.len(), 1);
         assert_eq!(loaded.file_pillar("src/a.rs").unwrap().id, "p-1");
+        assert_eq!(loaded.diff_hash, "abc");
 
-        // Mismatched hash → tour still loaded and marked stale via `tour_stale`,
-        // but the global `is_stale` stays false (tour is a separate view).
-        let stale = load_ai_state(er_dir, "different", None);
-        assert!(stale.has_tour());
-        assert!(!stale.is_stale);
-        assert!(stale.tour_stale);
+        assert!(load_tour_sidecar(er_dir, "tour.pr.json").is_none());
+
+        // load_ai_state does not load the tour and leaves staleness defaulted.
+        let state = load_ai_state(er_dir, "abc", None);
+        assert!(!state.has_tour());
+        assert!(!state.is_stale);
+        assert!(!state.tour_stale);
     }
 
     #[test]

--- a/crates/er-engine/src/ai/loader.rs
+++ b/crates/er-engine/src/ai/loader.rs
@@ -173,13 +173,15 @@ pub fn load_ai_state(er_dir: &str, current_diff_hash: &str, branch_scope: Option
         }
     }
 
-    // Load .er/tour.json (guided walkthrough — its own ordering/grouping)
+    // Load .er/tour.json (guided walkthrough — its own ordering/grouping).
+    // The tour is a separate, context-scoped view; track its staleness in
+    // `tour_stale` rather than the global `is_stale` so a stale tour never dims
+    // the review/findings overlays. `TabState::reload_ai_state` re-routes the
+    // tour to the PR- or branch-scoped sidecar and recomputes `tour_stale`.
     let tour_path = Path::new(er_dir).join("tour.json");
     if let Ok(content) = read_sidecar(&tour_path) {
         if let Ok(tour) = serde_json::from_str::<ErTour>(&content) {
-            if !state.is_stale && tour.diff_hash != current_diff_hash {
-                state.is_stale = true;
-            }
+            state.tour_stale = tour.diff_hash != current_diff_hash;
             state.tour = Some(tour);
         }
     }
@@ -442,18 +444,22 @@ mod tests {
         )
         .unwrap();
 
-        // Matching hash → fresh tour loaded.
+        // Matching hash → fresh tour loaded. Tour staleness is tracked in
+        // `tour_stale`, independent of the global `is_stale`.
         let state = load_ai_state(er_dir, "abc", None);
         assert!(state.has_tour());
         assert!(!state.is_stale);
+        assert!(!state.tour_stale);
         let loaded = state.tour.as_ref().unwrap();
         assert_eq!(loaded.pillars.len(), 1);
         assert_eq!(loaded.file_pillar("src/a.rs").unwrap().id, "p-1");
 
-        // Mismatched hash → tour still loaded but marked stale.
+        // Mismatched hash → tour still loaded and marked stale via `tour_stale`,
+        // but the global `is_stale` stays false (tour is a separate view).
         let stale = load_ai_state(er_dir, "different", None);
         assert!(stale.has_tour());
-        assert!(stale.is_stale);
+        assert!(!stale.is_stale);
+        assert!(stale.tour_stale);
     }
 
     #[test]

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -483,11 +483,16 @@ pub fn build_expert_review_prompt_prepared_diff(
 }
 
 /// Guided tour generation when `{output_dir}/diff-tmp` is already prepared
-/// (desktop "Generate tour"). Writes only `{output_dir}/tour.json`.
-pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str) -> String {
+/// (desktop "Generate tour"). Writes only `{output_dir}/{output_file}`.
+///
+/// `output_file` is the context-scoped sidecar name: `tour.json` for the local
+/// branch diff, `tour.pr.json` for the PR diff. The tour stays attached to
+/// whichever diff was being viewed when generated.
+pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str, output_file: &str) -> String {
     let safe_output_dir = sanitize_for_shell(output_dir)
         .replace('{', "{{")
         .replace('}', "}}");
+    let safe_output_file = output_file.replace('{', "{{").replace('}', "}}");
     format!(
         r#"You are preparing a guided **Tour** of a code diff for a reviewer. A diff for scope `{scope}` is already captured at `{safe_output_dir}/diff-tmp`.
 
@@ -500,7 +505,7 @@ pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str) -> String 
    - `importance` (0–100) ranks reviewer attention; higher sorts earlier among non-foundation.
    - Each pillar: a short `title`, a 1–3 sentence markdown `description` (what it is and what to look for), and its `files` (new-side paths) in reading order, each with a one-line `reason`.
    - Every changed file appears in exactly one pillar. 3–7 pillars is ideal.
-5. Write `{safe_output_dir}/tour.json` (and nothing else) with this exact shape:
+5. Write `{safe_output_dir}/{safe_output_file}` (and nothing else) with this exact shape:
 
 ```json
 {{
@@ -525,7 +530,7 @@ pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str) -> String 
 }}
 ```
 
-Do NOT modify `review.json`, `order.json`, or any other file. Write only `tour.json`."#
+Do NOT modify `review.json`, `order.json`, or any other file. Write only `{safe_output_file}`."#
     )
 }
 

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -385,6 +385,11 @@ pub struct AiState {
     pub feedback: Option<ErFeedback>,
     /// Whether the loaded data matches the current diff
     pub is_stale: bool,
+    /// Whether the loaded guided tour (`tour`) no longer matches the current
+    /// view's diff. Tracked independently from `is_stale` because the tour is a
+    /// separate, context-scoped view (branch vs PR) and its staleness should not
+    /// dim the other AI overlays. Drives the "Re-run guide" affordance.
+    pub tour_stale: bool,
     /// Files whose diff has changed since the review (per-file staleness)
     pub stale_files: HashSet<String>,
     /// Lazily-built comment index for O(1) lookups.
@@ -407,6 +412,7 @@ impl Default for AiState {
             triage: None,
             feedback: None,
             is_stale: false,
+            tour_stale: false,
             stale_files: HashSet::new(),
             comment_index: RefCell::new(None),
         }

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -45,12 +45,31 @@ fn log_branch_profile_phase(tab: &TabState, phase: &str, started_at: Instant) {
     );
 }
 
-/// Read and parse a guided-tour sidecar (`tour.json` / `tour.pr.json`) from a
-/// directory. Returns `None` if absent or malformed.
-fn read_tour_file(dir: &str, name: &str) -> Option<ai::ErTour> {
-    let path = std::path::Path::new(dir).join(name);
-    let content = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str::<ai::ErTour>(&content).ok()
+/// Decide whether a loaded guided tour is stale relative to the diff it is
+/// scoped to.
+///
+/// - Branch-scoped tours (`want_pr == false`) baseline against `branch_diff_hash`,
+///   which is always a SHA-256 of the branch diff and is valid in every
+///   working-tree mode. In Unstaged/Staged/History `diff_hash` is a *different*
+///   scope's diff, so using it would mark a fresh branch tour stale.
+/// - PR-scoped tours baseline against the current `diff_hash` (the PR diff's
+///   SHA-256 after a full refresh). On a fast-hash refresh (`diff_hash` is the
+///   16-char non-cryptographic hash) keep the previous result rather than
+///   compare against an incompatible hash.
+fn tour_stale_for(
+    tour_hash: &str,
+    want_pr: bool,
+    diff_hash: &str,
+    branch_diff_hash: &str,
+    prev: bool,
+) -> bool {
+    if !want_pr {
+        return tour_hash != branch_diff_hash;
+    }
+    if diff_hash.len() == 64 {
+        return tour_hash != diff_hash;
+    }
+    prev
 }
 
 /// Anchor data captured at comment creation time for later relocation
@@ -2724,28 +2743,27 @@ impl TabState {
             // tour — fall back to it for backward compatibility. Local tabs keep
             // branch and PR guides strictly separate (a branch `tour.json` must
             // not surface in the PR view).
-            read_tour_file(&dir, "tour.pr.json").or_else(|| {
+            ai::load_tour_sidecar(&dir, "tour.pr.json").or_else(|| {
                 if self.remote_repo.is_some() {
-                    read_tour_file(&dir, "tour.json")
+                    ai::load_tour_sidecar(&dir, "tour.json")
                 } else {
                     None
                 }
             })
         } else {
-            read_tour_file(&dir, "tour.json")
+            ai::load_tour_sidecar(&dir, "tour.json")
         };
         self.ai.tour = tour;
 
-        // Compare the tour's diff hash against the current view's diff hash.
-        // `self.diff_hash` is the SHA-256 of the current context diff after a
-        // full refresh; on fast-hash refreshes (len != 64) fall back to the
-        // always-SHA-256 `branch_diff_hash` for branch context, or keep the
-        // previous value for PR context (no reliable SHA-256 handy).
         self.ai.tour_stale = match self.ai.tour.as_ref() {
             None => false,
-            Some(t) if self.diff_hash.len() == 64 => t.diff_hash != self.diff_hash,
-            Some(t) if !want_pr => t.diff_hash != self.branch_diff_hash,
-            Some(_) => prev_tour_stale,
+            Some(t) => tour_stale_for(
+                &t.diff_hash,
+                want_pr,
+                &self.diff_hash,
+                &self.branch_diff_hash,
+                prev_tour_stale,
+            ),
         };
     }
 
@@ -9682,6 +9700,57 @@ mod tests {
         remote.mode = DiffMode::PrDiff;
         assert!(remote.tour_context_is_pr());
         assert_eq!(remote.tour_filename(), "tour.pr.json");
+    }
+
+    /// Branch-scoped tour freshness must baseline against `branch_diff_hash`,
+    /// never the active view's `diff_hash` — otherwise a fresh branch guide
+    /// reads as stale in Unstaged/Staged/History (where `diff_hash` is a
+    /// different scope's diff), spuriously surfacing "Re-run guide".
+    #[test]
+    fn tour_stale_for_branch_uses_branch_hash() {
+        let branch_hash = "b".repeat(64);
+        let unstaged_hash = "u".repeat(64); // a full SHA-256 of a *different* diff
+
+        // Fresh branch tour, viewed in a mode whose diff_hash != branch_hash.
+        assert!(
+            !tour_stale_for(&branch_hash, false, &unstaged_hash, &branch_hash, false),
+            "fresh branch tour must not read stale when diff_hash is another scope"
+        );
+        // Genuinely stale branch tour.
+        assert!(tour_stale_for(
+            "old",
+            false,
+            &unstaged_hash,
+            &branch_hash,
+            false
+        ));
+
+        // PR context: baseline against diff_hash (the PR diff) when it's SHA-256.
+        let pr_hash = "p".repeat(64);
+        assert!(!tour_stale_for(
+            &pr_hash,
+            true,
+            &pr_hash,
+            &branch_hash,
+            false
+        ));
+        assert!(tour_stale_for("old", true, &pr_hash, &branch_hash, false));
+
+        // PR context, fast-hash refresh (len != 64) → keep previous value.
+        assert!(tour_stale_for(
+            &pr_hash,
+            true,
+            "deadbeefdeadbeef",
+            &branch_hash,
+            true
+        ));
+        assert!(!tour_stale_for(
+            &pr_hash,
+            true,
+            "deadbeefdeadbeef",
+            &branch_hash,
+            false
+        ));
     }
 
     /// Entering Tour mode records whether the originating view was the PR diff,

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -45,6 +45,14 @@ fn log_branch_profile_phase(tab: &TabState, phase: &str, started_at: Instant) {
     );
 }
 
+/// Read and parse a guided-tour sidecar (`tour.json` / `tour.pr.json`) from a
+/// directory. Returns `None` if absent or malformed.
+fn read_tour_file(dir: &str, name: &str) -> Option<ai::ErTour> {
+    let path = std::path::Path::new(dir).join(name);
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str::<ai::ErTour>(&content).ok()
+}
+
 /// Anchor data captured at comment creation time for later relocation
 #[derive(Default)]
 pub(crate) struct LineAnchor {
@@ -661,6 +669,14 @@ pub struct TabState {
     /// Tour mode state (only populated when mode == Tour)
     pub tour: Option<TourState>,
 
+    /// Whether the active Tour reflects the PR diff (true) or the local branch
+    /// diff (false). Set when entering Tour mode from the originating view, so a
+    /// guide generated while viewing the PR stays attached to the PR diff (and
+    /// the Diff/PR toggle keeps PR Diff highlighted). Drives which tour sidecar
+    /// (`tour.pr.json` vs `tour.json`) loads and which mode the Diff toggle
+    /// returns to.
+    pub tour_is_pr: bool,
+
     // ── Watched files state ──
     /// Configuration for watched files
     pub watched_config: WatchedConfig,
@@ -1239,6 +1255,7 @@ impl TabState {
             pr_number: Some(pr_ref.number),
             history: None,
             tour: None,
+            tour_is_pr: false,
             watched_config: er_config.watched.clone(),
             watched_files: Vec::new(),
             selected_watched: None,
@@ -1358,6 +1375,7 @@ impl TabState {
             pr_number: Some(pr_ref.number),
             history: None,
             tour: None,
+            tour_is_pr: false,
             watched_config: er_config.watched.clone(),
             watched_files: Vec::new(),
             selected_watched: None,
@@ -1473,6 +1491,7 @@ impl TabState {
             pr_number: None,
             history: None,
             tour: None,
+            tour_is_pr: false,
             watched_config,
             watched_files: Vec::new(),
             selected_watched: None,
@@ -1588,6 +1607,7 @@ impl TabState {
             pr_number: None,
             history: None,
             tour: None,
+            tour_is_pr: false,
             watched_config: WatchedConfig::default(),
             watched_files: Vec::new(),
             selected_watched: None,
@@ -1913,6 +1933,32 @@ impl TabState {
         self.current_branch = git_branch.to_string();
         self.sync_managed_storage();
         Ok(())
+    }
+
+    /// Whether the current view's guided tour belongs to the PR diff (vs the
+    /// local branch diff). Remote tabs and PR Diff mode are always PR-scoped;
+    /// Tour mode follows whichever view it was entered from (`tour_is_pr`).
+    /// All other modes (Branch/Unstaged/Staged/History) are branch-scoped.
+    pub fn tour_context_is_pr(&self) -> bool {
+        if self.remote_repo.is_some() {
+            return true;
+        }
+        match self.mode {
+            DiffMode::PrDiff => true,
+            DiffMode::Tour => self.tour_is_pr,
+            _ => false,
+        }
+    }
+
+    /// Sidecar filename for the guided tour in the current view context.
+    /// PR-scoped tours live in `tour.pr.json`; branch-scoped tours in `tour.json`.
+    /// Both share the branch bucket directory (`branch_bucket_er_dir`).
+    pub fn tour_filename(&self) -> &'static str {
+        if self.tour_context_is_pr() {
+            "tour.pr.json"
+        } else {
+            "tour.json"
+        }
     }
 
     /// Branch name used to resolve managed storage for this tab (for sidecar validation).
@@ -2634,22 +2680,14 @@ impl TabState {
         let prev_stale_files = std::mem::take(&mut self.ai.stale_files);
         let er_dir = self.er_dir();
         let branch_scope = self.storage_branch_scope().map(str::to_string);
+        let prev_tour_stale = self.ai.tour_stale;
         self.ai = ai::load_ai_state(&er_dir, &self.branch_diff_hash, branch_scope.as_deref());
-        // The guided tour lives in the "branch" bucket. When the active bucket is a
-        // different view (unstaged/staged/history), load tour.json from the branch
-        // bucket so the Tour tab stays discoverable from any mode.
-        if self.ai.tour.is_none() {
-            if let Some(branch_dir) = self.branch_bucket_er_dir() {
-                if branch_dir != er_dir {
-                    let tour_path = std::path::Path::new(&branch_dir).join("tour.json");
-                    if let Ok(content) = std::fs::read_to_string(&tour_path) {
-                        if let Ok(tour) = serde_json::from_str::<ai::ErTour>(&content) {
-                            self.ai.tour = Some(tour);
-                        }
-                    }
-                }
-            }
-        }
+        // The guided tour lives in the "branch" bucket and is context-scoped:
+        // the PR diff loads `tour.pr.json`, the local branch diff loads
+        // `tour.json`. Route to the right sidecar (remote PR tabs fall back to a
+        // legacy `tour.json`) and recompute the tour's own staleness, regardless
+        // of the active view bucket.
+        self.reload_context_tour(&er_dir, prev_tour_stale);
         // Finding IDs may change after review reload — clear stale reference
         self.focused_finding_id = None;
         // Preserve per-file staleness across .er-* file reloads (recomputed in refresh_diff)
@@ -2666,6 +2704,49 @@ impl TabState {
         let max_cursor = if item_count == 0 { 0 } else { item_count - 1 };
         self.review_cursor = self.review_cursor.min(max_cursor);
         self.last_ai_check = ai::latest_er_mtime(&er_dir);
+    }
+
+    /// Load the guided tour for the current view context (PR vs branch) and
+    /// recompute its staleness. Tour sidecars live in the branch-bucket dir
+    /// (shared by Branch/PR/Tour modes), so the tour stays discoverable from any
+    /// view. PR context prefers `tour.pr.json` and falls back to the legacy
+    /// `tour.json` (tours written before the branch/PR split). Overrides
+    /// whatever `load_ai_state` loaded from the active bucket.
+    fn reload_context_tour(&mut self, er_dir: &str, prev_tour_stale: bool) {
+        let dir = self
+            .branch_bucket_er_dir()
+            .unwrap_or_else(|| er_dir.to_string());
+        let want_pr = self.tour_context_is_pr();
+
+        let tour = if want_pr {
+            // PR context loads `tour.pr.json`. Remote PR tabs have no branch
+            // context, so a legacy `tour.json` there is unambiguously the PR
+            // tour — fall back to it for backward compatibility. Local tabs keep
+            // branch and PR guides strictly separate (a branch `tour.json` must
+            // not surface in the PR view).
+            read_tour_file(&dir, "tour.pr.json").or_else(|| {
+                if self.remote_repo.is_some() {
+                    read_tour_file(&dir, "tour.json")
+                } else {
+                    None
+                }
+            })
+        } else {
+            read_tour_file(&dir, "tour.json")
+        };
+        self.ai.tour = tour;
+
+        // Compare the tour's diff hash against the current view's diff hash.
+        // `self.diff_hash` is the SHA-256 of the current context diff after a
+        // full refresh; on fast-hash refreshes (len != 64) fall back to the
+        // always-SHA-256 `branch_diff_hash` for branch context, or keep the
+        // previous value for PR context (no reliable SHA-256 handy).
+        self.ai.tour_stale = match self.ai.tour.as_ref() {
+            None => false,
+            Some(t) if self.diff_hash.len() == 64 => t.diff_hash != self.diff_hash,
+            Some(t) if !want_pr => t.diff_hash != self.branch_diff_hash,
+            Some(_) => prev_tour_stale,
+        };
     }
 
     /// Reload github comments from cache in remote mode.
@@ -3402,6 +3483,14 @@ impl TabState {
 
             // Capture bucket BEFORE changing mode so we can detect a bucket change.
             let prev_bucket = self.review_bucket();
+            let prev_mode = self.mode;
+
+            // Entering Tour: remember whether the originating view was the PR diff
+            // so the guide stays attached to the PR (vs the local branch) and the
+            // Diff toggle returns to the right view. Remote tabs are always PR.
+            if mode == DiffMode::Tour {
+                self.tour_is_pr = prev_mode == DiffMode::PrDiff || self.remote_repo.is_some();
+            }
 
             self.mode = mode;
             self.committed_unpushed = false;
@@ -6820,6 +6909,7 @@ mod tests {
             pr_number: None,
             history: None,
             tour: None,
+            tour_is_pr: false,
             watched_config: WatchedConfig::default(),
             watched_files: Vec::new(),
             selected_watched: None,
@@ -9550,6 +9640,69 @@ mod tests {
         tab.mode = DiffMode::PrDiff;
         assert_eq!(tab.mode, DiffMode::PrDiff);
         assert_eq!(tab.review_bucket(), ReviewBucket::Pr);
+    }
+
+    /// The guided tour's context (and thus which sidecar it loads/writes) follows
+    /// the view being looked at: PR Diff → `tour.pr.json`, local branch →
+    /// `tour.json`. Tour mode follows whichever view it was entered from.
+    #[test]
+    fn tour_context_and_filename_follow_view() {
+        let mut tab = make_test_tab(vec![]);
+
+        // Local branch diff → branch-scoped tour.
+        tab.mode = DiffMode::Branch;
+        assert!(!tab.tour_context_is_pr());
+        assert_eq!(tab.tour_filename(), "tour.json");
+
+        // PR diff → PR-scoped tour. Entering the Guide from here must keep it
+        // attached to the PR (the bug: it flipped to the local branch).
+        tab.mode = DiffMode::PrDiff;
+        assert!(tab.tour_context_is_pr());
+        assert_eq!(tab.tour_filename(), "tour.pr.json");
+
+        // Tour mode follows the originating view via tour_is_pr.
+        tab.mode = DiffMode::Tour;
+        tab.tour_is_pr = false;
+        assert!(!tab.tour_context_is_pr());
+        assert_eq!(tab.tour_filename(), "tour.json");
+        tab.tour_is_pr = true;
+        assert!(tab.tour_context_is_pr());
+        assert_eq!(tab.tour_filename(), "tour.pr.json");
+
+        // Working-tree scopes are always branch-scoped, regardless of tour_is_pr.
+        for m in [DiffMode::Unstaged, DiffMode::Staged, DiffMode::History] {
+            tab.mode = m;
+            assert!(!tab.tour_context_is_pr(), "{m:?} must be branch-scoped");
+            assert_eq!(tab.tour_filename(), "tour.json");
+        }
+
+        // Remote PR tabs are always PR-scoped.
+        let mut remote = make_test_tab(vec![]);
+        remote.remote_repo = Some("owner/repo".into());
+        remote.mode = DiffMode::PrDiff;
+        assert!(remote.tour_context_is_pr());
+        assert_eq!(remote.tour_filename(), "tour.pr.json");
+    }
+
+    /// Entering Tour mode records whether the originating view was the PR diff,
+    /// so the Diff toggle returns to the right view and the right tour loads.
+    #[test]
+    fn set_mode_tour_records_origin_view() {
+        let mut tab = make_test_tab(vec![]);
+
+        // From PR Diff → Tour is PR-scoped.
+        tab.mode = DiffMode::PrDiff;
+        tab.tour_is_pr = false;
+        tab.set_mode(DiffMode::Tour);
+        assert!(tab.tour_is_pr, "Tour entered from PR Diff must be PR-scoped");
+
+        // From the local branch → Tour is branch-scoped.
+        tab.mode = DiffMode::Branch;
+        tab.set_mode(DiffMode::Tour);
+        assert!(
+            !tab.tour_is_pr,
+            "Tour entered from the local branch must be branch-scoped"
+        );
     }
 
     /// pr_refs_fetched starts false on all non-remote constructors and on test tabs.

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -9694,7 +9694,10 @@ mod tests {
         tab.mode = DiffMode::PrDiff;
         tab.tour_is_pr = false;
         tab.set_mode(DiffMode::Tour);
-        assert!(tab.tour_is_pr, "Tour entered from PR Diff must be PR-scoped");
+        assert!(
+            tab.tour_is_pr,
+            "Tour entered from PR Diff must be PR-scoped"
+        );
 
         // From the local branch → Tour is branch-scoped.
         tab.mode = DiffMode::Branch;

--- a/desktop-ui/src/lib/components/BranchContextBar.svelte
+++ b/desktop-ui/src/lib/components/BranchContextBar.svelte
@@ -33,7 +33,12 @@
   );
 
   const mode = $derived(snapshot?.mode ?? "branch");
-  const prActive = $derived(mode === "pr");
+  /** PR Diff is "active" in PR mode, and also in Guide mode when the guide is
+   *  attached to the PR diff — entering the Guide must not flip the toggle to
+   *  Local Branch. */
+  const prActive = $derived(
+    mode === "pr" || (mode === "tour" && snapshot?.tour?.scope === "pr"),
+  );
   /** Show the [Local Branch | PR Diff] toggle when the branch has a PR and the
    *  tab is local (remote-only tabs are implicitly PR Diff). */
   const showSourceToggle = $derived(prNumber != null && activeTab?.kind !== "remote_pr");

--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -149,10 +149,31 @@
   const treeHidden = $derived(!snapshot?.panels.tree);
   const viewMode = $derived<DiffViewMode>(viewModeOverride ?? app.diffViewMode);
   const mode = $derived(snapshot?.mode ?? "branch");
-  /** Guide/Diff toggle is offered once a tour exists for this branch. */
+  /** Guide/Diff toggle is offered once a tour exists for the current view
+   *  context (PR vs local branch). */
   const tourAvailable = $derived(
     (snapshot?.features?.viewTour ?? true) && (snapshot?.tour?.available ?? false),
   );
+  /** Whether the current view's guide is attached to the PR diff. Drives where
+   *  the Diff toggle returns to so leaving the Guide doesn't switch diffs. */
+  const tourIsPr = $derived(snapshot?.tour?.scope === "pr");
+  /** False when new changes have landed since the guide was generated. */
+  const tourFresh = $derived(snapshot?.tour?.fresh ?? true);
+  /** PR number for returning to the PR diff from a PR-scoped guide. */
+  const tourPrNumber = $derived(
+    snapshot?.detected_pr_number ??
+      snapshot?.github?.number ??
+      snapshot?.pr?.number ??
+      null,
+  );
+  function exitGuideToDiff() {
+    if (mode !== "tour") return;
+    if (tourIsPr) {
+      void app.cmd("set_mode", { mode: "pr_diff", prNumber: tourPrNumber });
+    } else {
+      void app.cmd("set_mode", { mode: "branch" });
+    }
+  }
 
   let settingsOpen = $state(false);
 
@@ -1624,12 +1645,23 @@
       {/if}
       <span class="mono text-xs text-fg-3">{files.length} {files.length === 1 ? "file" : "files"}</span>
       <div class="ml-auto flex items-center gap-1">
+        {#if tourAvailable && !tourFresh}
+          <!-- New changes landed since the guide was generated — offer a re-run. -->
+          <button
+            class="flex items-center gap-1 h-[22px] px-2 mr-1 rounded text-[11px] font-medium border border-risk-med/40 text-risk-med hover:bg-risk-med/10 transition-colors shrink-0"
+            onclick={() => { app.showToast("info", "Regenerating guide…"); void app.cmd("generate_tour"); }}
+            title="The diff changed since this guide was generated — regenerate it"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+            Re-run guide
+          </button>
+        {/if}
         {#if tourAvailable}
           <div role="tablist" class="flex items-center bg-ink-800 border border-hairline rounded-md p-0.5 mr-1 shrink-0">
             <button
               role="tab"
               aria-selected={mode !== "tour"}
-              onclick={() => { if (mode === "tour") void app.cmd("set_mode", { mode: "branch" }); }}
+              onclick={exitGuideToDiff}
               class="h-[22px] px-2.5 rounded text-[11px] font-medium transition-colors {mode !== 'tour' ? 'bg-ink-650 text-fg cursor-default' : 'text-muted hover:text-fg-2'}"
             >
               Diff

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -112,10 +112,13 @@ export interface PillarSnapshot {
 }
 
 export interface TourSnapshot {
-  /** True when a tour.json exists for this branch (drives the Guide tab). */
+  /** True when a guided tour exists for the current view context (PR vs branch). */
   available: boolean;
-  /** True when the tour matches the current diff. */
+  /** True when the tour matches the current diff. When false and `available`,
+   *  the UI offers a "Re-run guide" affordance. */
   fresh: boolean;
+  /** Which diff the tour is attached to: `"pr"` or `"branch"`. */
+  scope: "pr" | "branch" | "";
   title: string;
   overviewMarkdown: string;
   pillars: PillarSnapshot[];


### PR DESCRIPTION
## What & why

The guided tour ("Guide") was hard-wired to the local **branch** diff. As a result:

1. **Bug:** Opening **Guide** while viewing the **PR diff** flipped the header toggle to **Local Branch** (and the Diff toggle always returned to the branch view).
2. The Guide button showed even when no guide existed for the diff you were looking at.
3. Generating a guide was not tied to the diff you were viewing.
4. There was no affordance to regenerate a guide after the diff changed.

This PR makes the Guide **context-aware** — it attaches to whichever diff you're viewing (PR diff or local branch) and stays there.

## Changes

- **Tour mode remembers its origin** (`TabState::tour_is_pr`, set in `set_mode`): a guide opened from the PR diff stays on the PR diff. The header **Local | PR Diff** toggle keeps **PR Diff** active in Guide mode, and the **Diff** toggle returns to the PR diff instead of the branch.
- **Per-context storage:** `tour.json` for the local branch diff, `tour.pr.json` for the PR diff (both in the branch bucket). `tour_filename()` / `tour_context_is_pr()` select the right one; `reload_context_tour()` routes loading. Remote PR tabs fall back to a legacy `tour.json` for backward compatibility.
- **Guide only shows when one exists for the current view** — a branch-only guide no longer surfaces in the PR diff (`snapshot.tour.available` is now context-scoped).
- **Generation targets the current view:** "Generate guide" captures the diff being viewed and writes the matching sidecar (the agent prompt writes the context filename).
- **Re-run affordance:** tour staleness moved to its own `AiState::tour_stale` (so a stale guide no longer dims the review/findings overlays) and drives a new **"Re-run guide"** button shown when the diff changed since the guide was generated. This also fixes prior PR-tour staleness, which compared against the branch hash.

## Tests

- New engine tests: `tour_context_and_filename_follow_view`, `set_mode_tour_records_origin_view`; updated the loader tour-staleness test for the new `tour_stale` field.
- `cargo test -p er-engine` (709 passing), `cargo check -p er-engine` / `-p er-tui`.
- `desktop-ui`: `svelte-check` (0 errors) and `bun test` (313 passing).

> [!NOTE]
> The Tauri desktop crate (`er-desktop`) couldn't be compiled in this environment (missing GTK/WebKit system libs), so its Rust changes (`snapshot.rs`, `commands.rs`) were reviewed by hand and exercised through the shared engine APIs. Worth a local `cargo check -p er-desktop` before merge.

> [!NOTE]
> Per the project's branching rules this is partly a feature, so it may belong on a release branch (with release notes) rather than `main` — retarget as you see fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkGM7Qy34dnxqDZzVir79o)_