### PR TITLE
Enable AI reviews in Guide (tour) mode

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -2858,7 +2858,8 @@ fn resolve_review_scope(scope: &str, tab: &er_engine::app::TabState) -> Result<S
             DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged => {
                 tab.mode.git_mode().to_string()
             }
-            DiffMode::PrDiff => "branch".to_string(),
+            // Guide (tour) reviews the branch diff it was built from.
+            DiffMode::PrDiff | DiffMode::Tour => "branch".to_string(),
             _ => {
                 return Err(format!(
                     "AI review not available in {} view — switch to All changes, PR Diff, Unstaged, or Staged",
@@ -7660,6 +7661,15 @@ mod tests {
         assert_eq!(resolve_review_scope("branch", &tab).unwrap(), "branch");
         assert_eq!(resolve_review_scope("current", &tab).unwrap(), "branch");
         assert_eq!(resolve_review_scope("pr", &tab).unwrap(), "branch");
+    }
+
+    #[test]
+    fn resolve_review_scope_accepts_tour_mode() {
+        // Guide (tour) reviews the branch diff it was regrouped from.
+        let mut tab = er_engine::app::TabState::new_for_test(vec![]);
+        tab.mode = er_engine::app::DiffMode::Tour;
+        assert_eq!(resolve_review_scope("branch", &tab).unwrap(), "branch");
+        assert_eq!(resolve_review_scope("current", &tab).unwrap(), "branch");
     }
 
     #[test]

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -2888,7 +2888,11 @@ pub fn list_diff_paths(state: State<AppState>) -> Result<Vec<String>, String> {
     let app = state.app.lock().map_err(|e| e.to_string())?;
     let tab = app.tab();
     match tab.mode {
-        DiffMode::Branch | DiffMode::Unstaged | DiffMode::Staged | DiffMode::PrDiff => {}
+        DiffMode::Branch
+        | DiffMode::Unstaged
+        | DiffMode::Staged
+        | DiffMode::PrDiff
+        | DiffMode::Tour => {}
         _ => {
             return Err(format!(
                 "File list not available in {} view",

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -2141,7 +2141,13 @@ impl TabState {
         match scope {
             "unstaged" => self.mode == DiffMode::Unstaged,
             "staged" => self.mode == DiffMode::Staged,
-            _ => self.mode == DiffMode::Branch || self.mode == DiffMode::PrDiff,
+            // Tour is the branch diff regrouped, so its cached raw_diff is the
+            // branch diff and matches a "branch"-scoped review.
+            _ => {
+                self.mode == DiffMode::Branch
+                    || self.mode == DiffMode::PrDiff
+                    || self.mode == DiffMode::Tour
+            }
         }
     }
 
@@ -8698,6 +8704,18 @@ mod tests {
         let mut tab = TabState::new_for_test(vec![]);
         tab.remote_repo = Some("owner/repo".to_string());
         assert!(tab.is_remote());
+    }
+
+    #[test]
+    fn review_scope_matches_cached_diff_treats_tour_as_branch() {
+        // Tour is the branch diff regrouped, so its cached raw_diff satisfies a
+        // "branch"-scoped review — no redundant git diff refetch.
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.mode = DiffMode::Tour;
+        assert!(tab.review_scope_matches_cached_diff("branch"));
+        // Working-tree scopes still don't match a Tour cache.
+        assert!(!tab.review_scope_matches_cached_diff("unstaged"));
+        assert!(!tab.review_scope_matches_cached_diff("staged"));
     }
 
     #[test]

--- a/desktop-ui/src/lib/components/AiReviewFilesModal.svelte
+++ b/desktop-ui/src/lib/components/AiReviewFilesModal.svelte
@@ -54,7 +54,7 @@
   const scopeLabel = $derived(
     mode === "pr"
       ? "PR Diff"
-      : mode === "branch"
+      : mode === "branch" || mode === "tour"
         ? "All changes"
         : mode === "unstaged"
           ? "Unstaged"

--- a/desktop-ui/src/lib/reviewScope.test.ts
+++ b/desktop-ui/src/lib/reviewScope.test.ts
@@ -7,6 +7,10 @@ describe("reviewScopeFromMode", () => {
     expect(reviewScopeFromMode("branch")).toBe("branch");
   });
 
+  it("maps guide (tour) to branch scope", () => {
+    expect(reviewScopeFromMode("tour")).toBe("branch");
+  });
+
   it("maps working-tree modes", () => {
     expect(reviewScopeFromMode("unstaged")).toBe("unstaged");
     expect(reviewScopeFromMode("staged")).toBe("staged");
@@ -21,5 +25,9 @@ describe("reviewScopeFromMode", () => {
 describe("scopeDescriptionFromMode", () => {
   it("describes PR diff mode", () => {
     expect(scopeDescriptionFromMode("pr")).toBe("PR diff vs base");
+  });
+
+  it("describes guide (tour) as the branch change set", () => {
+    expect(scopeDescriptionFromMode("tour")).toBe("All changes vs base");
   });
 });

--- a/desktop-ui/src/lib/reviewScope.ts
+++ b/desktop-ui/src/lib/reviewScope.ts
@@ -2,14 +2,16 @@ export type ReviewScope = "branch" | "unstaged" | "staged";
 
 /** Maps snapshot diff mode to the scope string passed to Tauri AI commands. */
 export function reviewScopeFromMode(mode: string | undefined): ReviewScope | null {
-  if (mode === "pr" || mode === "branch") return "branch";
+  // Guide (tour) is the branch diff regrouped into pillars — it reviews the
+  // same change set as branch/PR, and shares the same branch review bucket.
+  if (mode === "pr" || mode === "branch" || mode === "tour") return "branch";
   if (mode === "unstaged" || mode === "staged") return mode;
   return null;
 }
 
 export function scopeDescriptionFromMode(mode: string | undefined): string {
   if (mode === "pr") return "PR diff vs base";
-  if (mode === "branch") return "All changes vs base";
+  if (mode === "branch" || mode === "tour") return "All changes vs base";
   if (mode === "unstaged") return "Working tree changes";
   if (mode === "staged") return "Staged changes only";
   return "Switch to All changes, PR Diff, Unstaged, or Staged";

--- a/docs/release-notes/ai-reviews-in-guide-mode.md
+++ b/docs/release-notes/ai-reviews-in-guide-mode.md
@@ -1,0 +1,42 @@
+# AI reviews in Guide mode
+
+## What changed
+
+The Guide tab (the AI guided walkthrough — `tour.json`, internally `DiffMode::Tour`)
+now supports the full set of AI review actions, matching the Diff views:
+
+- Triage branch
+- Run review / Run reviewers… (General, experts, Professor)
+- Professor
+- Generate / Regenerate tour
+- Validate / re-anchor
+- Review select files
+
+Previously these were greyed out in Guide mode. Adding questions/notes and running
+**Elaborate** already worked there; this brings the rest of the AI Hub in line.
+
+## Why it's safe
+
+Guide is not a separate diff — it is the **branch diff regrouped into pillars**,
+built from the same `DiffFile` objects and sharing the same per-branch review
+bucket (`ReviewBucket::Branch`). Findings, inline comments, questions, and notes
+are keyed by file path (not by diff mode) and stored once per branch, so:
+
+- A review run from Guide writes to the same bucket Diff reads, and vice versa.
+- Findings and inline threads render in both views through the same pipeline.
+- No data is duplicated or mode-scoped — Diff and Guide stay in sync automatically.
+
+Running a review from Guide updates findings in place; it does **not** regenerate
+the pillar grouping (use *Regenerate tour* for that).
+
+## Implementation
+
+- `desktop-ui/src/lib/reviewScope.ts` — `reviewScopeFromMode("tour")` now maps to
+  the `"branch"` scope (was `null`, which disabled every review action). This
+  single mapping re-enables the gated actions in the AI Action Palette and the
+  Command Palette, since both key off `reviewScope != null`.
+- `crates/er-desktop/src/commands.rs` — `resolve_review_scope` accepts
+  `DiffMode::Tour` for the `"current"` scope (defensive; the frontend already
+  passes an explicit `"branch"` scope).
+- Tests: `reviewScope.test.ts` and `resolve_review_scope_accepts_tour_mode` cover
+  the new mapping.


### PR DESCRIPTION
## Summary

Guide mode (the AI guided walkthrough — `tour.json`, internally `DiffMode::Tour`) now supports the full set of AI review actions, matching the Diff views:

- Triage branch
- Run review / Run reviewers… (General, experts, Professor)
- Professor
- Generate / Regenerate tour
- Validate / re-anchor
- Review select files

Previously these were greyed out in Guide. Adding questions/notes and running **Elaborate** already worked there — this brings the rest of the AI Hub in line.

## Why it's safe (Diff and Guide already share everything)

Guide is **not a separate diff** — it's the branch diff regrouped into pillars, built from the same `DiffFile` objects and sharing the same per-branch review bucket (`ReviewBucket::Branch`). Findings, inline comments, questions, and notes are keyed by **file path** (not by diff mode) and stored once per branch, so:

- A review run from Guide writes to the same bucket Diff reads, and vice versa.
- Findings and inline threads render in both views through the same snapshot pipeline / `FlatDiffView`.
- Nothing is duplicated or mode-scoped — Diff and Guide stay in sync automatically.

Only the review *actions* were gated. The single blocker was the frontend helper `reviewScopeFromMode("tour")` returning `null`, which disabled every review action in the AI Action Palette and Command Palette (both key off `reviewScope != null`).

Running a review from Guide updates findings in place; it does **not** regenerate the pillar grouping (use *Regenerate tour* for that).

## Changes

- `desktop-ui/src/lib/reviewScope.ts` — `reviewScopeFromMode("tour")` → `"branch"` (was `null`); `scopeDescriptionFromMode("tour")` → "All changes vs base".
- `crates/er-desktop/src/commands.rs` — `resolve_review_scope` accepts `DiffMode::Tour` for the `"current"` scope (defensive; the frontend already passes an explicit `"branch"` scope).
- Tests: `reviewScope.test.ts` (2 new cases) and `resolve_review_scope_accepts_tour_mode`.
- Release notes: `docs/release-notes/ai-reviews-in-guide-mode.md`.

## Testing

- `vitest run src/lib/reviewScope.test.ts` → 6 passed.
- `cargo check -p er-engine` → clean. The `er-desktop` crate can't be compiled in this environment (missing GTK system libs); the backend change is a one-variant addition to an existing match arm that already had `DiffMode::PrDiff => "branch"`, plus a mirrored unit test.

Targeted at `release/v0.4.0` per the project's branching policy (features go on a release branch, not `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmWG6sLYoeNKjiuanUxB6y)_