### PR TITLE
Render commit timestamps as relative "time ago" in desktop

### DIFF
--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -676,7 +676,9 @@ pub struct CommitSummary {
     pub sha: String,
     pub title: String,
     pub author: String,
-    pub age: String,
+    /// ISO 8601 commit timestamp; the frontend renders it as a relative
+    /// "time ago" string (uniform across local and remote-PR commits).
+    pub committed_at: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2039,7 +2041,7 @@ fn build_commits_snapshot(tab: &TabState) -> Vec<CommitSummary> {
             sha: c.hash,
             title: c.subject,
             author: c.author,
-            age: c.relative_date,
+            committed_at: c.date,
         })
         .collect()
 }

--- a/crates/er-engine/src/git/status.rs
+++ b/crates/er-engine/src/git/status.rs
@@ -10,7 +10,6 @@ pub struct CommitInfo {
     pub short_hash: String,
     pub subject: String,
     pub author: String,
-    #[allow(dead_code)]
     pub date: String,
     pub relative_date: String,
     #[allow(dead_code)]

--- a/desktop-ui/src/lib/components/ScopeSelector.svelte
+++ b/desktop-ui/src/lib/components/ScopeSelector.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { app } from "$lib/stores/app.svelte";
   import type { CommitSummary } from "$lib/types";
+  import { timeAgo } from "$lib/time";
 
   interface Props {
     mode: "branch" | "unstaged" | "staged" | "history" | "pr" | "conflicts" | "hidden" | "tour";
@@ -212,7 +213,7 @@
                       ? 'color: var(--color-accent); background: var(--color-accent-soft); border: 1px solid var(--color-accent-border);'
                       : 'color: var(--color-muted); background: var(--color-card); border: 1px solid var(--color-hairline);'}"
                   >{commit.sha.slice(0, 7)}</span>
-                  <span class="text-[10px] text-muted">{commit.age}</span>
+                  <span class="text-[10px] text-muted">{timeAgo(commit.committed_at)}</span>
                   <!-- +/- and local badge: CommitSummary lacks additions/deletions/is_pushed fields — omitted until backend exposes them -->
                 </div>
               </div>

--- a/desktop-ui/src/lib/components/arena/ArenaHistoryList.svelte
+++ b/desktop-ui/src/lib/components/arena/ArenaHistoryList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ArenaRunSummary, RunStatus } from "$lib/types/arena";
   import { isArenaRunActive } from "$lib/stores/arena.svelte";
+  import { timeAgo } from "$lib/time";
 
   interface Props {
     summaries: ArenaRunSummary[];
@@ -50,19 +51,6 @@
     return "text-[var(--arena-fg-muted)]";
   }
 
-  function formatWhen(iso: string): string {
-    const t = Date.parse(iso);
-    if (Number.isNaN(t)) return iso;
-    const diff = Date.now() - t;
-    const min = Math.floor(diff / 60_000);
-    if (min < 1) return "just now";
-    if (min < 60) return `${min}m ago`;
-    const hr = Math.floor(min / 60);
-    if (hr < 24) return `${hr}h ago`;
-    const day = Math.floor(hr / 24);
-    return `${day}d ago`;
-  }
-
   function shortId(id: string): string {
     return id.length > 20 ? `${id.slice(0, 18)}…` : id;
   }
@@ -97,7 +85,7 @@
             </p>
             <p class="text-[10px] text-[var(--arena-fg-subtle)]">
               <span class={statusClass(run.status)}>{statusLabel(run.status)}</span>
-              · {formatWhen(run.created_at)}
+              · {timeAgo(run.created_at)}
               · {run.finding_count} findings
               · {run.reviewer_count} reviewer{run.reviewer_count === 1 ? "" : "s"}
             </p>

--- a/desktop-ui/src/lib/stories/fixtures.ts
+++ b/desktop-ui/src/lib/stories/fixtures.ts
@@ -418,11 +418,13 @@ export const worktreesMulti: WorktreeSnapshot[] = [
   { path: "/Users/vilfred/Projects/.codex/worktrees/c175", branch: "c175", is_current: false, is_pr: false, pr_number: null, is_merged: true },
 ];
 
+const isoAgo = (ms: number) => new Date(Date.now() - ms).toISOString();
+
 export const commitsRich: CommitSummary[] = [
-  { sha: "2afab9e0", title: "Fix lint errors in variant warning copy typings", author: "Vilfred", age: "45m" },
-  { sha: "d1a60769", title: "Add experiment-option resolver to combobox", author: "Claude", age: "1d" },
-  { sha: "54a9a3d2", title: "Wire warning metadata through dropdowns", author: "Vilfred", age: "2h" },
-  { sha: "2356d55a", title: "Merge branch 'main' into show-experiment-params", author: "Vilfred", age: "1h" },
+  { sha: "2afab9e0", title: "Fix lint errors in variant warning copy typings", author: "Vilfred", committed_at: isoAgo(45 * 60_000) },
+  { sha: "d1a60769", title: "Add experiment-option resolver to combobox", author: "Claude", committed_at: isoAgo(24 * 60 * 60_000) },
+  { sha: "54a9a3d2", title: "Wire warning metadata through dropdowns", author: "Vilfred", committed_at: isoAgo(2 * 60 * 60_000) },
+  { sha: "2356d55a", title: "Merge branch 'main' into show-experiment-params", author: "Vilfred", committed_at: isoAgo(60 * 60_000) },
 ];
 
 /** Active working-tree tab — ScopeSelector shows unstaged/staged/commits even when pr is set. */

--- a/desktop-ui/src/lib/time.test.ts
+++ b/desktop-ui/src/lib/time.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { timeAgo } from "./time";
+
+/** ISO string `ms` milliseconds before now. */
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("timeAgo", () => {
+  it("returns 'just now' under a minute", () => {
+    expect(timeAgo(ago(30_000))).toBe("just now");
+  });
+
+  it("formats minutes", () => {
+    expect(timeAgo(ago(16 * MIN))).toBe("16m ago");
+  });
+
+  it("formats hours", () => {
+    expect(timeAgo(ago(3 * HOUR))).toBe("3h ago");
+  });
+
+  it("formats days", () => {
+    expect(timeAgo(ago(5 * DAY))).toBe("5d ago");
+  });
+
+  it("formats weeks", () => {
+    expect(timeAgo(ago(14 * DAY))).toBe("2w ago");
+  });
+
+  it("formats months", () => {
+    expect(timeAgo(ago(90 * DAY))).toBe("3mo ago");
+  });
+
+  it("formats years", () => {
+    expect(timeAgo(ago(400 * DAY))).toBe("1y ago");
+  });
+
+  it("echoes a non-timestamp string unchanged", () => {
+    expect(timeAgo("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/desktop-ui/src/lib/time.ts
+++ b/desktop-ui/src/lib/time.ts
@@ -1,0 +1,28 @@
+/** Format an ISO 8601 timestamp as a compact "time ago" string (e.g. "16m ago",
+ *  "3h ago", "5d ago", "2w ago", "4mo ago", "1y ago"). Returns the input
+ *  unchanged if it isn't a parseable timestamp. */
+export function timeAgo(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+
+  const sec = Math.floor((Date.now() - t) / 1000);
+  if (sec < 60) return "just now";
+
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+
+  const wk = Math.floor(day / 7);
+  if (day < 30) return `${wk}w ago`;
+
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+
+  const yr = Math.floor(day / 365);
+  return `${yr}y ago`;
+}

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -298,7 +298,8 @@ export interface CommitSummary {
   sha: string;
   title: string;
   author: string;
-  age: string;
+  /** ISO 8601 commit timestamp; render via `timeAgo()` from `$lib/time`. */
+  committed_at: string;
 }
 
 export interface TabSummary {


### PR DESCRIPTION
## In plain terms

**The problem** — In the desktop app's COMMITS list, commits from a GitHub PR showed a raw machine timestamp like `2026-06-21T00:00:47Z` instead of a human-friendly "time ago". Commits from a local branch already showed a readable relative time, so the two looked inconsistent.

**Why it matters** — The commit list is meant to be scannable at a glance. A raw ISO timestamp is noise — you have to mentally subtract dates to know how recent a commit is — and the inconsistency between local and PR commits looks broken.

**The fix** — Send the commit's raw timestamp to the UI (it was already available and is identical in shape for both local and PR commits) and format it in one place on the frontend into a compact "16m ago" / "3h ago" / "5d ago" string. This makes every commit row read the same way regardless of where it came from.

**TL;DR** — Commit times now say "11h ago" instead of `2026-06-20T23:28:46Z`.

## What changed

- **`snapshot.rs`** — `CommitSummary.age` → `committed_at`, now carrying the ISO timestamp (`CommitInfo.date`) instead of a pre-formatted relative string. `CommitInfo.date` is uniformly ISO for both local (`git log %aI`) and remote-PR (`gh` `committedDate`) commits, so the single mapping covers every source.
- **`time.ts`** (new) — `timeAgo(iso)`: compact `just now` / `Xm` / `Xh` / `Xd` / `Xw` / `Xmo` / `Xy ago`, echoing the input unchanged if it isn't a parseable timestamp. Lifted the duplicated `ArenaHistoryList` formatter into it and reused it there.
- **`ScopeSelector.svelte`** — renders `timeAgo(commit.committed_at)`.
- **`status.rs`** — dropped the now-redundant `#[allow(dead_code)]` on `CommitInfo.date` (it has a consumer now).
- **`types.ts` / `fixtures.ts`** — field rename; added `time.test.ts` (8 cases covering each unit boundary + the non-ISO fallback).

## Root cause

The desktop snapshot's commit list (`build_commits_snapshot`) sourced the displayed string from `CommitInfo.relative_date`. For local commits that's git's `%ar` ("16 minutes ago"); for PR commits, `parse_pr_commits_view_value` set `relative_date` to the raw `committedDate` ISO with no conversion. So the PR path rendered an ISO string. Formatting from the always-ISO `date` field on the frontend fixes both paths uniformly.

## Known follow-up (out of scope here)

The **TUI** (`er-tui` `status_bar.rs:151`) still renders `commit.relative_date` directly, so remote-PR commits show ISO there too — same root cause, different surface, larger change (needs an ISO→relative formatter in Rust). Not addressed in this PR.

## Testing

- `svelte-check` — 0 errors
- `bun test src` — 313 pass (+ 8 new `timeAgo` tests)
- `cargo check -p er-engine -p er-desktop` — 0 warnings, 0 errors
- `cargo test -p er-engine parse_git_log` — 5 pass

## Rollback

Revert the single commit (`23993675`). No data/schema migration; pure display change.
