### PR TITLE
Linkify bare URLs in PR description (desktop)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ _TBD — summarize the headline features once the release is cut._
 ### Features
 - PR-cache: persist the top-10 "My PRs" / "To Review" PRs for instant sidebar render and checkout (stale-while-revalidate). (#74)
 - Preemptive "To Review" triage: background cheap-model triage scans for new non-draft PRs, surfaced in the Inbox. (#58)
+- Clickable bare URLs in the PR description (desktop) — plain `https://…` links in the Description block now render as anchors that open in the system browser, not just markdown-style `[text](url)` links.
 
 ### Fixes
 - _none yet_

--- a/desktop-ui/src/lib/markdown.test.ts
+++ b/desktop-ui/src/lib/markdown.test.ts
@@ -68,3 +68,43 @@ describe("parseMarkdown tables", () => {
     expect(html).toContain("&quot;onmouseover=");
   });
 });
+
+describe("renderInline bare URLs", () => {
+  it("linkifies a bare http(s) URL", () => {
+    expect(renderInline("see https://example.com/x for more")).toBe(
+      'see <a href="https://example.com/x" rel="noreferrer">https://example.com/x</a> for more',
+    );
+  });
+
+  it("keeps query strings (escaped &) inside a single href", () => {
+    const html = renderInline("https://e.com/p?a=1&b=2");
+    expect(html).toBe(
+      '<a href="https://e.com/p?a=1&amp;b=2" rel="noreferrer">https://e.com/p?a=1&amp;b=2</a>',
+    );
+  });
+
+  it("peels trailing sentence punctuation out of the link", () => {
+    expect(renderInline("go to https://e.com.")).toBe(
+      'go to <a href="https://e.com" rel="noreferrer">https://e.com</a>.',
+    );
+  });
+
+  it("peels an unbalanced closing paren but keeps balanced ones", () => {
+    expect(renderInline("(https://e.com/x)")).toBe(
+      '(<a href="https://e.com/x" rel="noreferrer">https://e.com/x</a>)',
+    );
+    expect(renderInline("https://e.com/foo_(bar)")).toBe(
+      '<a href="https://e.com/foo_(bar)" rel="noreferrer">https://e.com/foo_(bar)</a>',
+    );
+  });
+
+  it("does not double-link a URL already inside a markdown link", () => {
+    expect(renderInline("[site](https://e.com)")).toBe(
+      '<a href="https://e.com" rel="noreferrer">site</a>',
+    );
+  });
+
+  it("does not link a URL inside a code span", () => {
+    expect(renderInline("`https://e.com`")).toBe("<code>https://e.com</code>");
+  });
+});

--- a/desktop-ui/src/lib/markdown.test.ts
+++ b/desktop-ui/src/lib/markdown.test.ts
@@ -107,4 +107,17 @@ describe("renderInline bare URLs", () => {
   it("does not link a URL inside a code span", () => {
     expect(renderInline("`https://e.com`")).toBe("<code>https://e.com</code>");
   });
+
+  it("keeps the ';' that terminates an escaped entity at the end of a URL", () => {
+    // A URL ending in '&' escapes to '...&amp;'; peeling the ';' would corrupt it.
+    expect(renderInline("https://e.com/x?ref=&")).toBe(
+      '<a href="https://e.com/x?ref=&amp;" rel="noreferrer">https://e.com/x?ref=&amp;</a>',
+    );
+  });
+
+  it("still peels a real trailing semicolon (not part of an entity)", () => {
+    expect(renderInline("see https://e.com/x;")).toBe(
+      'see <a href="https://e.com/x" rel="noreferrer">https://e.com/x</a>;',
+    );
+  });
 });

--- a/desktop-ui/src/lib/markdown.ts
+++ b/desktop-ui/src/lib/markdown.ts
@@ -128,16 +128,50 @@ export function parseMarkdown(md: string): MarkdownNode[] {
   return out;
 }
 
-/** Render inline markdown (bold, italic, code, links) to safe HTML. */
+/**
+ * Wrap bare http(s) URLs in anchors. Runs last, over already-generated HTML,
+ * so it must skip URLs that are part of a tag we emitted: the preceding char
+ * must not be `"` (an href value), `>` (anchor text / a code span), `=` (an
+ * attribute), or a word char (mid-token). `^` covers the start of the string.
+ */
+function linkifyUrls(html: string): string {
+  return html.replace(/(^|[^"=>\w])(https?:\/\/[^\s<]+)/g, (_full, pre: string, rawUrl: string) => {
+    let url = rawUrl;
+    let trail = "";
+    // Peel trailing characters that are unlikely to belong to the URL:
+    // sentence punctuation always, and a closing paren only when unbalanced
+    // (so URLs that legitimately contain `(...)` survive).
+    for (;;) {
+      if (/[.,;:!?]$/.test(url)) {
+        trail = url.slice(-1) + trail;
+        url = url.slice(0, -1);
+        continue;
+      }
+      const opens = (url.match(/\(/g) ?? []).length;
+      const closes = (url.match(/\)/g) ?? []).length;
+      if (url.endsWith(")") && closes > opens) {
+        trail = ")" + trail;
+        url = url.slice(0, -1);
+        continue;
+      }
+      break;
+    }
+    return `${pre}<a href="${url}" rel="noreferrer">${url}</a>${trail}`;
+  });
+}
+
+/** Render inline markdown (bold, italic, code, links, bare URLs) to safe HTML. */
 export function renderInline(s: string): string {
   const escaped = s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
-  return escaped
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
-    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" rel="noreferrer">$1</a>');
+  return linkifyUrls(
+    escaped
+      .replace(/`([^`]+)`/g, "<code>$1</code>")
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" rel="noreferrer">$1</a>'),
+  );
 }

--- a/desktop-ui/src/lib/markdown.ts
+++ b/desktop-ui/src/lib/markdown.ts
@@ -142,7 +142,11 @@ function linkifyUrls(html: string): string {
     // sentence punctuation always, and a closing paren only when unbalanced
     // (so URLs that legitimately contain `(...)` survive).
     for (;;) {
-      if (/[.,;:!?]$/.test(url)) {
+      const punct = url.match(/[.,;:!?]$/);
+      if (punct) {
+        // Never strip the `;` that terminates an HTML entity (e.g. `&amp;`,
+        // `&gt;`, `&#39;`) produced by escaping — doing so corrupts the URL.
+        if (punct[0] === ";" && /&(?:#x?)?\w+;$/.test(url)) break;
         trail = url.slice(-1) + trail;
         url = url.slice(0, -1);
         continue;

--- a/docs/release-notes/clickable-links-in-pr-description.md
+++ b/docs/release-notes/clickable-links-in-pr-description.md
@@ -1,0 +1,44 @@
+# Clickable links in the PR description
+
+## What changed
+
+Bare `http(s)://…` URLs in a PR's Description block (desktop) are now rendered
+as clickable links. Previously only markdown-style `[text](url)` links were
+linkified; a plain URL — the common case when someone pastes a preview/deploy
+link into a PR body — showed as inert text.
+
+Clicking an autolinked URL behaves like every other link in the markdown
+renderer: it opens in the system browser via `open_url_in_browser` (the
+`onExternalLinkClick` handler on `MarkdownText`), never in-app.
+
+## Why it's safe
+
+The autolinker runs as the **last** step of `renderInline`, over HTML we've
+already generated and HTML-escaped, and it skips any URL that is already part
+of a tag — the character preceding the URL must not be `"` (an `href` value),
+`>` (anchor text or a code span), `=` (an attribute), or a word char. So a URL
+inside a markdown link, a code span, or an existing anchor is never
+double-wrapped, and the existing href-escaping guard (quotes → `&quot;`) is
+preserved. Query strings keep their escaped `&amp;` inside a single href, and
+trailing sentence punctuation / unbalanced closing parens are peeled out of the
+link so they don't get swallowed.
+
+## Scope note: PR description images
+
+A related ask was inlining images embedded in PR descriptions (e.g. an
+`<img src="https://github.com/user-attachments/assets/…">`). That is **not**
+included here: `user-attachments` asset URLs are gated behind the viewer's
+GitHub session and aren't anonymously hotlinkable, and the desktop webview has
+no GitHub credentials. Displaying them would require a backend pipeline that
+downloads the asset with authenticated `gh`, caches it under the app data dir,
+and serves the webview a local file URL — a separate change. As a lighter
+interim, an embedded image could be surfaced as a clickable link to the asset
+(opens in the browser, where the user is authenticated).
+
+## Implementation
+
+- `desktop-ui/src/lib/markdown.ts` — new `linkifyUrls()` helper, applied as the
+  final transform in `renderInline()`.
+- `desktop-ui/src/lib/markdown.test.ts` — covers autolinking, escaped query
+  strings, trailing-punctuation/paren peeling, and the no-double-link cases
+  (markdown links, code spans).

--- a/docs/release-notes/clickable-links-in-pr-description.md
+++ b/docs/release-notes/clickable-links-in-pr-description.md
@@ -21,7 +21,9 @@ inside a markdown link, a code span, or an existing anchor is never
 double-wrapped, and the existing href-escaping guard (quotes → `&quot;`) is
 preserved. Query strings keep their escaped `&amp;` inside a single href, and
 trailing sentence punctuation / unbalanced closing parens are peeled out of the
-link so they don't get swallowed.
+link so they don't get swallowed — except a trailing `;` that terminates an
+escaped HTML entity (`&amp;`, `&gt;`, …), which is kept so the URL isn't
+corrupted.
 
 ## Scope note: PR description images
 


### PR DESCRIPTION
## Summary

Plain `http(s)://…` URLs in a PR's **Description** block (desktop) now render as clickable links. Previously only markdown-style `[text](url)` links were linkified, so a pasted preview/deploy URL — exactly the case in the screenshot below — showed as inert text.

Clicking an autolinked URL behaves like every other markdown link: it opens in the system browser via `open_url_in_browser` (the `onExternalLinkClick` handler on `MarkdownText`), never in-app.

## How it works

A new `linkifyUrls()` helper runs as the **last** step of `renderInline`, over HTML that's already generated and escaped. It only wraps a URL when the preceding character is *not* one that signals the URL is already part of a tag (`"` href value, `>` anchor text / code span, `=` attribute, or a word char). So URLs inside markdown links, code spans, or existing anchors are never double-wrapped, and the existing href-escaping guard (`"` → `&quot;`) is preserved.

- Escaped query strings keep their `&amp;` inside a single href.
- Trailing sentence punctuation (`.,;:!?`) and unbalanced closing parens are peeled out of the link.

## Tests

`desktop-ui/src/lib/markdown.test.ts` adds coverage for autolinking, escaped query strings, trailing-punctuation/paren peeling, and the no-double-link cases (markdown links, code spans). `bun test src/lib/markdown.test.ts` → **15 pass**.

## Scope note: description images (the second half of the ask)

Inlining images embedded in PR bodies (e.g. `<img src="https://github.com/user-attachments/assets/…">`) is **not** included here, and it's a meaningfully larger change. The blocker isn't parsing — it's auth: `user-attachments` asset URLs are gated behind the viewer's GitHub session and aren't anonymously hotlinkable, and the desktop webview carries no GitHub credentials. Displaying them inline would require a backend pipeline that downloads the asset with authenticated `gh`, caches it under the app data dir, and serves the webview a local file URL (plus CSP/webview-policy allowances and cache cleanup). A lighter interim would be to surface an embedded image as a clickable link to the asset (opens in the browser, where the user is authenticated). Captured in `docs/release-notes/clickable-links-in-pr-description.md`.

## Notes

Targets `release/v0.4.0` per project policy (feature work, not a bug fix); release notes updated in `RELEASE_NOTES.md` and `docs/release-notes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY9WPuiPwT939getjERg38

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY9WPuiPwT939getjERg38)_