### PR TITLE
fix(desktop): enable Copy on inline comment/finding/note/question

### DIFF
--- a/crates/er-desktop/capabilities/default.json
+++ b/crates/er-desktop/capabilities/default.json
@@ -14,7 +14,7 @@
     "core:webview:allow-set-webview-size",
     "core:webview:allow-webview-show",
     "core:webview:allow-webview-hide",
-    "clipboard-manager:default",
+    "clipboard-manager:allow-write-text",
     "log:default",
     "notification:default",
     "window-state:default"

--- a/desktop-ui/src/lib/components/InlineThread.svelte
+++ b/desktop-ui/src/lib/components/InlineThread.svelte
@@ -6,7 +6,7 @@
   import ReplyActionBar from "$lib/components/ReplyActionBar.svelte";
   import MarkdownText from "$lib/components/ui/MarkdownText.svelte";
   import { navigateToThread } from "$lib/dom";
-  import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+  import { copyToClipboard } from "$lib/clipboard";
 
   interface Props {
     thread: ThreadSnapshot;
@@ -153,7 +153,7 @@
   async function copyThread() {
     const header = thread.line > 0 ? `${thread.file}:${thread.line}` : thread.file;
     const text = `**${header}**\n\n${buildPromoteBody()}`;
-    await writeText(text);
+    await copyToClipboard(text);
     justCopied = true;
     setTimeout(() => (justCopied = false), 1500);
   }

--- a/docs/release-notes/copy-inline-thread-actions.md
+++ b/docs/release-notes/copy-inline-thread-actions.md
@@ -1,0 +1,39 @@
+# Copy works on inline comments, findings, notes, and questions
+
+## What changed
+
+The **Copy** action in an inline thread's action bar (desktop) now actually
+copies. It was silently doing nothing on all four inline-thread surfaces —
+comments, findings, notes, and questions — which all share that one Copy
+button. Clicking it produced no "Copied" feedback and put nothing on the
+clipboard.
+
+## Why it failed
+
+Two issues stacked:
+
+1. The Tauri `clipboard-manager` plugin's `:default` permission set is
+   **empty** — the plugin grants no clipboard access by default ("clipboard
+   interaction needs to be explicitly enabled"). The desktop capability only
+   listed `clipboard-manager:default`, so the `writeText` IPC call was denied
+   by the ACL.
+2. `InlineThread.svelte` was the lone component calling the raw plugin
+   `writeText` with **no fallback**. The denied call threw before the
+   `justCopied = true` line, so neither the feedback flag nor the clipboard
+   write ever ran. The other copy buttons in the app route through the
+   `copyToClipboard` helper (which falls back to `navigator.clipboard`), which
+   masked the dead plugin path everywhere else.
+
+## The fix
+
+- `crates/er-desktop/capabilities/default.json` — replaced the empty
+  `clipboard-manager:default` with `clipboard-manager:allow-write-text`,
+  authorizing the plugin write path app-wide. Write-only: there is no
+  `readText` usage, so the grant is minimal.
+- `desktop-ui/src/lib/components/InlineThread.svelte` — routed Copy through the
+  shared `copyToClipboard` helper instead of the raw plugin `writeText`,
+  matching the other copy buttons and keeping Copy working in storybook /
+  non-Tauri contexts via the `navigator.clipboard` fallback.
+
+The capability is compiled into the binary by `tauri-build`, so the grant takes
+effect after a rebuild.


### PR DESCRIPTION
## In plain terms

**The problem** — In the desktop app, every inline review thread (a comment, an AI finding, a note, or a question) has a **Copy** button. Clicking it did nothing: no "Copied" confirmation, and nothing landed on your clipboard.

**Why it matters** — Copy is how you lift a finding or note out of the review to paste into a chat, an agent prompt, or a ticket. A dead Copy button quietly breaks that everyday hand-off — and because it failed silently, you'd only notice when the paste came up empty.

**The fix** — Two small changes. First, the desktop app never actually told the operating system "this app may write to the clipboard" (the clipboard plugin grants nothing unless you opt in), so we added that one permission. Second, the inline-thread Copy button was the only Copy in the app skipping the shared helper that has a browser fallback, so we routed it through that helper like every other Copy button.

**TL;DR** — The Copy button on inline review threads was silently broken; we granted the missing clipboard permission and made it use the same copy path as the rest of the app.

## What changed

- `crates/er-desktop/capabilities/default.json` — replaced the empty `clipboard-manager:default` permission set with `clipboard-manager:allow-write-text`. The plugin's `:default` set is intentionally empty ("clipboard interaction needs to be explicitly enabled"), so the `writeText` IPC was denied by the ACL. Write-only — there's no `readText` usage, so no over-grant.
- `desktop-ui/src/lib/components/InlineThread.svelte` — Copy now goes through the shared `copyToClipboard` helper (which falls back to `navigator.clipboard`) instead of the raw plugin `writeText`, matching the other copy buttons and keeping Copy working in storybook / non-Tauri contexts.
- `docs/release-notes/copy-inline-thread-actions.md` — release note for the fix.

## Testing

- `svelte-check` — 0 errors.
- Permission identifier `clipboard-manager:allow-write-text` confirmed valid in the generated Tauri ACL manifest (maps to the `write_text` command).
- **Manual (required — the capability is compiled into the binary by `tauri-build`, so a rebuild is needed):** rebuild via `scripts/tauri-dev.sh`, click Copy on a note **and** a finding, then confirm **both** (a) the green "Copied" checkmark appears and (b) pasting yields the markdown. If (a) shows but (b) is empty, the diagnosis was incomplete — flag it.

No automated test added: the ACL grant is build-time Tauri config and isn't unit-testable, and a "copyThread calls copyToClipboard" test would only assert implementation rather than behavior.

**Risk:** Level 1 (user-visible desktop fix). **Rollback:** revert the two commits on this branch.
