### PR TITLE
Scope reviews to Triage-recommended files in one click

### DIFF
--- a/desktop-ui/src/lib/components/AiReviewFilesModal.svelte
+++ b/desktop-ui/src/lib/components/AiReviewFilesModal.svelte
@@ -29,6 +29,7 @@
   import { fileTreeCollapse } from "$lib/stores/fileTreeCollapse.svelte";
   import { filesByPathMap } from "$lib/treeFromPaths";
   import { reviewScopeFromMode } from "$lib/reviewScope";
+  import { triageRecommendedPaths } from "$lib/triageSuggestions";
   import type { FileSnapshot } from "$lib/types";
 
   type SubView = "files" | "reviewers";
@@ -65,6 +66,19 @@
 
   const selectedCount = $derived(selected.size);
   const reviewerCount = $derived(selectedReviewers.size);
+
+  // Triage-recommended files present in this view — drives the quick-select button.
+  const triagePaths = $derived.by(() => {
+    const recommended = triageRecommendedPaths(app.snapshot?.ai.triage);
+    if (recommended.length === 0) return [];
+    const available = new Set(pickerFiles.map((f) => f.path));
+    return recommended.filter((p) => available.has(p));
+  });
+
+  function selectTriage() {
+    if (triagePaths.length === 0) return;
+    selected = new Set(triagePaths);
+  }
 
   function pathsToFileSnapshots(paths: string[]): FileSnapshot[] {
     const byPath = filesByPathMap(app.snapshot?.files ?? []);
@@ -290,6 +304,18 @@
       >
         Unmark all
       </button>
+      {#if triagePaths.length > 0}
+        <span class="text-ink-600">·</span>
+        <button
+          type="button"
+          class="text-xs text-info hover:text-info/80 disabled:opacity-40"
+          disabled={loading}
+          onclick={selectTriage}
+          title="Select only the files Triage flagged for review"
+        >
+          Triage ({triagePaths.length})
+        </button>
+      {/if}
       <span class="ml-auto text-[10px] text-ink-400 font-mono">{selectedCount} selected</span>
     </div>
 

--- a/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
+++ b/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
@@ -5,6 +5,7 @@
   import { openDiffFilePicker } from "$lib/components/AiReviewFilesModal.svelte";
   import { arena, type ArenaStartConfig } from "$lib/stores/arena.svelte";
   import { app } from "$lib/stores/app.svelte";
+  import { triageRecommendedPaths } from "$lib/triageSuggestions";
   import ArenaAgentPicker from "$lib/components/arena/ArenaAgentPicker.svelte";
   import type { AiProviderInfo, ReviewerInfo } from "$lib/types";
   import type { ArenaEstimate, ArenaLauncherScope, ArenaScope, ReviewerRef } from "$lib/types/arena";
@@ -276,6 +277,24 @@
         arenaLog("launcher: files selected", { count: paths.length });
       },
     });
+  }
+
+  /** Files Triage flagged for review — a one-click scope for the current diff. */
+  const triagePaths = $derived(triageRecommendedPaths(app.snapshot?.ai.triage));
+
+  const triageSelected = $derived(
+    scope === "selected" &&
+      triagePaths.length > 0 &&
+      selectedPaths.length === triagePaths.length &&
+      triagePaths.every((p) => selectedPaths.includes(p)),
+  );
+
+  function useTriageFiles() {
+    if (triagePaths.length === 0) return;
+    selectedPaths = [...triagePaths];
+    scope = "selected";
+    costApproved = false;
+    arenaLog("launcher: used triage files", { count: triagePaths.length });
   }
 
   function selectScope(next: ArenaLauncherScope) {
@@ -688,6 +707,24 @@
             {/each}
           </div>
         </div>
+
+        {#if triagePaths.length > 0}
+          <button
+            type="button"
+            aria-pressed={triageSelected}
+            onclick={useTriageFiles}
+            class="flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-[11px] transition-colors
+              {triageSelected
+              ? 'border-[var(--arena-periwinkle)] bg-[var(--arena-bg-2)]'
+              : 'border-[var(--arena-border)] bg-[var(--arena-bg-0)] hover:bg-[var(--arena-bg-2)]'}"
+          >
+            <span class="text-[var(--arena-info)]">◎</span>
+            <span class="font-medium text-[var(--arena-fg)]">
+              Review {triagePaths.length} triage-recommended file{triagePaths.length === 1 ? "" : "s"}
+            </span>
+            <span class="ml-auto text-[var(--arena-fg-subtle)]">from Triage</span>
+          </button>
+        {/if}
 
         {#if isArena || (isAgentsMode && agentArenaCount > 0)}
           <div

--- a/desktop-ui/src/lib/triageSuggestions.test.ts
+++ b/desktop-ui/src/lib/triageSuggestions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { triageRecommendedPaths } from "./triageSuggestions";
+import type { TriageSnapshot } from "./types";
+
+function makeTriage(overrides: Partial<TriageSnapshot> = {}): TriageSnapshot {
+  return {
+    fresh: true,
+    first_impression: "",
+    verdict_primary: "general",
+    experts: [],
+    rationale: "",
+    confidence: "",
+    priority_files: [],
+    files_changed: 0,
+    approx_risk: "",
+    domains: [],
+    ...overrides,
+  };
+}
+
+describe("triageRecommendedPaths", () => {
+  it("returns [] when there is no triage", () => {
+    expect(triageRecommendedPaths(null)).toEqual([]);
+    expect(triageRecommendedPaths(undefined)).toEqual([]);
+  });
+
+  it("returns [] when triage is stale", () => {
+    const triage = makeTriage({
+      fresh: false,
+      priority_files: [{ path: "src/a.rs", reason: "", risk: "high" }],
+    });
+    expect(triageRecommendedPaths(triage)).toEqual([]);
+  });
+
+  it("returns priority file paths in order", () => {
+    const triage = makeTriage({
+      priority_files: [
+        { path: "src/a.rs", reason: "session", risk: "high" },
+        { path: "src/b.rs", reason: "parsing", risk: "medium" },
+      ],
+    });
+    expect(triageRecommendedPaths(triage)).toEqual(["src/a.rs", "src/b.rs"]);
+  });
+
+  it("de-duplicates repeated paths while preserving first-seen order", () => {
+    const triage = makeTriage({
+      priority_files: [
+        { path: "src/a.rs", reason: "", risk: "high" },
+        { path: "src/b.rs", reason: "", risk: "low" },
+        { path: "src/a.rs", reason: "again", risk: "high" },
+      ],
+    });
+    expect(triageRecommendedPaths(triage)).toEqual(["src/a.rs", "src/b.rs"]);
+  });
+
+  it("skips empty paths", () => {
+    const triage = makeTriage({
+      priority_files: [
+        { path: "", reason: "", risk: "" },
+        { path: "src/a.rs", reason: "", risk: "high" },
+      ],
+    });
+    expect(triageRecommendedPaths(triage)).toEqual(["src/a.rs"]);
+  });
+});

--- a/desktop-ui/src/lib/triageSuggestions.ts
+++ b/desktop-ui/src/lib/triageSuggestions.ts
@@ -1,0 +1,23 @@
+import type { TriageSnapshot } from "$lib/types";
+
+/**
+ * File paths Triage flagged for review, in priority order, de-duplicated.
+ *
+ * Returns an empty array when there is no triage, the triage is stale
+ * (generated against a different diff), or it surfaced no priority files.
+ * Callers use the empty result to hide the "review triage files" quick action.
+ */
+export function triageRecommendedPaths(
+  triage: TriageSnapshot | null | undefined,
+): string[] {
+  if (!triage || !triage.fresh) return [];
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const pf of triage.priority_files) {
+    if (pf.path && !seen.has(pf.path)) {
+      seen.add(pf.path);
+      paths.push(pf.path);
+    }
+  }
+  return paths;
+}

--- a/docs/release-notes/triage-recommended-files-quick-select.md
+++ b/docs/release-notes/triage-recommended-files-quick-select.md
@@ -1,0 +1,49 @@
+# Triage-recommended files as a quick select
+
+## What changed
+
+When Triage has flagged specific files to review (its `priority_files`), you can
+now scope a review to exactly those files in one click — no manual file picking:
+
+- **Review select files** — the file picker shows a **Triage (N)** quick-select
+  button alongside *Mark all* / *Unmark all*. Clicking it narrows the selection
+  to just the Triage-recommended files, then you choose reviewers as usual.
+- **AI Review Arena** — the launcher shows a **Review N triage-recommended
+  files** button under the Scope control. Clicking it sets the run scope to those
+  files (equivalent to picking them in the "Selected" scope).
+
+This is most useful on large PRs, where a full review across every changed file
+is slow and costly. Triage does a fast first pass and surfaces the files that
+matter; this turns that recommendation into the default review scope with a
+single click.
+
+The button only appears when there is a **fresh** triage (generated against the
+current diff) that recommended at least one file. A stale triage hides it, so you
+never accidentally scope a review to an out-of-date recommendation.
+
+## Why it's safe
+
+The recommendation is read straight from the existing `TriageSnapshot.priority_files`
+already carried in the snapshot — no new backend command, no change to how
+reviews or arena runs are dispatched. Both entry points reuse the paths-based
+flows that already exist:
+
+- The file picker validates Triage paths against the current view's diff
+  (`list_diff_paths`), so only files actually present in the diff are selected.
+- The arena button sets the same `selectedPaths` / `"selected"` scope the manual
+  file picker already produces, so estimation and run dispatch are unchanged.
+
+## Implementation
+
+- `desktop-ui/src/lib/triageSuggestions.ts` — new pure helper
+  `triageRecommendedPaths(triage)` returns the fresh, de-duplicated priority-file
+  paths (empty for missing/stale/no-files triage).
+- `desktop-ui/src/lib/components/AiReviewFilesModal.svelte` — adds the **Triage
+  (N)** quick-select button (intersected with the loaded picker files). Works in
+  both the review flow and the arena's "pick files" flow, since they share the
+  modal.
+- `desktop-ui/src/lib/components/arena/ArenaLauncher.svelte` — adds the **Review
+  N triage-recommended files** button below the Scope control, with a
+  selected/pressed state when the current selection already matches Triage.
+- Tests: `triageSuggestions.test.ts` covers fresh/stale/missing/duplicate/empty
+  cases.


### PR DESCRIPTION
## What

When Triage has flagged specific files to review (its `priority_files`), you can now scope a review to exactly those files with a single click — in both review entry points. This is most useful on large PRs, where running a full review across every changed file is slow and costly: Triage does a fast first pass and surfaces the files that matter, and this turns that recommendation into the default review scope.

- **Review select files** — the file picker shows a **Triage (N)** quick-select button next to *Mark all* / *Unmark all*. Clicking it narrows the selection to just the Triage-recommended files, then you pick reviewers as usual.
- **AI Review Arena** — the launcher shows a **Review N triage-recommended files** button under the Scope control. Clicking it sets the run scope to those files (equivalent to picking them in the "Selected" scope), with a pressed state when the current selection already matches.

The button only appears when there is a **fresh** triage (generated against the current diff) that recommended at least one file. A stale triage hides it, so you never accidentally scope a review to an out-of-date recommendation.

## Why it's safe

The recommendation is read straight from the existing `TriageSnapshot.priority_files` already carried in the snapshot — no new backend command and no change to how reviews or arena runs are dispatched. Both entry points reuse the paths-based flows that already exist:

- The file picker validates Triage paths against the current view's diff (`list_diff_paths`), so only files actually present in the diff get selected.
- The arena button sets the same `selectedPaths` / `"selected"` scope the manual file picker already produces, so estimation and run dispatch are unchanged.

## Changes

- `desktop-ui/src/lib/triageSuggestions.ts` — new pure helper `triageRecommendedPaths(triage)` returning fresh, de-duplicated priority-file paths.
- `desktop-ui/src/lib/components/AiReviewFilesModal.svelte` — adds the **Triage (N)** quick-select button (intersected with the loaded picker files); shared with the arena's pick-files flow.
- `desktop-ui/src/lib/components/arena/ArenaLauncher.svelte` — adds the **Review N triage-recommended files** button below the Scope control.
- `docs/release-notes/triage-recommended-files-quick-select.md` — release note.

## Testing

- `desktop-ui/src/lib/triageSuggestions.test.ts` — covers fresh / stale / missing / duplicate / empty-path cases.
- `bun test src` → 567 pass, 0 fail.
- `bun run check` (svelte-check) → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWappfVQbmiTYdaP9i2ixA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWappfVQbmiTYdaP9i2ixA)_