### PR TITLE
Show agent intent in running-task titles

### DIFF
--- a/crates/er-engine/src/app/state/background.rs
+++ b/crates/er-engine/src/app/state/background.rs
@@ -43,7 +43,9 @@ impl BackgroundTaskTarget {
         )
     }
 
-    /// Human-readable label for UI ("branch-name", "owner/repo#123", etc.).
+    /// Human-readable label for the review *target* ("branch-name",
+    /// "owner/repo#123", etc.). This is the *where*, not the *what* — use
+    /// [`kind_label`] for the intent of the agent running against it.
     pub fn display_label(&self) -> String {
         if let (Some(slug), Some(n)) = (&self.remote_repo, self.pr_number) {
             return format!("{}#{}", slug, n);
@@ -52,6 +54,26 @@ impl BackgroundTaskTarget {
             self.repo_root.clone()
         } else {
             self.branch_label.clone()
+        }
+    }
+}
+
+/// Human-readable name for the *kind* of agent (the intent of the run) so
+/// concurrent tasks against the same target are distinguishable in the UI.
+/// Without this every agent on a branch shows the branch name and they look
+/// identical (e.g. a security pass and a professor pass running side by side).
+///
+/// Accepts the raw `BackgroundTask::kind` string: `"review"`/`"general"`,
+/// `"expert:<id>"`, `"professor"`, `"triage"`, or `"tour"`.
+pub fn kind_label(kind: &str) -> String {
+    match kind {
+        "" | "review" | "general" => "Review".to_string(),
+        "tour" => "Guide".to_string(),
+        other => {
+            // expert:<id>, professor, and triage all resolve through the
+            // shared finding-agent label map.
+            let id = other.strip_prefix("expert:").unwrap_or(other);
+            crate::ai::agent_label_for_category(id).to_string()
         }
     }
 }
@@ -154,7 +176,9 @@ impl BackgroundTaskSnapshot {
         Self {
             id: task.id.clone(),
             kind: task.kind.clone(),
-            label: task.target.display_label(),
+            // `label` is the agent's intent (what it's doing); `target_label`
+            // stays the branch/PR (where it's doing it) for secondary context.
+            label: kind_label(&task.kind),
             target_label: task.target.display_label(),
             scope: task.target.scope.clone(),
             repo_root: task.target.repo_root.clone(),
@@ -238,6 +262,37 @@ mod tests {
 
         let d = target("feat-a", "unstaged");
         assert_ne!(a, d);
+    }
+
+    #[test]
+    fn kind_label_shows_agent_intent() {
+        assert_eq!(kind_label("review"), "Review");
+        assert_eq!(kind_label("general"), "Review");
+        assert_eq!(kind_label(""), "Review");
+        assert_eq!(kind_label("tour"), "Guide");
+        assert_eq!(kind_label("professor"), "Professor");
+        assert_eq!(kind_label("triage"), "Triage");
+        assert_eq!(kind_label("expert:security"), "Security");
+        assert_eq!(kind_label("expert:performance"), "Performance");
+    }
+
+    #[test]
+    fn snapshot_label_is_intent_not_target() {
+        // Two agents on the same branch must produce distinct labels so the
+        // UI doesn't show the branch name twice.
+        let t = target("feat-a", "branch");
+        let sec = BackgroundTask::new("expert:security".to_string(), t.clone());
+        let prof = BackgroundTask::new("professor".to_string(), t.clone());
+
+        let sec_snap = BackgroundTaskSnapshot::from_task(&sec);
+        let prof_snap = BackgroundTaskSnapshot::from_task(&prof);
+
+        assert_eq!(sec_snap.label, "Security");
+        assert_eq!(prof_snap.label, "Professor");
+        assert_ne!(sec_snap.label, prof_snap.label);
+        // Target context is preserved separately.
+        assert_eq!(sec_snap.target_label, "feat-a");
+        assert_eq!(prof_snap.target_label, "feat-a");
     }
 
     #[test]

--- a/desktop-ui/src/lib/components/BackgroundTasks.svelte
+++ b/desktop-ui/src/lib/components/BackgroundTasks.svelte
@@ -60,40 +60,52 @@
   const pills = $derived.by<Pill[]>(() => {
     const out: Pill[] = [];
     if (running.length === 1) {
+      const t = running[0];
       out.push({
-        key: `run-${running[0].id}`,
+        key: `run-${t.id}`,
         status: "running",
-        text: `Review running · ${truncate(running[0].label)}`,
+        text: t.target_label
+          ? `${t.label} running · ${truncate(t.target_label)}`
+          : `${t.label} running`,
       });
     } else if (running.length > 1) {
       out.push({
         key: "run-multi",
         status: "running",
         text: `${running.length} reviews running`,
-        title: running.map((t) => t.label).join(", "),
+        title: running
+          .map((t) => (t.target_label ? `${t.label} · ${t.target_label}` : t.label))
+          .join(", "),
       });
     }
     if (queued.length === 1) {
+      const t = queued[0];
       out.push({
-        key: `queue-${queued[0].id}`,
+        key: `queue-${t.id}`,
         status: "queued",
-        text: `Review queued · ${truncate(queued[0].label)}`,
+        text: t.target_label
+          ? `${t.label} queued · ${truncate(t.target_label)}`
+          : `${t.label} queued`,
         title: "Waiting for a free review slot — click ✕ to remove",
-        cancelTaskId: queued[0].id,
+        cancelTaskId: t.id,
       });
     } else if (queued.length > 1) {
       out.push({
         key: "queue-multi",
         status: "queued",
         text: `${queued.length} reviews queued`,
-        title: queued.map((t) => t.label).join(", "),
+        title: queued
+          .map((t) => (t.target_label ? `${t.label} · ${t.target_label}` : t.label))
+          .join(", "),
       });
     }
     for (const t of failed) {
       out.push({
         key: `fail-${t.id}`,
         status: "failed",
-        text: `Review failed · ${truncate(t.label)}`,
+        text: t.target_label
+          ? `${t.label} failed · ${truncate(t.target_label)}`
+          : `${t.label} failed`,
         title: t.error ?? undefined,
       });
     }
@@ -101,7 +113,9 @@
       out.push({
         key: `done-${t.id}`,
         status: "done",
-        text: `Review done · ${truncate(t.label)}`,
+        text: t.target_label
+          ? `${t.label} done · ${truncate(t.target_label)}`
+          : `${t.label} done`,
       });
     }
     return out;

--- a/desktop-ui/src/lib/components/RunningAgentPanel.svelte
+++ b/desktop-ui/src/lib/components/RunningAgentPanel.svelte
@@ -139,7 +139,9 @@
   {#if activeTask}
     <!-- Task header -->
     <div class="flex items-center gap-2 px-3 py-1.5 shrink-0">
-      <span class="text-[10px] font-mono text-ink-200 truncate flex-1">{activeTask.label}</span>
+      <span class="text-[10px] font-mono text-ink-200 truncate flex-1">
+        {activeTask.label}{#if activeTask.target_label}<span class="text-ink-400"> · {activeTask.target_label}</span>{/if}
+      </span>
       {#if activeTask.status === "failed" && activeTask.error}
         <span class="text-[10px] font-mono text-del-fg shrink-0 truncate max-w-[120px]">{activeTask.error}</span>
       {:else}


### PR DESCRIPTION
## What & why

When multiple AI agents run against the same branch, the running-agents popover and the bottom status pills showed **the branch name as the title for every task** — so a security pass and a professor pass running side by side looked identical, with no way to tell which agent was which.

This makes each running task title show its **intent** instead.

Before (both tasks):
```
dur/dev-6418-update…  [branch]
dur/dev-6418-update…  [branch]
```
After:
```
Security  [branch]
Professor [branch]
```

## Changes

- **`crates/er-engine/src/app/state/background.rs`**
  - Add `kind_label(kind)` — maps a `BackgroundTask::kind` (`review`/`general`, `expert:<id>`, `professor`, `triage`, `tour`) to a human-readable intent (`Review`, `Security`, `Professor`, `Triage`, `Guide`, …) via the existing `ai::agent_label_for_category` map.
  - `BackgroundTaskSnapshot::from_task` now sets `label` to the intent (the *what*) while `target_label` keeps the branch/PR (the *where*).
  - Tests for `kind_label` and for two same-branch tasks producing distinct labels.
- **`desktop-ui/src/lib/components/RunningAgentPanel.svelte`** — tab strip already renders `label`; the panel header now appends a dimmed `· <target_label>` so the branch context isn't lost.
- **`desktop-ui/src/lib/components/BackgroundTasks.svelte`** — status pills now read `"<intent> running · <branch>"` (and the same for queued/failed/done), avoiding the redundant `"Review running · Review"`.

The desktop inbox notifications already used `target_label` for their titles, so their bodies now carry the intent instead of duplicating the branch — a small bonus, no behavior regressions.

## Testing

- `cargo test -p er-engine background` — all 11 pass, including the two new tests.
- `cargo build -p er-engine` — clean.
- Desktop (`er-desktop`) and the Svelte typecheck couldn't be built in this environment (missing GTK system libs / frontend deps); the frontend edits use the already-present `target_label` field on `BackgroundTaskSnapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUUFyG2rcSwhvCFsgCzysG)_