### PR TITLE
Improve Cmd+click reference usages: wider expand, full-diff scope, expand-on-jump

### DIFF
--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -1093,45 +1093,46 @@
   // popover lists them. Only computed while a highlight is active.
   const RULER_MARK_HEIGHT_PX = 3;
 
+  // Collect usage sources from the FULL diff — every file, including ones the
+  // user has collapsed — so the references popover reflects the whole diff, not
+  // just what is currently rendered. Each line's `rowIdx` is its position in
+  // the live (post-collapse) render model, or -1 when its file is collapsed
+  // (and thus has no rendered row); the (filePath, hunkIdx, lineIdx) anchor
+  // lets `jumpToUsageLine` expand the file and re-resolve the row on click.
   function collectUsageSources(): UsageSource[] {
-    const rows = crossFileModel.rows;
+    // Map each rendered line's LineSnapshot to its current row index. Using
+    // object identity covers both unified rows and split rows (whose left/right
+    // sides reuse the same LineSnapshot objects from the hunk).
+    const lineToRow = new Map<LineSnapshot, number>();
     const byPath = new Map(files.map((f) => [f.path, f]));
-    const out: UsageSource[] = [];
+    const rows = crossFileModel.rows;
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i];
       if (row.type === "content-unified") {
         const line = byPath.get(row.filePath)?.hunks[row.hunkIdx]?.lines[row.lineIdx];
-        if (line && line.kind !== "fold") {
-          out.push({
-            rowIdx: i,
-            filePath: row.filePath,
-            lineNum: line.new_num ?? line.old_num,
-            text: line.text,
-            hunkIdx: row.hunkIdx,
-          });
-        }
+        if (line) lineToRow.set(line, i);
       } else if (row.type === "content-split") {
         const sr =
           crossFileModel.splitRowsByFile.get(row.filePath)?.[row.hunkIdx]?.[row.splitRowIdx];
-        if (!sr) continue;
-        const { left, right } = sr;
-        if (left && left.kind !== "fold") {
+        if (sr?.left) lineToRow.set(sr.left, i);
+        if (sr?.right) lineToRow.set(sr.right, i);
+      }
+    }
+
+    const out: UsageSource[] = [];
+    for (const file of files) {
+      for (let h = 0; h < file.hunks.length; h++) {
+        const lines = file.hunks[h].lines;
+        for (let l = 0; l < lines.length; l++) {
+          const line = lines[l];
+          if (line.kind === "fold") continue;
           out.push({
-            rowIdx: i,
-            filePath: row.filePath,
-            lineNum: left.new_num ?? left.old_num,
-            text: left.text,
-            hunkIdx: row.hunkIdx,
-          });
-        }
-        // Context rows reuse the same LineSnapshot on both sides — count once.
-        if (right && right !== left && right.kind !== "fold") {
-          out.push({
-            rowIdx: i,
-            filePath: row.filePath,
-            lineNum: right.new_num ?? right.old_num,
-            text: right.text,
-            hunkIdx: row.hunkIdx,
+            rowIdx: lineToRow.get(line) ?? -1,
+            filePath: file.path,
+            lineNum: line.new_num ?? line.old_num,
+            text: line.text,
+            hunkIdx: h,
+            lineIdx: l,
           });
         }
       }
@@ -1139,16 +1140,29 @@
     return out;
   }
 
+  /** Current render-model row for a usage, re-resolved from its stable anchor
+   *  (filePath, hunkIdx, lineIdx). -1 when the line still has no rendered row
+   *  (file collapsed or not yet loaded). */
+  function resolveUsageRow(u: Pick<UsageSource, "filePath" | "hunkIdx" | "lineIdx">): number {
+    const match = usageSourcesAll.find(
+      (s) => s.filePath === u.filePath && s.hunkIdx === u.hunkIdx && s.lineIdx === u.lineIdx,
+    );
+    return match?.rowIdx ?? -1;
+  }
+
   /** Upper bound on collected matches — a one-letter Cmd+F query over a huge
    *  diff must not build an unbounded match list. */
   const SEARCH_MATCH_CAP = 5000;
 
-  // Flat line list in render order — shared by match collection and the
-  // context previews (ruler hover popover, popover row expansion). Only
-  // materialized while a highlight is active.
-  const usageSources = $derived.by((): UsageSource[] =>
+  // Flat line list, only materialized while a highlight is active.
+  // Full diff (all files, including collapsed) — drives the references popover
+  // and the context previews (popover row expansion, ruler hover).
+  const usageSourcesAll = $derived.by((): UsageSource[] =>
     refHighlight.identifier ? collectUsageSources() : [],
   );
+  // Rendered subset — drives the overview ruler and Cmd+F search, both of which
+  // can only scroll to a row that exists in the live render model.
+  const usageSources = $derived(usageSourcesAll.filter((s) => s.rowIdx >= 0));
 
   // Identifier highlights and Cmd+F queries share this pipeline; the store's
   // matchOptions switch between whole-word and substring/smart-case matching.
@@ -1159,15 +1173,25 @@
   });
   const usageLines = $derived(usageResult.lines);
 
+  // Popover usages span the whole diff (collapsed files included).
+  const usageLinesAll = $derived.by((): UsageLine[] => {
+    const ident = refHighlight.identifier;
+    if (!ident) return [];
+    return collectMatches(usageSourcesAll, ident, refHighlight.matchOptions, SEARCH_MATCH_CAP)
+      .lines;
+  });
+
   /** Context window the Cmd+click popover reveals when a usage row is
    *  expanded. Wider than the ruler-hover tooltip's compact peek so a
    *  multi-line construct (a function definition, a block) shows its body
    *  inline instead of just the signature's immediate neighbors. */
   const POPOVER_CONTEXT_LINES = 8;
 
-  /** Context lines around a usage (ruler hover popover, popover expansion). */
+  /** Context lines around a usage (ruler hover popover, popover expansion).
+   *  Resolved over the full-diff sources so context works for usages in
+   *  collapsed files too. */
   function contextForUsage(u: UsageLine, contextLines?: number): UsageContextLine[] {
-    return usageContext(usageSources, u, contextLines);
+    return usageContext(usageSourcesAll, u, contextLines);
   }
 
   /** First matched line at a ruler mark's row, with its surrounding context. */
@@ -1230,6 +1254,35 @@
     applyScrollTop(Math.max(0, top - viewportHeightPx / 2));
     await tick();
     requestAnimationFrame(() => flashRowEl(rowIdx));
+  }
+
+  /**
+   * Jump from a usage row in the references popover. A usage may live in a
+   * collapsed (or not-yet-loaded) file, which has no rendered row — expand and
+   * load it first, then re-resolve the row from the usage's stable anchor and
+   * route through the shared `jumpToUsage` so the scroll + flash are identical.
+   */
+  async function jumpToUsageLine(u: UsageLine): Promise<void> {
+    let rebuilt = false;
+    if (diffFileCollapse.isCollapsed(u.filePath)) {
+      diffFileCollapse.expand(u.filePath);
+      rebuilt = true;
+    }
+    const file = files.find((f) => f.path === u.filePath);
+    if (file?.is_lazy_stub) {
+      await requestLazyFiles([file.source_index]);
+      rebuilt = true;
+    }
+    if (rebuilt) {
+      // Let the model re-derive and the new rows lay out before reading offsets.
+      await tick();
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      );
+    }
+    const rowIdx = rebuilt ? resolveUsageRow(u) : u.rowIdx;
+    if (rowIdx < 0) return;
+    await jumpToUsage(rowIdx);
   }
 
   // ── Cmd+F search navigation (PR #73) ──────────────────────────────────────
@@ -1961,9 +2014,9 @@
   {#if refHighlight.popoverOpen && refHighlight.identifier !== null}
     <ReferenceUsagesPopover
       identifier={refHighlight.identifier}
-      usages={usageLines}
+      usages={usageLinesAll}
       anchor={refHighlight.popoverAnchor}
-      onJump={jumpToUsage}
+      onJump={jumpToUsageLine}
       getContext={(u) => contextForUsage(u, POPOVER_CONTEXT_LINES)}
     />
   {/if}

--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -1159,9 +1159,15 @@
   });
   const usageLines = $derived(usageResult.lines);
 
+  /** Context window the Cmd+click popover reveals when a usage row is
+   *  expanded. Wider than the ruler-hover tooltip's compact peek so a
+   *  multi-line construct (a function definition, a block) shows its body
+   *  inline instead of just the signature's immediate neighbors. */
+  const POPOVER_CONTEXT_LINES = 8;
+
   /** Context lines around a usage (ruler hover popover, popover expansion). */
-  function contextForUsage(u: UsageLine): UsageContextLine[] {
-    return usageContext(usageSources, u);
+  function contextForUsage(u: UsageLine, contextLines?: number): UsageContextLine[] {
+    return usageContext(usageSources, u, contextLines);
   }
 
   /** First matched line at a ruler mark's row, with its surrounding context. */
@@ -1958,7 +1964,7 @@
       usages={usageLines}
       anchor={refHighlight.popoverAnchor}
       onJump={jumpToUsage}
-      getContext={contextForUsage}
+      getContext={(u) => contextForUsage(u, POPOVER_CONTEXT_LINES)}
     />
   {/if}
   </div>

--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -1161,8 +1161,15 @@
     refHighlight.identifier ? collectUsageSources() : [],
   );
   // Rendered subset — drives the overview ruler and Cmd+F search, both of which
-  // can only scroll to a row that exists in the live render model.
-  const usageSources = $derived(usageSourcesAll.filter((s) => s.rowIdx >= 0));
+  // can only scroll to a row that exists in the live render model. Sorted by
+  // rowIdx because both consumers require ascending render order: the ruler's
+  // buildRulerMarks merges by increasing offset, and Cmd+F steps linearly. The
+  // full-diff order is file→hunk→line, which is non-monotonic in split view
+  // (a modify block's del and add lines share a row but are visited apart);
+  // the stable sort restores render order while keeping del before add.
+  const usageSources = $derived(
+    usageSourcesAll.filter((s) => s.rowIdx >= 0).sort((a, b) => a.rowIdx - b.rowIdx),
+  );
 
   // Identifier highlights and Cmd+F queries share this pipeline; the store's
   // matchOptions switch between whole-word and substring/smart-case matching.

--- a/desktop-ui/src/lib/components/ReferenceUsagesPopover.svelte
+++ b/desktop-ui/src/lib/components/ReferenceUsagesPopover.svelte
@@ -11,8 +11,10 @@
    *   (capped height) and horizontally (file-path headers and code previews
    *   are unwrappable single lines; the `min-w-full w-max` inner wrapper
    *   lets them extend past the popover width and scroll into view).
-   * - Each row has a chevron that expands ~2 adjacent context lines inline
-   *   under the row (match emphasized). Multiple rows can be expanded;
+   * - Each row has a chevron that expands a window of adjacent context lines
+   *   inline under the row (match emphasized) — wide enough to show a
+   *   referenced function's body, not just its signature. Multiple rows can be
+   *   expanded;
    *   expansion never affects keyboard navigation — arrows still move
    *   between usage rows and Enter still jumps.
    * - Esc closes the popover first (global handler in `keyboard.ts`); a

--- a/desktop-ui/src/lib/components/ReferenceUsagesPopover.svelte
+++ b/desktop-ui/src/lib/components/ReferenceUsagesPopover.svelte
@@ -2,11 +2,13 @@
   /**
    * Cmd+click usages popover (issue #69) — a fixed-position panel anchored
    * near the clicked token, listing every word-boundary usage of the
-   * highlighted identifier across the rendered diff, grouped by file.
+   * highlighted identifier across the whole diff (collapsed files included),
+   * grouped by file.
    *
-   * - Click a usage (or ArrowUp/Down + Enter) to jump via `onJump` — the
-   *   exact same shared jump (`jumpToUsage` in FlatDiffView) a ruler-mark
-   *   click uses, so the scroll + `.flash` ring are identical — then close.
+   * - Click a usage (or ArrowUp/Down + Enter) to jump via `onJump`
+   *   (`jumpToUsageLine` in FlatDiffView), which expands the file first when
+   *   it's collapsed, then routes through the same shared scroll + `.flash`
+   *   ring a ruler-mark click uses — then close.
    * - Long one-line content never truncates: the list scrolls vertically
    *   (capped height) and horizontally (file-path headers and code previews
    *   are unwrappable single lines; the `min-w-full w-max` inner wrapper
@@ -36,7 +38,9 @@
     identifier: string;
     usages: UsageLine[];
     anchor: { x: number; y: number } | null;
-    onJump: (rowIdx: number) => void;
+    /** Jump to a usage. The parent expands the file first when it's collapsed,
+     *  so the whole usage (with its stable anchor) is handed over, not a row. */
+    onJump: (usage: UsageLine) => void;
     /** Surrounding lines for a usage (shown when a row is expanded). */
     getContext: (u: UsageLine) => UsageContextLine[];
   }
@@ -99,7 +103,7 @@
     // to remove). The jump itself is the same shared call both entry points
     // bind — identical scroll centering and `.flash` ring.
     refHighlight.closePopover();
-    onJump(u.rowIdx);
+    onJump(u);
   }
 
   async function move(delta: number): Promise<void> {

--- a/desktop-ui/src/lib/referenceUsages.test.ts
+++ b/desktop-ui/src/lib/referenceUsages.test.ts
@@ -273,6 +273,22 @@ describe("usageContext", () => {
     expect(out.map((l) => l.isMatch)).toEqual([false, true]);
   });
 
+  it("uses the (hunkIdx, lineIdx) anchor to pick the right hunk in a collapsed file", () => {
+    // Same collapsed file, two hunks, a line with identical text + lineNum in
+    // each (rowIdx -1 everywhere). The anchor must select the hunk-1 line, not
+    // the first text/lineNum match in hunk 0.
+    const dup: UsageSource[] = [
+      { rowIdx: -1, filePath: "a.ts", lineNum: 3, text: "ctx", hunkIdx: 0, lineIdx: 0 },
+      { rowIdx: -1, filePath: "a.ts", lineNum: 4, text: "foo()", hunkIdx: 0, lineIdx: 1 },
+      { rowIdx: -1, filePath: "a.ts", lineNum: 4, text: "foo()", hunkIdx: 1, lineIdx: 0 },
+      { rowIdx: -1, filePath: "a.ts", lineNum: 5, text: "after", hunkIdx: 1, lineIdx: 1 },
+    ];
+    const out = usageContext(dup, dup[2], 1);
+    // Context must come from hunk 1 (the "after" line), never hunk 0's "ctx".
+    expect(out.map((l) => l.text)).toEqual(["foo()", "after"]);
+    expect(out.map((l) => l.isMatch)).toEqual([true, false]);
+  });
+
   it("falls back to the usage line alone when it is not in the sources", () => {
     const out = usageContext(sources, { rowIdx: 99, filePath: "z.ts", lineNum: 7, text: "gone" });
     expect(out).toEqual([{ rowIdx: 99, lineNum: 7, text: "gone", isMatch: true }]);

--- a/desktop-ui/src/lib/referenceUsages.test.ts
+++ b/desktop-ui/src/lib/referenceUsages.test.ts
@@ -259,6 +259,20 @@ describe("usageContext", () => {
     expect(out.map((l) => l.lineNum)).toEqual([1, 2, 3]);
   });
 
+  it("disambiguates collapsed-file usages (shared rowIdx -1) by filePath", () => {
+    // Two collapsed files: every line has rowIdx -1 (no rendered row) and they
+    // happen to share a line number. filePath must pick the right anchor.
+    const collapsed: UsageSource[] = [
+      { rowIdx: -1, filePath: "a.ts", lineNum: 1, text: "before a", hunkIdx: 0, lineIdx: 0 },
+      { rowIdx: -1, filePath: "a.ts", lineNum: 2, text: "foo in a", hunkIdx: 0, lineIdx: 1 },
+      { rowIdx: -1, filePath: "b.ts", lineNum: 1, text: "before b", hunkIdx: 0, lineIdx: 0 },
+      { rowIdx: -1, filePath: "b.ts", lineNum: 2, text: "foo in b", hunkIdx: 0, lineIdx: 1 },
+    ];
+    const out = usageContext(collapsed, collapsed[3], 1);
+    expect(out.map((l) => l.text)).toEqual(["before b", "foo in b"]);
+    expect(out.map((l) => l.isMatch)).toEqual([false, true]);
+  });
+
   it("falls back to the usage line alone when it is not in the sources", () => {
     const out = usageContext(sources, { rowIdx: 99, filePath: "z.ts", lineNum: 7, text: "gone" });
     expect(out).toEqual([{ rowIdx: 99, lineNum: 7, text: "gone", isMatch: true }]);

--- a/desktop-ui/src/lib/referenceUsages.ts
+++ b/desktop-ui/src/lib/referenceUsages.ts
@@ -191,22 +191,27 @@ export interface UsageContextLine {
  * on screen but not in the file. At the first/last line of a hunk or of the
  * whole list, fewer lines are returned.
  *
- * The usage is located by `filePath` + `rowIdx` + `text` + `lineNum` (split
- * rows can share a `rowIdx` between their left and right sides; collapsed-file
- * usages all share `rowIdx === -1`, so `filePath` disambiguates them). When it
- * cannot be found (e.g. the diff refreshed underneath a stale reference), the
- * usage line itself is returned alone so callers always have something to
- * render.
+ * The usage is located by its `(filePath, hunkIdx, lineIdx)` anchor when those
+ * are known, falling back to `filePath` + `rowIdx` + `text` + `lineNum`. The
+ * anchor matters for collapsed files: every line there shares `rowIdx === -1`,
+ * so two lines with the same text and line number in different hunks would
+ * otherwise be indistinguishable. (Split rows can also share a `rowIdx` between
+ * their left and right sides, disambiguated by `text`/`lineNum`/`lineIdx`.)
+ * When the usage cannot be found (e.g. the diff refreshed underneath a stale
+ * reference), the usage line itself is returned alone so callers always have
+ * something to render.
  */
 export function usageContext(
   sources: UsageSource[],
-  usage: Pick<UsageSource, "rowIdx" | "filePath" | "lineNum" | "text">,
+  usage: Pick<UsageSource, "rowIdx" | "filePath" | "lineNum" | "text" | "hunkIdx" | "lineIdx">,
   contextLines = 2,
 ): UsageContextLine[] {
   const idx = sources.findIndex(
     (s) =>
       s.filePath === usage.filePath &&
       s.rowIdx === usage.rowIdx &&
+      s.hunkIdx === usage.hunkIdx &&
+      s.lineIdx === usage.lineIdx &&
       s.text === usage.text &&
       s.lineNum === usage.lineNum,
   );

--- a/desktop-ui/src/lib/referenceUsages.ts
+++ b/desktop-ui/src/lib/referenceUsages.ts
@@ -29,6 +29,13 @@ export interface UsageSource {
    * the underlying file, so their lines are not real context for each other.
    */
   hunkIdx?: number;
+  /**
+   * Line index within its hunk, when known. Together with `filePath`/`hunkIdx`
+   * this is a stable anchor that survives collapse: a usage in a collapsed
+   * file has no rendered row (`rowIdx === -1`), so jumping re-resolves the row
+   * from this anchor after the file is expanded.
+   */
+  lineIdx?: number;
 }
 
 /** A line with at least one word-boundary match of the active identifier. */
@@ -184,10 +191,12 @@ export interface UsageContextLine {
  * on screen but not in the file. At the first/last line of a hunk or of the
  * whole list, fewer lines are returned.
  *
- * The usage is located by `rowIdx` + `text` + `lineNum` (split rows can share
- * a `rowIdx` between their left and right sides). When it cannot be found
- * (e.g. the diff refreshed underneath a stale reference), the usage line
- * itself is returned alone so callers always have something to render.
+ * The usage is located by `filePath` + `rowIdx` + `text` + `lineNum` (split
+ * rows can share a `rowIdx` between their left and right sides; collapsed-file
+ * usages all share `rowIdx === -1`, so `filePath` disambiguates them). When it
+ * cannot be found (e.g. the diff refreshed underneath a stale reference), the
+ * usage line itself is returned alone so callers always have something to
+ * render.
  */
 export function usageContext(
   sources: UsageSource[],
@@ -195,7 +204,11 @@ export function usageContext(
   contextLines = 2,
 ): UsageContextLine[] {
   const idx = sources.findIndex(
-    (s) => s.rowIdx === usage.rowIdx && s.text === usage.text && s.lineNum === usage.lineNum,
+    (s) =>
+      s.filePath === usage.filePath &&
+      s.rowIdx === usage.rowIdx &&
+      s.text === usage.text &&
+      s.lineNum === usage.lineNum,
   );
   if (idx === -1) {
     return [{ rowIdx: usage.rowIdx, lineNum: usage.lineNum, text: usage.text, isMatch: true }];


### PR DESCRIPTION
Three related improvements to the desktop Cmd+click references popover.

## 1. Expand reveals the function body, not just the signature

Expanding a usage row only showed **±2 context lines** — for a function definition that meant the signature was visible but the body was cut off, reading as if the function had been "collapsed." The popover now expands a wider window (**±8 lines**, via `POPOVER_CONTEXT_LINES`). The compact ruler-hover tooltip keeps its ±2 peek.

## 2. References cover the whole diff (collapsed files included)

Usages were collected only from currently-rendered rows, so references inside **collapsed files were missing** from the list and the count. Collection now runs over the full diff — every file, collapsed or not. Each usage carries:
- its current render-model `rowIdx`, or `-1` when its file is collapsed (no rendered row), and
- a stable `(filePath, hunkIdx, lineIdx)` anchor.

The overview ruler and Cmd+F search keep their rendered-only view (`usageSources` is the `rowIdx >= 0` subset) — they can only scroll to rows that actually exist.

## 3. Clicking a collapsed-file reference unfolds it and jumps

`jumpToUsageLine` expands the file (and loads it if it's a lazy stub), waits for the model to re-derive, re-resolves the row from the usage's anchor, then routes through the same shared scroll + `.flash` ring every reference jump uses. So clicking a reference in a collapsed file now unfolds that file and lands on the line.

`usageContext` also now disambiguates by `filePath`, since every line in a collapsed file shares `rowIdx === -1`.

## Changes

- `desktop-ui/src/lib/components/FlatDiffView.svelte` — full-diff usage collection with row/anchor resolution; `usageSourcesAll` (full) + `usageSources` (rendered subset); `usageLinesAll` for the popover; `POPOVER_CONTEXT_LINES`; `jumpToUsageLine` / `resolveUsageRow`.
- `desktop-ui/src/lib/components/ReferenceUsagesPopover.svelte` — `onJump` now passes the usage (not a row); doc comments.
- `desktop-ui/src/lib/referenceUsages.ts` — `UsageSource.lineIdx`; `usageContext` matches on `filePath`.
- `desktop-ui/src/lib/referenceUsages.test.ts` — wider-context note + collapsed-file disambiguation test.

## Testing

- `bun test src/lib/referenceUsages.test.ts src/lib/diffRenderModel.test.ts` — 73 pass.
- Full `bun test src` — no new failures (3 pre-existing failures are an environment issue: `svelte` package not installed for `diffNav.svelte.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)