### PR TITLE
Don't open terminal on backtick while typing a comment

### DIFF
--- a/desktop-ui/src/lib/stores/keyboard.ts
+++ b/desktop-ui/src/lib/stores/keyboard.ts
@@ -291,7 +291,7 @@ export function initKeyboard(): () => void {
     ) {
       return;
     }
-    if (e.key === "`" && !target.closest(".xterm")) {
+    if (e.key === "`" && !inField && !target.closest(".xterm")) {
       e.preventDefault();
       terminal.toggle();
       return;


### PR DESCRIPTION
## Problem

When composing an inline comment (or typing in any input/textarea), pressing `` ` `` toggled the embedded terminal instead of inserting a backtick. The global backtick shortcut only guarded against focus being inside the terminal (`.xterm`), not against focus being in a text field, so `e.preventDefault()` swallowed the keystroke.

## Fix

Gate the backtick → `terminal.toggle()` shortcut on `!inField` in `desktop-ui/src/lib/stores/keyboard.ts`. `inField` already covers `INPUT`, `TEXTAREA`, `SELECT`, and `contentEditable`, so backticks now land in the comment text while the shortcut still works everywhere else.

The inline comment composer (`DiffComposer.svelte`) uses a `<textarea>`, which is covered by `inField`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPh6B6vtaq9MXkDy46eRSN)_