### PR TITLE
Co-locate tests and supporting files in the Guide

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -984,10 +984,11 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
         return Vec::new();
     };
     if pillar_id == "__other__" {
+        // A file is "assigned" if it is any pillar's primary or related file.
         let assigned: std::collections::HashSet<&str> = tour
             .pillars
             .iter()
-            .flat_map(|p| p.files.iter().map(|f| f.path.as_str()))
+            .flat_map(|p| p.all_file_paths())
             .collect();
         return tab
             .active_diff_files()
@@ -1000,9 +1001,8 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
         .iter()
         .find(|p| p.id == pillar_id)
         .map(|p| {
-            p.files
-                .iter()
-                .map(|f| f.path.clone())
+            p.all_file_paths()
+                .map(|p| p.to_string())
                 .filter(|p| diff_paths.contains(p.as_str()))
                 .collect()
         })

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -983,30 +983,17 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
     let Some(tour) = tab.ai.tour.as_ref() else {
         return Vec::new();
     };
-    // The diff-present paths a pillar owns, using the SAME rule as the desktop
-    // snapshot (`build_tour_snapshot`): a primary that is in the diff, plus that
-    // primary's related files that are in the diff. A related file whose primary
-    // is absent is NOT owned here — it surfaces standalone in "Other changes",
-    // exactly as the snapshot places it. Keeping the two in sync is what lets a
-    // pillar's "Review all" reach 100%.
-    let owned = |p: &er_engine::ai::TourPillar| -> Vec<String> {
-        let mut out = Vec::new();
-        for f in &p.files {
-            if !diff_paths.contains(f.path.as_str()) {
-                continue;
-            }
-            out.push(f.path.clone());
-            for r in &f.related {
-                if diff_paths.contains(r.path.as_str()) {
-                    out.push(r.path.clone());
-                }
-            }
-        }
-        out
-    };
+    // Use the shared ownership rule (`ErTour::pillar_ownership`) so bulk-review
+    // attributes each file to exactly the pillar the desktop snapshot displays
+    // it under — including the global cross-pillar dedup that gives a shared
+    // related file to the first pillar that references it. Keeping these in sync
+    // is what lets a pillar's "Review all" reach 100%.
+    let ownership = tour.pillar_ownership(|p| diff_paths.contains(p));
     if pillar_id == "__other__" {
-        let assigned: std::collections::HashSet<String> =
-            tour.pillars.iter().flat_map(&owned).collect();
+        let assigned: std::collections::HashSet<&str> = ownership
+            .iter()
+            .flat_map(|(_, paths)| paths.iter().map(String::as_str))
+            .collect();
         return tab
             .active_diff_files()
             .iter()
@@ -1014,10 +1001,10 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
             .filter(|p| !assigned.contains(p.as_str()))
             .collect();
     }
-    tour.pillars
-        .iter()
-        .find(|p| p.id == pillar_id)
-        .map(&owned)
+    ownership
+        .into_iter()
+        .find(|(id, _)| id == pillar_id)
+        .map(|(_, paths)| paths)
         .unwrap_or_default()
 }
 

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -983,13 +983,30 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
     let Some(tour) = tab.ai.tour.as_ref() else {
         return Vec::new();
     };
+    // The diff-present paths a pillar owns, using the SAME rule as the desktop
+    // snapshot (`build_tour_snapshot`): a primary that is in the diff, plus that
+    // primary's related files that are in the diff. A related file whose primary
+    // is absent is NOT owned here — it surfaces standalone in "Other changes",
+    // exactly as the snapshot places it. Keeping the two in sync is what lets a
+    // pillar's "Review all" reach 100%.
+    let owned = |p: &er_engine::ai::TourPillar| -> Vec<String> {
+        let mut out = Vec::new();
+        for f in &p.files {
+            if !diff_paths.contains(f.path.as_str()) {
+                continue;
+            }
+            out.push(f.path.clone());
+            for r in &f.related {
+                if diff_paths.contains(r.path.as_str()) {
+                    out.push(r.path.clone());
+                }
+            }
+        }
+        out
+    };
     if pillar_id == "__other__" {
-        // A file is "assigned" if it is any pillar's primary or related file.
-        let assigned: std::collections::HashSet<&str> = tour
-            .pillars
-            .iter()
-            .flat_map(|p| p.all_file_paths())
-            .collect();
+        let assigned: std::collections::HashSet<String> =
+            tour.pillars.iter().flat_map(&owned).collect();
         return tab
             .active_diff_files()
             .iter()
@@ -1000,12 +1017,7 @@ fn pillar_file_paths(tab: &er_engine::app::TabState, pillar_id: &str) -> Vec<Str
     tour.pillars
         .iter()
         .find(|p| p.id == pillar_id)
-        .map(|p| {
-            p.all_file_paths()
-                .map(|p| p.to_string())
-                .filter(|p| diff_paths.contains(p.as_str()))
-                .collect()
-        })
+        .map(&owned)
         .unwrap_or_default()
 }
 

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -1488,11 +1488,11 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
                         reason: r.reason.clone(),
                     })
                     .collect();
+                // Reuse `make_file` for the field copy, then swap in the
+                // diff-filtered/deduped related set (single construction site).
                 files.push(TourFileRef {
-                    path: f.path.clone(),
-                    reason: f.reason.clone(),
-                    finding_ids: f.finding_ids.clone(),
                     related,
+                    ..make_file(f)
                 });
             }
             if files.is_empty() {
@@ -1538,8 +1538,19 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
             });
         }
     } else {
+        // Unstaged/Staged/History show a different diff than the branch tour, so
+        // the tour's related metadata can't be validated against it. Drop related
+        // here (only `available`/pillar-count is consumed in these modes) so
+        // `count_total` isn't inflated by files absent from the visible diff.
         for p in tour.ordered_pillars() {
-            let files: Vec<TourFileRef> = p.files.iter().map(&make_file).collect();
+            let files: Vec<TourFileRef> = p
+                .files
+                .iter()
+                .map(|f| TourFileRef {
+                    related: Vec::new(),
+                    ..make_file(f)
+                })
+                .collect();
             let reviewed_count = count_reviewed(&files);
             let total_count = count_total(&files);
             pillars.push(PillarSnapshot {

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -1466,6 +1466,9 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
 
     if branch_scope {
         // Filter to files actually in the diff; dedup so a file shows once.
+        // This per-pillar primary+related assignment with a global `seen` is the
+        // same ownership rule as `ErTour::pillar_ownership` (which bulk-review
+        // uses via `pillar_file_paths`) — keep the two in sync.
         let diff_paths: std::collections::HashSet<&str> =
             tab.files.iter().map(|f| f.path.as_str()).collect();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -265,6 +265,19 @@ pub struct TourFileRef {
     pub path: String,
     pub reason: String,
     pub finding_ids: Vec<String>,
+    /// Co-located files (tests/styles/stories/snapshots) shown nested under this
+    /// row in the Guide. Only includes related files present in the diff.
+    pub related: Vec<RelatedFileRef>,
+}
+
+/// A co-located related file nested under a `TourFileRef` (wire form).
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedFileRef {
+    pub path: String,
+    /// `"test"`, `"style"`, `"story"`, `"snapshot"`, or `"other"`.
+    pub kind: String,
+    pub reason: String,
 }
 
 /// One tour pillar (wire form) with per-pillar review progress.
@@ -1427,13 +1440,27 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
         path: f.path.clone(),
         reason: f.reason.clone(),
         finding_ids: f.finding_ids.clone(),
+        related: f
+            .related
+            .iter()
+            .map(|r| RelatedFileRef {
+                path: r.path.clone(),
+                kind: r.kind.clone(),
+                reason: r.reason.clone(),
+            })
+            .collect(),
     };
+    // A pillar's review progress counts each primary file plus its co-located
+    // related files (they are real diff files the reviewer steps through).
     let count_reviewed = |files: &[TourFileRef]| {
         files
             .iter()
-            .filter(|f| tab.reviewed.contains_key(&f.path))
+            .flat_map(|f| std::iter::once(&f.path).chain(f.related.iter().map(|r| &r.path)))
+            .filter(|p| tab.reviewed.contains_key(p.as_str()))
             .count()
     };
+    let count_total =
+        |files: &[TourFileRef]| files.iter().map(|f| 1 + f.related.len()).sum::<usize>();
 
     let mut pillars: Vec<PillarSnapshot> = Vec::new();
 
@@ -1448,13 +1475,31 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
                 if !diff_paths.contains(f.path.as_str()) || !seen.insert(f.path.clone()) {
                     continue;
                 }
-                files.push(make_file(f));
+                // Keep only related files present in the diff and not already
+                // shown elsewhere; mark them seen so they don't also land in a
+                // later pillar or the "Other changes" bucket.
+                let related: Vec<RelatedFileRef> = f
+                    .related
+                    .iter()
+                    .filter(|r| diff_paths.contains(r.path.as_str()) && seen.insert(r.path.clone()))
+                    .map(|r| RelatedFileRef {
+                        path: r.path.clone(),
+                        kind: r.kind.clone(),
+                        reason: r.reason.clone(),
+                    })
+                    .collect();
+                files.push(TourFileRef {
+                    path: f.path.clone(),
+                    reason: f.reason.clone(),
+                    finding_ids: f.finding_ids.clone(),
+                    related,
+                });
             }
             if files.is_empty() {
                 continue;
             }
             let reviewed_count = count_reviewed(&files);
-            let total_count = files.len();
+            let total_count = count_total(&files);
             pillars.push(PillarSnapshot {
                 id: p.id.clone(),
                 title: p.title.clone(),
@@ -1475,11 +1520,12 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
                 path: f.path.clone(),
                 reason: String::new(),
                 finding_ids: Vec::new(),
+                related: Vec::new(),
             })
             .collect();
         if !other.is_empty() {
             let reviewed_count = count_reviewed(&other);
-            let total_count = other.len();
+            let total_count = count_total(&other);
             pillars.push(PillarSnapshot {
                 id: "__other__".to_string(),
                 title: "Other changes".to_string(),
@@ -1495,7 +1541,7 @@ fn build_tour_snapshot(tab: &TabState) -> TourSnapshot {
         for p in tour.ordered_pillars() {
             let files: Vec<TourFileRef> = p.files.iter().map(&make_file).collect();
             let reviewed_count = count_reviewed(&files);
-            let total_count = files.len();
+            let total_count = count_total(&files);
             pillars.push(PillarSnapshot {
                 id: p.id.clone(),
                 title: p.title.clone(),

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -504,7 +504,8 @@ pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str, output_fil
    - `foundation: true` for pillars other pillars build on (data models, core types, shared utilities, schema). Order these first.
    - `importance` (0–100) ranks reviewer attention; higher sorts earlier among non-foundation.
    - Each pillar: a short `title`, a 1–3 sentence markdown `description` (what it is and what to look for), and its `files` (new-side paths) in reading order, each with a one-line `reason`.
-   - Every changed file appears in exactly one pillar. 3–7 pillars is ideal.
+   - **Co-locate tests and supporting files.** When a changed file has an accompanying test, style, story, or snapshot in the diff (e.g. `foo.ts` + `foo.test.ts`/`foo.spec.ts`, `foo.css`/`foo.scss`, `foo.stories.ts`, `__snapshots__/foo.snap`), attach it to its source file's `related` array instead of listing it as a separate `files` entry. Set `kind` to `"test"`, `"style"`, `"story"`, `"snapshot"`, or `"other"`. The reviewer then sees each file with its tests nested beneath it. A related file is owned by its source file, not a standalone pillar entry.
+   - Every changed file appears exactly once — as a pillar `files` entry **or** as one file's `related` child. 3–7 pillars is ideal.
 5. Write `{safe_output_dir}/{safe_output_file}` (and nothing else) with this exact shape:
 
 ```json
@@ -523,12 +524,21 @@ pub fn build_tour_prompt_prepared_diff(scope: &str, output_dir: &str, output_fil
       "importance": 90,
       "foundation": true,
       "files": [
-        {{"path": "src/foo.rs", "reason": "...", "finding_ids": []}}
+        {{
+          "path": "src/foo.ts",
+          "reason": "...",
+          "finding_ids": [],
+          "related": [
+            {{"path": "src/foo.test.ts", "kind": "test", "reason": "Tests for foo"}}
+          ]
+        }}
       ]
     }}
   ]
 }}
 ```
+
+`related` is optional and defaults to empty — omit it for files with no co-located test/style/story/snapshot in the diff.
 
 Do NOT modify `review.json`, `order.json`, or any other file. Write only `{safe_output_file}`."#
     )

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -274,6 +274,42 @@ pub struct TourFile {
     /// Optional links to `review.json` finding ids surfaced for this file.
     #[serde(default)]
     pub finding_ids: Vec<String>,
+    /// Co-located files that belong with this one (its tests, styles, stories,
+    /// snapshots). They render nested beneath the parent in the guide instead of
+    /// as standalone rows, so a reviewer sees a file and its tests together.
+    #[serde(default)]
+    pub related: Vec<TourRelatedFile>,
+}
+
+/// A file co-located with a `TourFile` (a test, style, story, or snapshot for
+/// it). Rendered as an indented child row under its parent in the guide.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TourRelatedFile {
+    /// New-side path; matches `DiffFile.path`. Only rendered when present in the
+    /// current diff.
+    pub path: String,
+    /// Relationship kind: `"test"`, `"style"`, `"story"`, `"snapshot"`, or
+    /// `"other"`. Drives the small label shown next to the nested row.
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub reason: String,
+}
+
+impl TourFile {
+    /// This file's path followed by its related (co-located) file paths, in
+    /// reading order.
+    pub fn all_paths(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.path.as_str()).chain(self.related.iter().map(|r| r.path.as_str()))
+    }
+}
+
+impl TourPillar {
+    /// All paths assigned to this pillar — each file followed by its co-located
+    /// related files — in reading order.
+    pub fn all_file_paths(&self) -> impl Iterator<Item = &str> {
+        self.files.iter().flat_map(|f| f.all_paths())
+    }
 }
 
 impl ErTour {
@@ -290,11 +326,12 @@ impl ErTour {
         pillars
     }
 
-    /// The pillar a given file path belongs to, if any.
+    /// The pillar a given file path belongs to, if any. Matches both a pillar's
+    /// primary files and their co-located related files.
     pub fn file_pillar(&self, path: &str) -> Option<&TourPillar> {
         self.pillars
             .iter()
-            .find(|p| p.files.iter().any(|f| f.path == path))
+            .find(|p| p.all_file_paths().any(|fp| fp == path))
     }
 }
 
@@ -2757,5 +2794,96 @@ mod tests {
         assert_eq!(ordered.len(), 1);
         assert_eq!(ordered[0].1, Some(0));
         assert_eq!(ordered[0].3, "f_some");
+    }
+
+    // ── Tour related (co-located) files ──
+
+    fn tour_file_with_related(path: &str, related: Vec<(&str, &str)>) -> TourFile {
+        TourFile {
+            path: path.to_string(),
+            reason: String::new(),
+            finding_ids: Vec::new(),
+            related: related
+                .into_iter()
+                .map(|(p, kind)| TourRelatedFile {
+                    path: p.to_string(),
+                    kind: kind.to_string(),
+                    reason: String::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn pillar_with(id: &str, files: Vec<TourFile>) -> TourPillar {
+        TourPillar {
+            id: id.to_string(),
+            title: id.to_string(),
+            description: String::new(),
+            order: 0,
+            importance: 0,
+            foundation: false,
+            files,
+        }
+    }
+
+    #[test]
+    fn tour_file_all_paths_includes_related_in_order() {
+        let tf = tour_file_with_related(
+            "src/foo.ts",
+            vec![("src/foo.test.ts", "test"), ("src/foo.css", "style")],
+        );
+        let paths: Vec<&str> = tf.all_paths().collect();
+        assert_eq!(paths, vec!["src/foo.ts", "src/foo.test.ts", "src/foo.css"]);
+    }
+
+    #[test]
+    fn tour_pillar_all_file_paths_flattens_primaries_and_related() {
+        let pillar = pillar_with(
+            "p-1",
+            vec![
+                tour_file_with_related("a.ts", vec![("a.test.ts", "test")]),
+                tour_file_with_related("b.ts", vec![]),
+            ],
+        );
+        let paths: Vec<&str> = pillar.all_file_paths().collect();
+        assert_eq!(paths, vec!["a.ts", "a.test.ts", "b.ts"]);
+    }
+
+    #[test]
+    fn file_pillar_resolves_related_file_to_its_parent_pillar() {
+        let tour = ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![pillar_with(
+                "p-1",
+                vec![tour_file_with_related("a.ts", vec![("a.test.ts", "test")])],
+            )],
+        };
+        // Both the primary and its related file resolve to the same pillar.
+        assert_eq!(tour.file_pillar("a.ts").map(|p| p.id.as_str()), Some("p-1"));
+        assert_eq!(
+            tour.file_pillar("a.test.ts").map(|p| p.id.as_str()),
+            Some("p-1")
+        );
+        assert!(tour.file_pillar("missing.ts").is_none());
+    }
+
+    #[test]
+    fn tour_file_related_defaults_to_empty_when_absent() {
+        // Old tour.json without a `related` field still parses.
+        let json = r#"{"path": "a.ts", "reason": "r", "finding_ids": []}"#;
+        let tf: TourFile = serde_json::from_str(json).unwrap();
+        assert!(tf.related.is_empty());
+    }
+
+    #[test]
+    fn tour_related_file_kind_defaults_to_empty() {
+        let json = r#"{"path": "a.test.ts"}"#;
+        let r: TourRelatedFile = serde_json::from_str(json).unwrap();
+        assert_eq!(r.kind, "");
+        assert_eq!(r.reason, "");
     }
 }

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -326,6 +326,40 @@ impl ErTour {
         pillars
     }
 
+    /// Assign each in-diff path to the single pillar that owns it, in display
+    /// order. A primary present in the diff claims itself plus its in-diff
+    /// related files; the **first** pillar (in display order) to reference a
+    /// path wins (global `seen`). This is the one ownership rule the desktop
+    /// snapshot (`build_tour_snapshot`) and bulk-review (`pillar_file_paths`)
+    /// must agree on, so it lives here as the single source of truth.
+    ///
+    /// Returns `(pillar_id, owned_paths)` per pillar, `owned_paths` in reading
+    /// order (each primary followed by its related). Paths owned by no pillar
+    /// are the caller's "Other changes".
+    pub fn pillar_ownership<F>(&self, in_diff: F) -> Vec<(String, Vec<String>)>
+    where
+        F: Fn(&str) -> bool,
+    {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for p in self.ordered_pillars() {
+            let mut owned = Vec::new();
+            for f in &p.files {
+                if !in_diff(&f.path) || !seen.insert(f.path.clone()) {
+                    continue;
+                }
+                owned.push(f.path.clone());
+                for r in &f.related {
+                    if in_diff(&r.path) && seen.insert(r.path.clone()) {
+                        owned.push(r.path.clone());
+                    }
+                }
+            }
+            out.push((p.id.clone(), owned));
+        }
+        out
+    }
+
     /// The pillar a given file path belongs to, if any. Matches both a pillar's
     /// primary files and their co-located related files.
     pub fn file_pillar(&self, path: &str) -> Option<&TourPillar> {
@@ -2885,5 +2919,96 @@ mod tests {
         let r: TourRelatedFile = serde_json::from_str(json).unwrap();
         assert_eq!(r.kind, "");
         assert_eq!(r.reason, "");
+    }
+
+    #[test]
+    fn pillar_ownership_assigns_primary_and_related_per_pillar() {
+        let tour = ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![
+                pillar_with(
+                    "p-1",
+                    vec![tour_file_with_related("a.ts", vec![("a.test.ts", "test")])],
+                ),
+                pillar_with("p-2", vec![tour_file_with_related("b.ts", vec![])]),
+            ],
+        };
+        let in_diff = |p: &str| matches!(p, "a.ts" | "a.test.ts" | "b.ts");
+        let ownership = tour.pillar_ownership(in_diff);
+        assert_eq!(
+            ownership,
+            vec![
+                (
+                    "p-1".to_string(),
+                    vec!["a.ts".to_string(), "a.test.ts".to_string()]
+                ),
+                ("p-2".to_string(), vec!["b.ts".to_string()]),
+            ]
+        );
+    }
+
+    #[test]
+    fn pillar_ownership_first_pillar_wins_for_shared_related() {
+        // The same related file listed under two pillars must be owned by the
+        // first pillar only — so bulk-review attribution can't double-count it.
+        let tour = ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![
+                pillar_with(
+                    "p-1",
+                    vec![tour_file_with_related(
+                        "a.ts",
+                        vec![("shared.snap", "snapshot")],
+                    )],
+                ),
+                pillar_with(
+                    "p-2",
+                    vec![tour_file_with_related(
+                        "b.ts",
+                        vec![("shared.snap", "snapshot")],
+                    )],
+                ),
+            ],
+        };
+        let in_diff = |p: &str| matches!(p, "a.ts" | "b.ts" | "shared.snap");
+        let ownership = tour.pillar_ownership(in_diff);
+        assert_eq!(
+            ownership,
+            vec![
+                (
+                    "p-1".to_string(),
+                    vec!["a.ts".to_string(), "shared.snap".to_string()]
+                ),
+                ("p-2".to_string(), vec!["b.ts".to_string()]),
+            ]
+        );
+    }
+
+    #[test]
+    fn pillar_ownership_skips_related_when_primary_absent() {
+        let tour = ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![pillar_with(
+                "p-1",
+                vec![tour_file_with_related("a.ts", vec![("a.test.ts", "test")])],
+            )],
+        };
+        // Only the related file is in the diff; its primary is absent.
+        let in_diff = |p: &str| p == "a.test.ts";
+        let ownership = tour.pillar_ownership(in_diff);
+        // p-1 owns nothing → a.test.ts is unowned ("Other changes").
+        assert_eq!(ownership, vec![("p-1".to_string(), Vec::<String>::new())]);
     }
 }

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -238,6 +238,10 @@ pub struct TourState {
     pub selected_pillar: usize,
     /// Flattened, pillar-ordered diff files for the whole tour.
     pub files: Vec<DiffFile>,
+    /// Per-`files` flag: `true` when this row is a co-located related file (a
+    /// test/style/story/snapshot nested under the preceding primary file).
+    /// Rendered indented in the pillar list. Always the same length as `files`.
+    pub file_is_related: Vec<bool>,
     /// `(start, end_exclusive)` index range into `files` for each pillar.
     pub pillar_file_ranges: Vec<(usize, usize)>,
     /// File navigation within `files`.
@@ -3637,18 +3641,33 @@ impl TabState {
         let ordered = tour.ordered_pillars();
         let mut pillars: Vec<TourPillarView> = Vec::new();
         let mut files: Vec<DiffFile> = Vec::new();
+        let mut file_is_related: Vec<bool> = Vec::new();
         let mut ranges: Vec<(usize, usize)> = Vec::new();
         let mut used: HashSet<String> = HashSet::new();
+
+        // Push a diff file into the flat tour list once. `related` rows render
+        // indented under the primary file they belong to.
+        let push_file = |files: &mut Vec<DiffFile>,
+                         file_is_related: &mut Vec<bool>,
+                         used: &mut HashSet<String>,
+                         path: &str,
+                         related: bool| {
+            if used.contains(path) {
+                return;
+            }
+            if let Some(df) = self.files.iter().find(|f| f.path == path) {
+                files.push(df.clone());
+                file_is_related.push(related);
+                used.insert(path.to_string());
+            }
+        };
 
         for p in &ordered {
             let start = files.len();
             for tf in &p.files {
-                if used.contains(&tf.path) {
-                    continue;
-                }
-                if let Some(df) = self.files.iter().find(|f| f.path == tf.path) {
-                    files.push(df.clone());
-                    used.insert(tf.path.clone());
+                push_file(&mut files, &mut file_is_related, &mut used, &tf.path, false);
+                for r in &tf.related {
+                    push_file(&mut files, &mut file_is_related, &mut used, &r.path, true);
                 }
             }
             let end = files.len();
@@ -3671,6 +3690,7 @@ impl TabState {
         for df in &self.files {
             if !used.contains(&df.path) {
                 files.push(df.clone());
+                file_is_related.push(false);
             }
         }
         if files.len() > start {
@@ -3696,6 +3716,7 @@ impl TabState {
             pillars,
             selected_pillar,
             files,
+            file_is_related,
             pillar_file_ranges: ranges,
             selected_file,
             current_hunk: 0,
@@ -9709,6 +9730,73 @@ mod tests {
             compacted: false,
             raw_hunk_count: 0,
         }
+    }
+
+    /// rebuild_tour_state nests a file's co-located related files (its tests)
+    /// immediately after it, in the same pillar, flagged for indented rendering.
+    #[test]
+    fn rebuild_tour_state_nests_related_files_under_parent() {
+        use crate::ai::{ErTour, TourFile, TourPillar, TourRelatedFile};
+
+        let mut tab = make_test_tab(vec![
+            test_diff_file("a.ts"),
+            test_diff_file("a.test.ts"),
+            test_diff_file("b.ts"),
+            test_diff_file("c.ts"), // unassigned → "Other changes"
+        ]);
+
+        tab.ai.tour = Some(ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![TourPillar {
+                id: "p-1".to_string(),
+                title: "Core".to_string(),
+                description: String::new(),
+                order: 0,
+                importance: 0,
+                foundation: false,
+                files: vec![
+                    TourFile {
+                        path: "a.ts".to_string(),
+                        reason: String::new(),
+                        finding_ids: Vec::new(),
+                        related: vec![TourRelatedFile {
+                            path: "a.test.ts".to_string(),
+                            kind: "test".to_string(),
+                            reason: String::new(),
+                        }],
+                    },
+                    TourFile {
+                        path: "b.ts".to_string(),
+                        reason: String::new(),
+                        finding_ids: Vec::new(),
+                        related: Vec::new(),
+                    },
+                ],
+            }],
+        });
+
+        tab.rebuild_tour_state();
+        let tour = tab.tour.as_ref().expect("tour state built");
+
+        // a.test.ts is nested directly after a.ts, then b.ts, then the Other file.
+        let order: Vec<&str> = tour.files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(order, vec!["a.ts", "a.test.ts", "b.ts", "c.ts"]);
+        assert_eq!(tour.file_is_related, vec![false, true, false, false]);
+
+        // The test file lives in the same pillar as its source, not "Other changes".
+        let p1 = tour.pillar_of_file(0);
+        assert_eq!(
+            p1,
+            tour.pillar_of_file(1),
+            "related file shares parent's pillar"
+        );
+        assert_ne!(p1, tour.pillar_of_file(3), "c.ts falls into Other changes");
+        // Two pillars: "Core" + "Other changes".
+        assert_eq!(tour.pillars.len(), 2);
     }
 
     /// `mark_reviewed` / `unmark_reviewed` must resolve paths via

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -3646,28 +3646,40 @@ impl TabState {
         let mut used: HashSet<String> = HashSet::new();
 
         // Push a diff file into the flat tour list once. `related` rows render
-        // indented under the primary file they belong to.
+        // indented under the primary file they belong to. Returns whether a row
+        // was pushed (false when the path is absent from the diff or already used).
         let push_file = |files: &mut Vec<DiffFile>,
                          file_is_related: &mut Vec<bool>,
                          used: &mut HashSet<String>,
                          path: &str,
-                         related: bool| {
+                         related: bool|
+         -> bool {
             if used.contains(path) {
-                return;
+                return false;
             }
             if let Some(df) = self.files.iter().find(|f| f.path == path) {
                 files.push(df.clone());
                 file_is_related.push(related);
                 used.insert(path.to_string());
+                return true;
             }
+            false
         };
 
         for p in &ordered {
             let start = files.len();
             for tf in &p.files {
-                push_file(&mut files, &mut file_is_related, &mut used, &tf.path, false);
-                for r in &tf.related {
-                    push_file(&mut files, &mut file_is_related, &mut used, &r.path, true);
+                // Only nest a file's related items when the primary itself is in
+                // this pillar; otherwise an orphaned `↳` row with no parent would
+                // appear. A related file whose primary is absent falls through to
+                // the "Other changes" pillar as a standalone row — matching the
+                // desktop snapshot (`build_tour_snapshot`).
+                let pushed_primary =
+                    push_file(&mut files, &mut file_is_related, &mut used, &tf.path, false);
+                if pushed_primary {
+                    for r in &tf.related {
+                        push_file(&mut files, &mut file_is_related, &mut used, &r.path, true);
+                    }
                 }
             }
             let end = files.len();
@@ -9797,6 +9809,58 @@ mod tests {
         assert_ne!(p1, tour.pillar_of_file(3), "c.ts falls into Other changes");
         // Two pillars: "Core" + "Other changes".
         assert_eq!(tour.pillars.len(), 2);
+    }
+
+    /// A related file whose primary is NOT in the diff must not nest as an
+    /// orphaned `↳` row; it falls through to "Other changes" as a standalone
+    /// file, matching the desktop snapshot's ownership rule.
+    #[test]
+    fn rebuild_tour_state_drops_related_when_primary_absent() {
+        use crate::ai::{ErTour, TourFile, TourPillar, TourRelatedFile};
+
+        // Only the test file is in the diff; its primary `a.ts` is unchanged/absent.
+        let mut tab = make_test_tab(vec![test_diff_file("a.test.ts")]);
+        tab.ai.tour = Some(ErTour {
+            version: 1,
+            diff_hash: String::new(),
+            created_at: String::new(),
+            title: String::new(),
+            overview: String::new(),
+            pillars: vec![TourPillar {
+                id: "p-1".to_string(),
+                title: "Core".to_string(),
+                description: String::new(),
+                order: 0,
+                importance: 0,
+                foundation: false,
+                files: vec![TourFile {
+                    path: "a.ts".to_string(),
+                    reason: String::new(),
+                    finding_ids: Vec::new(),
+                    related: vec![TourRelatedFile {
+                        path: "a.test.ts".to_string(),
+                        kind: "test".to_string(),
+                        reason: String::new(),
+                    }],
+                }],
+            }],
+        });
+
+        tab.rebuild_tour_state();
+        let tour = tab.tour.as_ref().expect("tour state built");
+
+        // a.test.ts is the only row, rendered standalone (not a nested child).
+        assert_eq!(
+            tour.files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.test.ts"]
+        );
+        assert_eq!(tour.file_is_related, vec![false]);
+        // The "Core" pillar has no in-diff files, so only "Other changes" shows.
+        assert_eq!(tour.pillars.len(), 1);
+        assert_eq!(tour.pillars[0].id, "__other__");
     }
 
     /// `mark_reviewed` / `unmark_reviewed` must resolve paths via

--- a/crates/er-tui/src/ui/diff_view.rs
+++ b/crates/er-tui/src/ui/diff_view.rs
@@ -2196,6 +2196,19 @@ fn render_tour_diff(f: &mut Frame, area: Rect, app: &App, hl: &mut Highlighter) 
                     .bg(file_header_bg),
             ),
         ];
+        // Mark co-located related files (tests/styles/…) with a "↳" so the
+        // nesting shown in the pillar list is also visible in the diff body.
+        if tour.file_is_related.get(file_idx).copied().unwrap_or(false) {
+            header_spans.insert(
+                1,
+                Span::styled(
+                    "↳ ",
+                    ratatui::style::Style::default()
+                        .fg(styles::DIM())
+                        .bg(file_header_bg),
+                ),
+            );
+        }
         if reviewed {
             header_spans.push(Span::styled(
                 "  ✓ reviewed",

--- a/crates/er-tui/src/ui/file_tree.rs
+++ b/crates/er-tui/src/ui/file_tree.rs
@@ -606,8 +606,14 @@ fn render_pillar_list(f: &mut Frame, area: Rect, app: &App) {
             } else {
                 "  "
             };
-            let indent = if is_related { "     ↳ " } else { "   " };
-            let name = shorten_path(&fd.path, inner_width.saturating_sub(indent.len() + 3));
+            // `indent_cols` is the display width (not byte length — "↳" is a
+            // 3-byte, 1-column glyph, so `indent.len()` would over-truncate).
+            let (indent, indent_cols) = if is_related {
+                ("     ↳ ", 7)
+            } else {
+                ("   ", 3)
+            };
+            let name = shorten_path(&fd.path, inner_width.saturating_sub(indent_cols + 3));
             let fstyle = if is_file_selected {
                 ratatui::style::Style::default().fg(styles::BRIGHT())
             } else if tab.reviewed.contains_key(&fd.path) || is_related {

--- a/crates/er-tui/src/ui/file_tree.rs
+++ b/crates/er-tui/src/ui/file_tree.rs
@@ -598,15 +598,19 @@ fn render_pillar_list(f: &mut Frame, area: Rect, app: &App) {
         for (fi, fd) in files.iter().enumerate() {
             let abs_idx = start + fi;
             let is_file_selected = is_selected && abs_idx == tour.selected_file;
+            // Co-located related files (tests/styles/stories/snapshots) render
+            // indented under their primary file with a "↳" marker.
+            let is_related = tour.file_is_related.get(abs_idx).copied().unwrap_or(false);
             let reviewed_mark = if tab.reviewed.contains_key(&fd.path) {
                 "✓ "
             } else {
                 "  "
             };
-            let name = shorten_path(&fd.path, inner_width.saturating_sub(6));
+            let indent = if is_related { "     ↳ " } else { "   " };
+            let name = shorten_path(&fd.path, inner_width.saturating_sub(indent.len() + 3));
             let fstyle = if is_file_selected {
                 ratatui::style::Style::default().fg(styles::BRIGHT())
-            } else if tab.reviewed.contains_key(&fd.path) {
+            } else if tab.reviewed.contains_key(&fd.path) || is_related {
                 ratatui::style::Style::default().fg(styles::DIM())
             } else {
                 ratatui::style::Style::default().fg(styles::TEXT())
@@ -618,7 +622,7 @@ fn render_pillar_list(f: &mut Frame, area: Rect, app: &App) {
                 styles::surface_style()
             };
             let line = Line::from(vec![
-                Span::raw("   "),
+                Span::styled(indent, ratatui::style::Style::default().fg(styles::DIM())),
                 Span::styled(reviewed_mark, mark_style),
                 Span::styled(name, fstyle),
             ]);

--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -128,13 +128,18 @@
     if (snapshot?.mode === "tour" && snapshot.tour?.pillars?.length) {
       const out: FileSnapshot[] = [];
       const seen = new Set<string>();
+      const pushPath = (path: string) => {
+        const f = byPath.get(path);
+        if (f && !seen.has(path)) {
+          out.push(f);
+          seen.add(path);
+        }
+      };
       for (const p of snapshot.tour.pillars) {
         for (const tf of p.files) {
-          const f = byPath.get(tf.path);
-          if (f && !seen.has(tf.path)) {
-            out.push(f);
-            seen.add(tf.path);
-          }
+          // Primary file, then its co-located related files directly after it.
+          pushPath(tf.path);
+          for (const r of tf.related ?? []) pushPath(r.path);
         }
       }
       for (const f of all) {
@@ -514,7 +519,9 @@
     },
   );
 
-  /** Per-pillar file rows for the rail (path + +/- + reviewed), in diff order. */
+  /** Per-pillar primary file rows for the rail (path + +/- + reviewed), in diff
+   *  order. Co-located related files are excluded here and rendered nested via
+   *  {@link relatedRows}. */
   const pillarFileRows = $derived.by((): Map<string, FileSnapshot[]> => {
     const m = new Map<string, FileSnapshot[]>();
     if (!tourActive || !snapshot?.tour?.pillars?.length) return m;
@@ -526,6 +533,25 @@
         if (f) list.push(f);
       }
       m.set(p.id, list);
+    }
+    return m;
+  });
+
+  /** Map of primary file path → its co-located related rows (test/style/…), for
+   *  nested rendering in the pillar rail. */
+  const relatedRows = $derived.by((): Map<string, { file: FileSnapshot; kind: string }[]> => {
+    const m = new Map<string, { file: FileSnapshot; kind: string }[]>();
+    if (!tourActive || !snapshot?.tour?.pillars?.length) return m;
+    const byPath = new Map(files.map((f) => [f.path, f]));
+    for (const p of snapshot.tour.pillars) {
+      for (const tf of p.files) {
+        const children: { file: FileSnapshot; kind: string }[] = [];
+        for (const r of tf.related ?? []) {
+          const f = byPath.get(r.path);
+          if (f) children.push({ file: f, kind: r.kind });
+        }
+        if (children.length) m.set(tf.path, children);
+      }
     }
     return m;
   });
@@ -1845,6 +1871,7 @@
                 <PillarRail
                   info={span.info}
                   fileRows={pillarFileRows.get(span.info.pillarId) ?? []}
+                  {relatedRows}
                   selectedPath={visibleFilePath}
                 />
               </div>

--- a/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
@@ -6,9 +6,26 @@
   interface Props {
     info: PillarHeaderInfo;
     fileRows: FileSnapshot[];
+    /** Primary file path → its co-located related rows (test/style/…). */
+    relatedRows?: Map<string, { file: FileSnapshot; kind: string }[]>;
     selectedPath: string | null;
   }
-  const { info, fileRows, selectedPath }: Props = $props();
+  const { info, fileRows, relatedRows, selectedPath }: Props = $props();
+
+  function kindLabel(kind: string): string {
+    switch (kind) {
+      case "test":
+        return "test";
+      case "style":
+        return "style";
+      case "story":
+        return "story";
+      case "snapshot":
+        return "snap";
+      default:
+        return "";
+    }
+  }
 
   const allReviewed = $derived(info.totalCount > 0 && info.reviewedCount === info.totalCount);
 
@@ -59,40 +76,57 @@
 
   <div class="flex flex-col gap-0.5 mt-1">
     {#each fileRows as f (f.path)}
-      {@const isSelected = f.path === selectedPath}
-      <!-- Row is a plain container holding two sibling buttons (reviewed-toggle
-           + jump-to-file). Mirrors FileHeaderContent: no role=button wrapping an
-           interactive control, so each button keeps native keyboard activation. -->
-      <div
-        class="w-full px-1.5 py-[3px] rounded flex items-center gap-1.5 relative {isSelected ? 'bg-ink-650 text-fg' : 'text-fg-2 hover:bg-card'}"
-      >
-        {#if isSelected}
-          <span class="absolute left-0 top-[3px] bottom-[3px] w-[2px] rounded-r bg-accent"></span>
-        {/if}
-        <button
-          type="button"
-          class="shrink-0 w-[14px] h-[14px] rounded-[3px] flex items-center justify-center border transition
-            {f.reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-ink-500 text-transparent hover:border-fg-3'}"
-          title={f.reviewed ? "Marked reviewed — click to unmark" : "Mark file reviewed"}
-          aria-label={f.reviewed ? "Unmark as reviewed" : "Mark as reviewed"}
-          aria-pressed={f.reviewed}
-          onclick={() => toggleReviewed(f)}
-        >
-          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          class="flex items-center gap-1.5 flex-1 min-w-0 text-left"
-          title={f.path}
-          onclick={() => jumpToFile(f)}
-        >
-          <span class="text-[11px] truncate flex-1 {f.reviewed ? 'text-fg-3 line-through' : ''}">{basename(f.path)}</span>
-          {#if f.additions > 0}<span class="mono text-[9px] text-add-fg">+{f.additions}</span>{/if}
-          {#if f.deletions > 0}<span class="mono text-[9px] text-del-fg">−{f.deletions}</span>{/if}
-        </button>
-      </div>
+      {@render fileRow(f, false, "")}
+      {#each relatedRows?.get(f.path) ?? [] as child (child.file.path)}
+        {@render fileRow(child.file, true, child.kind)}
+      {/each}
     {/each}
   </div>
 </div>
+
+<!-- Row is a plain container holding two sibling buttons (reviewed-toggle +
+     jump-to-file). Mirrors FileHeaderContent: no role=button wrapping an
+     interactive control, so each button keeps native keyboard activation.
+     `nested` rows are co-located related files (tests/styles/…) indented under
+     their primary file. -->
+{#snippet fileRow(f: FileSnapshot, nested: boolean, kind: string)}
+  {@const isSelected = f.path === selectedPath}
+  <div
+    class="w-full px-1.5 py-[3px] rounded flex items-center gap-1.5 relative {nested
+      ? 'pl-5'
+      : ''} {isSelected ? 'bg-ink-650 text-fg' : 'text-fg-2 hover:bg-card'}"
+  >
+    {#if isSelected}
+      <span class="absolute left-0 top-[3px] bottom-[3px] w-[2px] rounded-r bg-accent"></span>
+    {/if}
+    {#if nested}
+      <span class="text-fg-3 text-[10px] shrink-0 -mr-0.5" aria-hidden="true">↳</span>
+    {/if}
+    <button
+      type="button"
+      class="shrink-0 w-[14px] h-[14px] rounded-[3px] flex items-center justify-center border transition
+        {f.reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-ink-500 text-transparent hover:border-fg-3'}"
+      title={f.reviewed ? "Marked reviewed — click to unmark" : "Mark file reviewed"}
+      aria-label={f.reviewed ? "Unmark as reviewed" : "Mark as reviewed"}
+      aria-pressed={f.reviewed}
+      onclick={() => toggleReviewed(f)}
+    >
+      <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    </button>
+    <button
+      type="button"
+      class="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+      title={f.path}
+      onclick={() => jumpToFile(f)}
+    >
+      <span class="text-[11px] truncate flex-1 {f.reviewed ? 'text-fg-3 line-through' : ''}">{basename(f.path)}</span>
+      {#if nested && kindLabel(kind)}
+        <span class="mono text-[8px] uppercase tracking-wide text-fg-3 px-1 rounded bg-card shrink-0">{kindLabel(kind)}</span>
+      {/if}
+      {#if f.additions > 0}<span class="mono text-[9px] text-add-fg">+{f.additions}</span>{/if}
+      {#if f.deletions > 0}<span class="mono text-[9px] text-del-fg">−{f.deletions}</span>{/if}
+    </button>
+  </div>
+{/snippet}

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -105,8 +105,10 @@ export interface TourFileRef {
   path: string;
   reason: string;
   findingIds: string[];
-  /** Co-located files (tests/styles/stories/snapshots) nested under this row. */
-  related: RelatedFileRef[];
+  /** Co-located files (tests/styles/stories/snapshots) nested under this row.
+   *  Optional: absent on tour snapshots produced before this field existed —
+   *  every reader must guard with `?? []`. */
+  related?: RelatedFileRef[];
 }
 
 export interface PillarSnapshot {

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -94,10 +94,19 @@ export interface FileSnapshot {
   hunks_omitted?: boolean;
 }
 
+export interface RelatedFileRef {
+  path: string;
+  /** "test" | "style" | "story" | "snapshot" | "other" */
+  kind: string;
+  reason: string;
+}
+
 export interface TourFileRef {
   path: string;
   reason: string;
   findingIds: string[];
+  /** Co-located files (tests/styles/stories/snapshots) nested under this row. */
+  related: RelatedFileRef[];
 }
 
 export interface PillarSnapshot {

--- a/docs/release-notes/colocated-tests-in-guide.md
+++ b/docs/release-notes/colocated-tests-in-guide.md
@@ -1,0 +1,48 @@
+# Co-located tests in the Guide
+
+## What changed
+
+The Guide (the AI guided walkthrough — `tour.json`, internally `DiffMode::Tour`)
+now nests a file's **co-located related files** — its tests, styles, stories,
+and snapshots — directly beneath it instead of scattering them across pillars or
+dumping them in "Other changes".
+
+When `er-tour` groups the diff into pillars, a changed file's accompanying
+test/style/story/snapshot in the same diff is attached to that file rather than
+listed as its own entry. In the pillar rail you now see, for example:
+
+```
+projections.ts
+  ↳ projections.test.ts   test
+filters.ts
+  ↳ filters.test.ts       test
+```
+
+so a reviewer reads each file together with the tests that exercise it.
+
+## How it works
+
+- **Tour model.** `TourFile` gains an optional `related: [{path, kind, reason}]`
+  array (`kind` ∈ `test`/`style`/`story`/`snapshot`/`other`). It is
+  serde-defaulted, so older `tour.json` files keep loading unchanged.
+- **Generation.** The `er-tour` skill and the desktop "Generate tour" prompt now
+  instruct the model to put a file's test/style/story/snapshot into that file's
+  `related` array instead of a standalone `files` entry. Each changed file still
+  appears exactly once — as a primary entry or as one file's related child.
+- **Rendering.** Related files render as indented child rows (a `↳` marker plus a
+  small `kind` label) under their parent in both the desktop Guide rail
+  (`PillarRail`) and the TUI pillar list. They are real diff files: still
+  navigable, still independently markable as reviewed, and counted in the
+  pillar's reviewed progress and "Review all".
+- **Scope.** Only related files **present in the current diff** are shown
+  (matching how the Guide already drops files absent from the diff). A related
+  file is owned by its source file and is excluded from the "Other changes"
+  bucket.
+
+## Why it's safe
+
+`related` defaults to empty, so a tour generated before this change renders
+exactly as before. Co-located files were always part of the branch diff and the
+branch review bucket; nesting only changes how they are grouped and displayed —
+findings, comments, questions, and reviewed state remain keyed by file path and
+shared across the Diff and Guide views.

--- a/skills/er-tour/SKILL.md
+++ b/skills/er-tour/SKILL.md
@@ -62,8 +62,16 @@ pipe into `shasum` — use file-based hashing).
    - Each pillar gets a short `title`, a 1–3 sentence markdown `description`
      (what it is and why review it here), and its `files` in reading order with
      a one-line `reason` each.
-   - Every changed file should appear in exactly one pillar. Group trivial
-     files (lock files, generated, config) into a single low-importance pillar.
+   - **Co-locate tests and supporting files.** When a changed file has an
+     accompanying test, style, story, or snapshot in the diff (`foo.ts` +
+     `foo.test.ts`/`foo.spec.ts`, `foo.css`/`foo.scss`, `foo.stories.ts`,
+     `__snapshots__/foo.snap`), attach it to that source file's `related` array
+     with a `kind` (`test`/`style`/`story`/`snapshot`/`other`) instead of listing
+     it as a separate `files` entry. The reviewer then sees each file with its
+     tests nested beneath it.
+   - Every changed file should appear exactly once — as a pillar `files` entry
+     **or** as one file's `related` child. Group trivial files (lock files,
+     generated, config) into a single low-importance pillar.
 4. Writes `.er/tour.json` (atomic) and persists a cached copy at
    `.er/reviews/<branch>/<commit>/tour.json`.
 
@@ -133,7 +141,14 @@ Print a one-line summary: "Tour: N pillars, M files".
       "importance": 90,
       "foundation": true,
       "files": [
-        {"path": "src/auth/store.rs", "reason": "Defines TokenStore", "finding_ids": ["f-1"]}
+        {
+          "path": "src/auth/store.rs",
+          "reason": "Defines TokenStore",
+          "finding_ids": ["f-1"],
+          "related": [
+            {"path": "src/auth/store.test.ts", "kind": "test", "reason": "TokenStore tests"}
+          ]
+        }
       ]
     },
     {
@@ -160,6 +175,12 @@ Field notes:
   not present in the current diff are skipped by the UI; unassigned diff files
   fall into an "Other changes" pillar automatically.
 - `files[].finding_ids` — optional ids from `review.json` (omit if no review).
+- `files[].related` — optional co-located files (tests/styles/stories/snapshots)
+  for this file, each with `path`, `kind`
+  (`test`/`style`/`story`/`snapshot`/`other`), and an optional `reason`. They
+  render nested under the parent file in the guide. Only related files present
+  in the diff are shown; a related file must not also appear as a primary
+  `files` entry.
 
 ## Guidelines
 
@@ -167,7 +188,8 @@ Field notes:
 - Titles under ~40 characters (they render in the pillar nav).
 - Descriptions explain *why review this here* and *what to look for*, not a
   restatement of the diff.
-- Every changed file appears in exactly one pillar.
+- Every changed file appears exactly once — as a pillar `files` entry or as one
+  file's `related` child (its test/style/story/snapshot).
 
 ## .gitignore
 


### PR DESCRIPTION
## What & why

In the Guide (the AI guided walkthrough — `tour.json` / `DiffMode::Tour`), a changed file's test/style/story/snapshot was listed as a standalone entry, so tests ended up scattered across pillars or dumped into "Other changes" instead of sitting next to the code they exercise.

This nests a file's **co-located related files** directly beneath it, so a reviewer reads each file together with its tests:

```
projections.ts
  ↳ projections.test.ts   test
filters.ts
  ↳ filters.test.ts       test
```

## Changes

**Engine (`er-engine`)**
- `TourFile` gains an optional `related: Vec<TourRelatedFile>` (`path` / `kind` ∈ test·style·story·snapshot·other / `reason`). It's serde-defaulted, so existing `tour.json` files load unchanged.
- New `TourFile::all_paths` / `TourPillar::all_file_paths` helpers; `file_pillar` now resolves a related file to its parent's pillar.
- `rebuild_tour_state` pushes each file's in-diff related files immediately after it within the same pillar and records `TourState.file_is_related` for indented rendering.

**TUI (`er-tui`)**
- The pillar list renders related rows indented with a `↳` marker.

**Desktop (`er-desktop` + `desktop-ui`)**
- `TourFileRef` carries `related` (filtered to the diff, deduped, included in pillar reviewed/total counts and "Review all").
- `PillarRail` renders nested child rows with a small `kind` label; `FlatDiffView` orders related files right after their parent; `pillar_file_paths` includes related for bulk-review and "Other changes" exclusion.

**Generation**
- The `er-tour` skill and the desktop "Generate tour" prompt now instruct the model to attach a file's test/style/story/snapshot to that file's `related` array instead of a standalone entry. Each changed file still appears exactly once.

## Notes

- Only related files **present in the current diff** are shown (matching how the Guide already drops absent files). Related files remain real diff files: navigable, independently markable as reviewed, and counted in pillar progress.
- No release branch exists yet, so this targets `main`; happy to retarget if there's a release branch it should land on.

## Testing

- `cargo test -p er-engine -p er-tui` — green (733 + 72), including new unit tests for the model helpers, serde defaults, and `rebuild_tour_state` nesting.
- Both touched Svelte components compile via the Svelte compiler. The desktop Rust crate and `svelte-check` couldn't be fully compiled in the sandbox (missing GTK system libs / esbuild native binary), but `rustfmt --check` passes across the workspace and the changes are mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDgngFmggUR1wSVbYZZCNw)_