### PR TITLE
Reset reference highlight when diff context changes

### DIFF
--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -232,6 +232,15 @@
     untrack(() => diffFileCollapse.clear());
   });
 
+  // Clear the reference highlight when the diff context changes (tab/branch/PR/
+  // mode). The store is a global singleton, so without this its query — and the
+  // ruler marks derived from it — would persist into the next diff, e.g. stale
+  // scroll-gutter marks carrying over when switching between PRs.
+  $effect(() => {
+    snapshotKey;
+    untrack(() => refHighlight.clear());
+  });
+
   // ── D10 measured-height overlay ───────────────────────────────────────────
   let overlayHeights = $state(new Map<string, number>());
   let overlaySerial = $state(0);


### PR DESCRIPTION
## Problem

When switching between PRs (or otherwise changing the diff context), the scroll-gutter reference marks from the previous diff persisted into the next one. The reference-highlight store (`refHighlight` in `referenceHighlight.svelte.ts`) is a global singleton, and nothing reset its active query when the diff context changed — so the `ReferenceRuler` marks derived from `refHighlight.identifier` carried over, producing stale gutter marks against the new PR's diff.

## Fix

Added an `$effect` in `FlatDiffView.svelte` that calls `refHighlight.clear()` whenever `snapshotKey` (tab/branch/PR/mode) changes. This mirrors the existing collapse-state reset effect keyed on the same `snapshotKey`, so the reference highlight now resets together with the rest of the per-context view state.

- Clears the highlight identifier/query, popover, and active match index, which in turn empties the ruler marks and the inline highlight.
- Uses `untrack()` like the adjacent collapse reset, so the effect only depends on `snapshotKey`.

## Notes

Both `refHighlight` and `untrack` were already imported in the file; the change is a self-contained 6-line addition with no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDJxm5PVc3PRET6RwFMTuT)_