### PR TITLE
Fix Branch view showing a different PR than the one opened

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -423,28 +423,12 @@ pub fn kick_github_status_refresh(
 
 fn active_github_key(app: &App, state: &AppState) -> Option<(String, String, u64)> {
     let tab = app.tab();
-    if let (Some(slug), Some(n)) = (tab.remote_repo.as_ref(), tab.pr_number) {
-        return slug
-            .split_once('/')
-            .map(|(o, r)| (o.to_string(), r.to_string(), n));
-    }
-
-    let branch = tab
-        .local_branch_view
-        .as_deref()
-        .unwrap_or(&tab.current_branch)
-        .to_string();
-    state.pr_cache.lock().ok().and_then(|cache| {
-        cache.iter().find_map(|(slug, prs)| {
-            prs.iter()
-                .filter(|p| p.head_ref == branch)
-                .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
-                .and_then(|p| {
-                    slug.split_once('/')
-                        .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
-                })
-        })
-    })
+    // Prefer the tab's own PR number (remote or local PR tab) so the background
+    // gh-status fetch targets the PR that was actually opened, not an arbitrary
+    // head_ref match when a branch carries more than one open PR. Plain branch /
+    // working tabs fall back to head_ref matching inside the resolver.
+    let cache = state.pr_cache.lock().ok()?;
+    crate::snapshot::resolve_github_status_key(tab, &cache)
 }
 
 fn active_pr_author(

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -674,6 +674,65 @@ pub struct Panels {
     pub right: bool,
 }
 
+/// Resolve the `(owner, repo, pr_number)` GitHub-status key for a tab.
+///
+/// The key drives both the live `github` card in the snapshot and the
+/// background `gh status` fetch. The resolution order matters:
+///
+/// 1. **Remote PR tab** — key directly off `remote_repo` + `pr_number`.
+/// 2. **Local PR tab** (`pr_number` set, no remote) — force the tab's OWN
+///    `pr_number` and resolve only the owner/repo slug from the PR-list cache.
+///    The slug is found by the matching PR number first, falling back to any PR
+///    on the viewed head branch. This is the fix for the "Branch view shows
+///    another PR" bug: a single head branch can have two open PRs (e.g. one
+///    targeting `main`, one targeting a stacked base), and matching purely by
+///    head_ref returned an arbitrary one — often not the PR that was opened.
+/// 3. **Plain branch / working tab** (no `pr_number`) — match the viewed
+///    branch's head_ref, preferring an OPEN PR.
+pub(crate) fn resolve_github_status_key(
+    tab: &TabState,
+    pr_cache: &HashMap<String, Vec<PrInfo>>,
+) -> Option<(String, String, u64)> {
+    // 1. Remote PR: slug + number directly.
+    if let (Some(slug), Some(number)) = (tab.remote_repo.as_ref(), tab.pr_number) {
+        return slug
+            .split_once('/')
+            .map(|(o, r)| (o.to_string(), r.to_string(), number));
+    }
+
+    let branch = tab
+        .local_branch_view
+        .as_deref()
+        .unwrap_or(&tab.current_branch);
+
+    // 2. Local PR tab: trust the tab's own pr_number; only resolve the slug.
+    if let Some(number) = tab.pr_number {
+        return pr_cache
+            .iter()
+            .find(|(_, prs)| prs.iter().any(|p| p.number == number))
+            .or_else(|| {
+                pr_cache
+                    .iter()
+                    .find(|(_, prs)| prs.iter().any(|p| p.head_ref == branch))
+            })
+            .and_then(|(slug, _)| {
+                slug.split_once('/')
+                    .map(|(o, r)| (o.to_string(), r.to_string(), number))
+            });
+    }
+
+    // 3. Plain branch / working tab: match by head_ref, prefer an OPEN PR.
+    pr_cache.iter().find_map(|(slug, prs)| {
+        prs.iter()
+            .filter(|p| p.head_ref == branch)
+            .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
+            .and_then(|p| {
+                slug.split_once('/')
+                    .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
+            })
+    })
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct FileSnapshot {
     pub path: String,
@@ -1807,48 +1866,26 @@ fn build_snapshot_inner(
             .collect()
     };
 
-    // Resolve the active tab's GitHub status from the cache.
-    // For remote PR tabs: use remote_repo + pr_number directly.
-    // For working-tree / local-branch tabs: look up the current branch in pr_cache.
-    let github = if let (Some(slug), Some(number)) = (tab.remote_repo.as_ref(), tab.pr_number) {
-        slug.split_once('/').and_then(|(o, r)| {
-            let key = (o.to_string(), r.to_string(), number);
+    // Resolve the active tab's GitHub status from the cache. The key prefers the
+    // tab's own PR number for PR tabs (remote or local) and only falls back to a
+    // head_ref match for plain branch/working tabs — see `resolve_github_status_key`.
+    // Matching purely by head_ref previously let a branch with two open PRs show
+    // an arbitrary one, so a freshly opened PR's Branch card could display a
+    // different PR entirely.
+    let github = pr_cache
+        .and_then(|pc| pc.lock().ok())
+        .and_then(|cache| resolve_github_status_key(tab, &cache))
+        .and_then(|key| {
             gh_status_cache
                 .and_then(|c| c.lock().ok())
                 .and_then(|g| g.get(&key).cloned())
         })
-    } else {
-        // Find a PR whose head_ref matches the viewed branch. Prefer open PRs,
-        // but keep merged/closed matches so the Sources card can show terminal
-        // PR state instead of looking disconnected.
-        let branch = tab
-            .local_branch_view
-            .as_deref()
-            .unwrap_or(&tab.current_branch);
-        let pr_key = pr_cache.and_then(|pc| pc.lock().ok()).and_then(|cache| {
-            cache.iter().find_map(|(slug, prs)| {
-                prs.iter()
-                    .filter(|p| p.head_ref == branch)
-                    .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
-                    .and_then(|p| {
-                        slug.split_once('/')
-                            .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
-                    })
-            })
+        .map(|mut status| {
+            if let Some(login) = gh_user.and_then(|g| g.lock().ok().and_then(|v| v.clone())) {
+                status.is_authored_by_me = status.author.eq_ignore_ascii_case(&login);
+            }
+            status
         });
-        pr_key.and_then(|(o, r, n)| {
-            let key = (o, r, n);
-            gh_status_cache
-                .and_then(|c| c.lock().ok())
-                .and_then(|g| g.get(&key).cloned())
-        })
-    }
-    .map(|mut status| {
-        if let Some(login) = gh_user.and_then(|g| g.lock().ok().and_then(|v| v.clone())) {
-            status.is_authored_by_me = status.author.eq_ignore_ascii_case(&login);
-        }
-        status
-    });
 
     // Detected PR number for the active branch — taken straight from the PR-list
     // cache (the same branch→PR match the sidebar badge uses). Unlike `github`,
@@ -3465,6 +3502,91 @@ mod tests {
         let pr_stale = compute_oid_staleness(Some("head2"), Some("head1"), "pr_head", "msg")
             .expect("differing oids must be stale");
         assert_eq!(pr_stale.kind, "pr_head");
+    }
+
+    fn pr_with(number: u64, head_ref: &str, state: &str) -> PrInfo {
+        let mut p = minimal_pr_info(number, "t");
+        p.head_ref = head_ref.to_string();
+        p.state = state.to_string();
+        p
+    }
+
+    /// A local PR tab (pr_number set, no remote) must key its GitHub status off
+    /// its OWN pr_number — even when the same head branch carries a second open
+    /// PR. Regression test for the "Branch view shows another PR entirely" bug.
+    #[test]
+    fn github_key_prefers_local_pr_number_over_head_ref_collision() {
+        let branch = "feature/shell-stores";
+        // One head branch, two OPEN PRs (e.g. targeting different bases).
+        let mut cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        cache.insert(
+            "octo/cat".to_string(),
+            vec![pr_with(1308, branch, "OPEN"), pr_with(117, branch, "OPEN")],
+        );
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.local_branch_view = Some(branch.to_string());
+        tab.pr_number = Some(117);
+
+        let key = resolve_github_status_key(&tab, &cache);
+        assert_eq!(
+            key,
+            Some(("octo".to_string(), "cat".to_string(), 117)),
+            "must resolve the opened PR (#117), not the head_ref collision (#1308)"
+        );
+    }
+
+    /// Even if the tab's own PR isn't in the cache yet, the slug is recovered
+    /// from any PR on the head branch and the tab's number is forced.
+    #[test]
+    fn github_key_recovers_slug_when_own_pr_absent_from_cache() {
+        let branch = "feature/shell-stores";
+        let mut cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        cache.insert("octo/cat".to_string(), vec![pr_with(1308, branch, "OPEN")]);
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.local_branch_view = Some(branch.to_string());
+        tab.pr_number = Some(117);
+
+        assert_eq!(
+            resolve_github_status_key(&tab, &cache),
+            Some(("octo".to_string(), "cat".to_string(), 117))
+        );
+    }
+
+    /// Remote PR tabs key straight off remote_repo + pr_number.
+    #[test]
+    fn github_key_remote_tab_uses_remote_repo() {
+        let cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.remote_repo = Some("octo/cat".to_string());
+        tab.pr_number = Some(42);
+
+        assert_eq!(
+            resolve_github_status_key(&tab, &cache),
+            Some(("octo".to_string(), "cat".to_string(), 42))
+        );
+    }
+
+    /// A plain branch tab (no pr_number) still matches by head_ref, preferring
+    /// an OPEN PR over a closed one.
+    #[test]
+    fn github_key_branch_tab_matches_head_ref_preferring_open() {
+        let branch = "feature/x";
+        let mut cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        cache.insert(
+            "octo/cat".to_string(),
+            vec![pr_with(10, branch, "CLOSED"), pr_with(11, branch, "OPEN")],
+        );
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.local_branch_view = Some(branch.to_string());
+        tab.pr_number = None;
+
+        assert_eq!(
+            resolve_github_status_key(&tab, &cache),
+            Some(("octo".to_string(), "cat".to_string(), 11))
+        );
     }
 
     fn commit_info(hash: &str, subject: &str) -> er_engine::git::CommitInfo {


### PR DESCRIPTION
## Problem

When opening a PR, the right‑panel **Branch** card (GitHub status, checks, comments, reviews) could show a **completely different PR** than the one actually opened — even though the tab title and the Local|PR toggle correctly reflected the opened PR.

Root cause: a local PR tab (`pr_number` set, `remote_repo` empty) resolved its GitHub‑status key purely by matching the viewed **head branch** against the PR‑list cache. A single head branch can carry more than one open PR (e.g. two PRs targeting different bases — a stacked branch). The head_ref match then returned an arbitrary one, so the Branch panel rendered the wrong PR's metadata. This affected both the snapshot's `github` card and the background `gh status` fetch (`active_github_key`), while `detected_pr_number` already (correctly) preferred the tab's own number — hence the visible mismatch (title #117, card #1308).

## Fix

Resolve the `(owner, repo, pr_number)` GitHub‑status key from the tab's **own** `pr_number` for both remote and local PR tabs, falling back to a head_ref match only for plain branch/working tabs:

- New shared `resolve_github_status_key(tab, pr_cache)` in `snapshot.rs`, used by both the snapshot builder and the active‑tab gh‑status kick (`active_github_key` in `commands.rs`).
- For a local PR tab it forces the tab's number and only recovers the owner/repo slug from the cache (by number, then by head branch), so it stays correct even before the PR appears in the cache.
- The existing background gh‑status kick in the PR‑open path now targets the correct PR, so the Branch card syncs **after** the open without blocking the main view load.

Plain branch tabs (no `pr_number`) keep the previous head_ref behavior (prefer OPEN), so no change for the working‑tree / tracked‑branch cases.

## Tests

Added unit tests in `snapshot.rs` covering:
- head_ref collision (two open PRs, same branch) → resolves the opened PR
- slug recovery when the tab's own PR isn't in the cache yet
- remote PR tab keys off `remote_repo`
- plain branch tab matches head_ref, preferring OPEN

All 98 `er-desktop` lib tests pass; `cargo clippy -p er-desktop` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017r4F8PteEGjnFmtXojS2Jj)_