### PR TITLE
fix(desktop): renamed files no longer stick on "Loading content…" (formatting fix)

### DIFF
--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -1394,10 +1394,7 @@ pub(crate) fn build_file_snapshot(
         // mode-only / binary change has no +/- lines, so it can never yield
         // hunks. Without the guard such files report as stubs forever and the
         // desktop spins on "Loading content…" with nothing left to fetch.
-        is_lazy_stub: (tab.lazy_mode
-            && f.hunks.is_empty()
-            && !f.compacted
-            && f.adds + f.dels > 0)
+        is_lazy_stub: (tab.lazy_mode && f.hunks.is_empty() && !f.compacted && f.adds + f.dels > 0)
             || budget_omitted,
         hunks,
         source_index,

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -1390,7 +1390,15 @@ pub(crate) fn build_file_snapshot(
         finding_count,
         comment_count,
         question_count,
-        is_lazy_stub: (tab.lazy_mode && f.hunks.is_empty() && !f.compacted) || budget_omitted,
+        // `adds + dels > 0` excludes the terminal-empty case: a pure rename /
+        // mode-only / binary change has no +/- lines, so it can never yield
+        // hunks. Without the guard such files report as stubs forever and the
+        // desktop spins on "Loading content…" with nothing left to fetch.
+        is_lazy_stub: (tab.lazy_mode
+            && f.hunks.is_empty()
+            && !f.compacted
+            && f.adds + f.dels > 0)
+            || budget_omitted,
         hunks,
         source_index,
         cache_key: format!("{lines_key:016x}"),
@@ -3602,6 +3610,52 @@ mod tests {
             "omitted file must not carry hunks"
         );
         assert!(without.is_lazy_stub);
+    }
+
+    #[test]
+    fn lazy_pure_rename_is_not_a_stub_but_unparsed_content_is() {
+        // A `DiffFile` with no hunks and zero +/- lines: a pure rename (or
+        // mode-only / binary change). In lazy mode this used to report as a
+        // stub forever — parsing it can never yield hunks, so the desktop UI
+        // spun on "Loading content…" with nothing to fetch.
+        let rename = DiffFile {
+            path: "lib/components/qc/ReplicateDeviationSection.svelte".to_string(),
+            status: FileStatus::Renamed(
+                "routes/quality-control/component/ReplicateDeviationSection.svelte".to_string(),
+            ),
+            hunks: Vec::new(),
+            adds: 0,
+            dels: 0,
+            compacted: false,
+            raw_hunk_count: 0,
+        };
+        // A genuinely-unparsed content file: empty hunks but real +/- counts
+        // from the header scan. This one *must* still read as a stub so the
+        // viewport loader fetches its hunks.
+        let unparsed = DiffFile {
+            path: "src/big.rs".to_string(),
+            status: FileStatus::Modified,
+            hunks: Vec::new(),
+            adds: 40,
+            dels: 12,
+            compacted: false,
+            raw_hunk_count: 3,
+        };
+
+        let mut tab = TabState::new_for_test(vec![rename, unparsed]);
+        tab.lazy_mode = true;
+
+        let rename_snap = build_file_snapshot(0, &tab.files[0], &tab, None, true);
+        assert!(
+            !rename_snap.is_lazy_stub,
+            "a pure rename has nothing to load and must not be a perpetual stub"
+        );
+
+        let unparsed_snap = build_file_snapshot(1, &tab.files[1], &tab, None, true);
+        assert!(
+            unparsed_snap.is_lazy_stub,
+            "an unparsed content file must still be a stub so the loader fetches it"
+        );
     }
 
     #[test]

--- a/desktop-ui/src/lib/components/diff-rows/NoChangesRow.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/NoChangesRow.svelte
@@ -12,5 +12,5 @@
   style="height:{row.height}px;display:flex;align-items:center"
   data-row-identity={row.identity}
 >
-  No changes
+  {row.renamed ? "File renamed without changes." : "No changes"}
 </div>

--- a/desktop-ui/src/lib/diffRenderModel.test.ts
+++ b/desktop-ui/src/lib/diffRenderModel.test.ts
@@ -250,6 +250,18 @@ describe("getFileBlock — bypass cases", () => {
     expect(block.rows[1].type).toBe("no-changes");
     expect(block.totalHeight).toBe(FILE_HEADER_HEIGHT + NO_CHANGES_HEIGHT);
   });
+
+  it("no-changes row flags a pure rename so the UI can label it", () => {
+    const renamed = file({ path: "moved.ts", hunks: [], status: "renamed" });
+    const renamedRow = getFileBlock(mkInputs(renamed, [renamed], emptyAi())).rows[1];
+    if (renamedRow.type !== "no-changes") throw new Error(`expected no-changes, got ${renamedRow.type}`);
+    expect(renamedRow.renamed).toBe(true);
+
+    const modified = file({ path: "empty.ts", hunks: [], status: "modified" });
+    const modifiedRow = getFileBlock(mkInputs(modified, [modified], emptyAi())).rows[1];
+    if (modifiedRow.type !== "no-changes") throw new Error(`expected no-changes, got ${modifiedRow.type}`);
+    expect(modifiedRow.renamed).toBe(false);
+  });
 });
 
 describe("getFileBlock — thread/finding injection", () => {

--- a/desktop-ui/src/lib/diffRenderModel.ts
+++ b/desktop-ui/src/lib/diffRenderModel.ts
@@ -213,6 +213,8 @@ export type CrossFileFlatRow =
       sourceIndex: number;
       height: number;
       identity: string;
+      /** Pure rename (no content change) — render "File renamed without changes." */
+      renamed: boolean;
     }
   | {
       type: "inline-thread";
@@ -419,6 +421,7 @@ export function getFileBlock(input: RenderModelInputs): FileBlock {
       sourceIndex: file.source_index,
       height: NO_CHANGES_HEIGHT,
       identity: `nochanges:${file.path}`,
+      renamed: file.status === "renamed",
     });
   } else {
     for (let hunkIdx = 0; hunkIdx < file.hunks.length; hunkIdx++) {

--- a/docs/release-notes/renamed-files-stuck-on-loading.md
+++ b/docs/release-notes/renamed-files-stuck-on-loading.md
@@ -1,0 +1,32 @@
+# Renamed files no longer stick on "Loading content…" (desktop)
+
+## What changed
+
+In a large diff (desktop lazy-load mode), a file that was **purely renamed** — moved
+with no content change (`+0 −0`) — used to sit on **"Loading content…"** forever. The
+same happened to binary and mode-only changes. Now those files render immediately:
+
+- A pure rename shows **"File renamed without changes."** (matching how GitHub presents
+  a no-content rename).
+- Binary / mode-only changes show **"No changes"** instead of a perpetual spinner.
+
+## Why it's safe
+
+Lazy mode marks a file as a "still-loading stub" when it has no parsed hunks. A pure
+rename / binary / mode-only change has no `+`/`-` lines at all, so parsing it can never
+produce hunks — it was being re-classified as a stub on every pass and never escaped the
+loading state. The fix only narrows that classification to files that actually have
+content to parse (`adds + dels > 0`), which is the **same** condition `ensure_file_parsed_at`
+already uses to decide whether a file is worth fetching from git. No content file changes
+behavior; only the genuinely-empty cases stop being treated as loadable.
+
+## Implementation
+
+- `crates/er-desktop/src/snapshot.rs` — `build_file_snapshot` only flags `is_lazy_stub`
+  when `f.adds + f.dels > 0`, so renames / binary / mode-only files fall through to the
+  normal no-changes render instead of a perpetual stub.
+- `desktop-ui/src/lib/diffRenderModel.ts` / `NoChangesRow.svelte` — the no-changes render
+  row carries a `renamed` flag (from the file's `renamed` status) so the UI can show
+  "File renamed without changes." for renames and "No changes" otherwise.
+- Tests cover the predicate (a lazy pure rename is not a stub; an unparsed content file
+  still is) and the render row's rename flag.


### PR DESCRIPTION
Supersedes #113 with the CI **Format** failure fixed.

## In plain terms

Same fix as #113 — pure renames (and binary / mode-only changes) no longer get stuck on **"Loading content…"** in the desktop app. They now render **"File renamed without changes."** (renames, matching GitHub) or **"No changes"** (binary / mode-only).

The only addition here is a formatting fix: PR #113's CI failed `cargo fmt --all -- --check` because the `is_lazy_stub` predicate was hand-wrapped across multiple lines. rustfmt wants it on one line — collapsed it, no behavior change.

## What changed

- `crates/er-desktop/src/snapshot.rs` — `build_file_snapshot` flags `is_lazy_stub` only when `f.adds + f.dels > 0` (the same condition `ensure_file_parsed_at` uses to decide a file is worth fetching from git). Files with no content to parse (rename / binary / mode-only) fall through to the normal no-changes render. Predicate is on a single line to satisfy rustfmt.
- `desktop-ui/src/lib/diffRenderModel.ts` + `NoChangesRow.svelte` — the no-changes render row carries a `renamed` flag (from `file.status === "renamed"`) so the UI shows "File renamed without changes." for renames and "No changes" otherwise.
- `docs/release-notes/renamed-files-stuck-on-loading.md` — release note.

## Tests

- **Rust** (`snapshot.rs`): `lazy_pure_rename_is_not_a_stub_but_unparsed_content_is` — a pure rename (empty hunks, `adds=dels=0`) is **not** a stub; an unparsed content file (`adds+dels>0`) still is.
- **Frontend** (`diffRenderModel.test.ts`): the no-changes row carries `renamed: true` for a renamed file and `false` for a modified one.
- `cargo fmt --all -- --check` now passes locally.

## Review

Ran `/code-review` (high effort) over `release/v0.4.1...HEAD` — traced the Rust predicate, the frontend render branch, and the status-string serialization (`FileStatus::Renamed(_) => "renamed"` matches `file.status === "renamed"`). No correctness, reuse, simplification, efficiency, altitude, or convention findings.

## Risk / rollback

- **Risk:** Level 1 (desktop render classification only; no data/storage changes).
- **Rollback:** revert the commit — purely a render-classification + formatting change, nothing persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011x9Vo1MtcjwQAgasNvcJj2)_