### PR TITLE
perf(desktop): slim gh CLI rate-limit pressure in background loops

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -569,30 +569,27 @@ fn process_ai_task_inbox(app: &App, state: &AppState) {
     }
 }
 
-/// Fetch all GitHub status data for a PR. Runs the 4 gh calls in parallel.
-/// Returns None when the PR overview fetch fails (e.g. no network, gh not authed).
-/// Comments/reviews/checks failures are non-fatal — the snapshot still populates.
+/// Fetch all GitHub status data for a PR. Runs 2 gh calls in parallel: one
+/// combined `gh pr view --json` for overview+comments+reviews, one `gh pr
+/// checks` for CI status (separate subcommand, can't be merged into `pr view`).
+/// Returns None when the overview/status-bundle fetch fails (e.g. no network,
+/// gh not authed). Comments/reviews parse failures inside the bundle are
+/// non-fatal; checks failures are non-fatal — the snapshot still populates.
 pub fn fetch_github_status(owner: &str, repo: &str, number: u64) -> Option<GithubStatusSnapshot> {
     let t = std::time::Instant::now();
-    // Run 4 independent gh calls concurrently — cuts wall time from ~3.5s to ~1s.
-    let (overview_res, checks, comments, reviews) = std::thread::scope(|s| {
-        let o = s.spawn(|| er_engine::github::gh_pr_overview_remote_full(owner, repo, number));
+    // Run 2 independent gh calls concurrently — cuts wall time and gh
+    // subprocess count from 4 to 2.
+    let (bundle_res, checks) = std::thread::scope(|s| {
+        let b = s.spawn(|| er_engine::github::gh_pr_status_remote(owner, repo, number));
         let c = s.spawn(|| {
             er_engine::github::gh_pr_checks_remote(owner, repo, number).unwrap_or_default()
         });
-        let cm = s.spawn(|| {
-            er_engine::github::gh_pr_comments_overview(owner, repo, number).unwrap_or_default()
-        });
-        let r =
-            s.spawn(|| er_engine::github::gh_pr_reviews(owner, repo, number).unwrap_or_default());
-        (
-            o.join().ok(),
-            c.join().unwrap_or_default(),
-            cm.join().unwrap_or_default(),
-            r.join().unwrap_or_default(),
-        )
+        (b.join().ok(), c.join().unwrap_or_default())
     });
-    let overview = overview_res?.ok()?;
+    let bundle = bundle_res?.ok()?;
+    let overview = bundle.overview;
+    let comments = bundle.comments;
+    let reviews = bundle.reviews;
     crate::profile_log::profile_log(
         "gh_status_fetch",
         &[
@@ -674,6 +671,21 @@ pub fn fetch_github_status(owner: &str, repo: &str, number: u64) -> Option<Githu
 /// local-branch tabs where the viewed branch has an open PR in pr_cache.
 fn kick_active_gh_status(app: &App, state: &AppState) {
     if let Some((owner, repo, number)) = active_github_key(app, state) {
+        let last_updated = state.gh_status_cache.lock().ok().and_then(|cache| {
+            cache
+                .get(&(owner.clone(), repo.clone(), number))
+                .and_then(|snap| snap.last_updated.clone())
+        });
+        // The active tab's status is already fresh (<10s) — the 30s
+        // background loop or a recent kick already covered it. Don't fire a
+        // redundant 4-subprocess fan-out on every tab switch / open / close.
+        if crate::gh_status_cache::status_is_fresh(
+            last_updated.as_deref(),
+            crate::gh_status_cache::now_epoch_secs(),
+            10,
+        ) {
+            return;
+        }
         kick_github_status_refresh(
             state.gh_status_cache.clone(),
             Arc::clone(&state.gh_status_in_flight),
@@ -5717,13 +5729,18 @@ fn open_pr_review_impl(
     // (placed by `new_local_pr_from_github_diff` from `inputs.raw_diff`), so trust
     // it and skip the redundant `gh pr diff` that `enter_pr_diff()` would run via
     // `refresh_diff()`. A miss — or a hit whose head oid is unknown (empty), where
-    // seeding it would mislead the staleness probe — falls back to the full path.
+    // seeding it would mislead the staleness probe — still skips the redundant
+    // refetch via `enter_pr_diff_freshly_loaded()`: `new_local_pr_from_github_diff`
+    // (above) already parsed `inputs.raw_diff` into `tab.files`/`raw_diff`/
+    // `diff_hash`, the exact content a plain `enter_pr_diff()` would re-fetch.
     if cache_hit && !head_oid_for_preload.trim().is_empty() {
         app.tab_mut()
             .enter_pr_diff_preloaded(head_oid_for_preload)
             .map_err(|e| e.to_string())?;
     } else {
-        app.tab_mut().enter_pr_diff().map_err(|e| e.to_string())?;
+        app.tab_mut()
+            .enter_pr_diff_freshly_loaded()
+            .map_err(|e| e.to_string())?;
     }
     let pr_diff_enter_ms = t_pr_diff.elapsed().as_millis();
     log_branch_open_phase(&project_id, &branch_label, "pr_diff_enter", t_pr_diff);

--- a/crates/er-desktop/src/gh_status_cache.rs
+++ b/crates/er-desktop/src/gh_status_cache.rs
@@ -119,6 +119,38 @@ pub fn prune_gh_status_cache(map: &mut GithubStatusCache, keep: &HashSet<(String
     });
 }
 
+/// True only when `last_updated` parses as a u64 epoch-seconds string AND is
+/// less than `ttl_secs` old relative to `now_secs`. Fails open — `None`,
+/// non-numeric, or any other unparseable value returns `false` (= "stale, go
+/// fetch"), never panics, never silently treats unknown freshness as fresh.
+///
+/// `now_secs.saturating_sub(parsed)` means a `last_updated` that is in the
+/// future (clock skew) reads as age 0, i.e. "fresh" — both sides come from
+/// `SystemTime::now()` on the same machine, so this is intentionally
+/// permissive rather than a correctness gap worth guarding against here.
+pub fn status_is_fresh(last_updated: Option<&str>, now_secs: u64, ttl_secs: u64) -> bool {
+    let Some(raw) = last_updated else {
+        return false;
+    };
+    let Ok(parsed) = raw.parse::<u64>() else {
+        return false;
+    };
+    now_secs.saturating_sub(parsed) < ttl_secs
+}
+
+/// Current time as epoch seconds, in the same format `fetch_github_status`
+/// writes to `GithubStatusSnapshot.last_updated` (`commands.rs:642-645`).
+/// `now_secs` is a parameter on `status_is_fresh` (not called internally) so
+/// callers can pass a fixed value in tests; this just centralizes the
+/// `SystemTime` boilerplate for the three real call sites.
+pub fn now_epoch_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,5 +303,40 @@ mod tests {
             !map.contains_key(&other),
             "unkept entry dropped even though it is also mixed-case"
         );
+    }
+
+    // ── status_is_fresh ──
+
+    #[test]
+    fn status_is_fresh_within_ttl() {
+        assert!(status_is_fresh(Some("1000"), 1050, 90)); // 50s old, ttl 90s
+    }
+
+    #[test]
+    fn status_is_fresh_stale_beyond_ttl() {
+        assert!(!status_is_fresh(Some("1000"), 1200, 90)); // 200s old, ttl 90s
+    }
+
+    #[test]
+    fn status_is_fresh_none_is_stale() {
+        assert!(!status_is_fresh(None, 1000, 90));
+    }
+
+    #[test]
+    fn status_is_fresh_non_numeric_is_stale() {
+        // The ISO-string shape from the (unrepresentative) test fixture above —
+        // confirms a format mismatch fails open rather than panicking.
+        assert!(!status_is_fresh(Some("2024-01-02T11:00:00Z"), 1000, 90));
+    }
+
+    #[test]
+    fn status_is_fresh_exactly_at_ttl_boundary_is_stale() {
+        // age == ttl_secs exactly → `<` excludes it → stale, not fresh.
+        assert!(!status_is_fresh(Some("1000"), 1090, 90));
+    }
+
+    #[test]
+    fn status_is_fresh_one_second_inside_boundary_is_fresh() {
+        assert!(status_is_fresh(Some("1000"), 1089, 90));
     }
 }

--- a/crates/er-desktop/src/gh_status_cache.rs
+++ b/crates/er-desktop/src/gh_status_cache.rs
@@ -142,13 +142,19 @@ pub fn status_is_fresh(last_updated: Option<&str>, now_secs: u64, ttl_secs: u64)
 /// writes to `GithubStatusSnapshot.last_updated` (`commands.rs:642-645`).
 /// `now_secs` is a parameter on `status_is_fresh` (not called internally) so
 /// callers can pass a fixed value in tests; this just centralizes the
-/// `SystemTime` boilerplate for the three real call sites.
+/// `SystemTime` boilerplate for the two real call sites (`kick_active_gh_status`
+/// and the 30s background `gh_status` loop).
 pub fn now_epoch_secs() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
+    // Fall back to u64::MAX (not 0) on a pre-epoch clock: an unrepresentable
+    // "now" then reads as maximally-OLD in `status_is_fresh` (age >= ttl →
+    // stale → fetch), preserving the fail-open contract. `unwrap_or(0)` would
+    // instead make every gate see age 0 and treat a real `last_updated` as
+    // fresh, wrongly skipping the fetch.
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -338,5 +344,13 @@ mod tests {
     #[test]
     fn status_is_fresh_one_second_inside_boundary_is_fresh() {
         assert!(status_is_fresh(Some("1000"), 1089, 90));
+    }
+
+    #[test]
+    fn status_is_fresh_max_now_sentinel_is_stale() {
+        // `now_epoch_secs()` returns u64::MAX on a pre-epoch clock fault. A real
+        // stored `last_updated` must then read as maximally-old (fail open →
+        // fetch), never as fresh — the opposite of the old `unwrap_or(0)`.
+        assert!(!status_is_fresh(Some("1750000000"), u64::MAX, 90));
     }
 }

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -578,11 +578,16 @@ fn cached_head_oid(pr_cache: &pr_cache::PrCacheMap, owner: &str, repo: &str, num
         .unwrap_or_default()
 }
 
-/// Whether the background comment-sync loop should SKIP this tick: the same PR
-/// head OID was already synced less than `ttl` ago, so nothing new can have been
-/// pushed. An empty/unknown `head_oid` never skips (fail open — keep syncing
-/// every tick until the probe loop populates a real OID). Pure so the skip
-/// decision is unit-testable without the surrounding thread/loop.
+/// Whether the background comment-sync loop should SKIP this tick: this PR's
+/// head OID is unchanged since the last successful sync AND that sync was less
+/// than `ttl` ago. This is a poll THROTTLE, not change-detection — PR comments
+/// and reviews are posted independently of any push, so an unchanged head OID
+/// does NOT mean "nothing new". `ttl` therefore bounds how stale the comment
+/// panel can get on a push-idle PR; the OID check only ACCELERATES resync after
+/// a push (a new head OID drops through the throttle so freshly-pushed review
+/// threads appear promptly). An empty/unknown `head_oid` never skips (fail open —
+/// keep syncing every tick until the probe loop populates a real OID). Pure so
+/// the skip decision is unit-testable without the surrounding thread/loop.
 fn comment_sync_recently_synced(
     last_entry: Option<&(String, std::time::Instant)>,
     head_oid: &str,
@@ -599,11 +604,11 @@ fn comment_sync_recently_synced(
 /// already probed this PR less than `ttl` ago (the throttle), regardless of
 /// whether the OID changed. Pure so the throttle is unit-testable.
 fn probe_recently_done(
-    last_entry: Option<&(String, std::time::Instant)>,
+    last_probe: Option<&std::time::Instant>,
     now: std::time::Instant,
     ttl: std::time::Duration,
 ) -> bool {
-    last_entry.is_some_and(|(_, last_at)| now.saturating_duration_since(*last_at) < ttl)
+    last_probe.is_some_and(|last_at| now.saturating_duration_since(*last_at) < ttl)
 }
 
 fn main() {
@@ -884,9 +889,12 @@ fn main() {
         }
     }
 
-    // The 30s `gh_status` loop below runs its first iteration immediately and
-    // shares dedup state via `gh_status_in_flight`, so a separate startup kick
-    // here would be a redundant duplicate fetch on the same identity.
+    // The 30s `gh_status` loop below now sleeps before its first iteration (to
+    // avoid a startup gh burst), so a cold-restored active PR tab shows its
+    // disk-cached status until that first tick (~30s) — an intentional tradeoff
+    // to keep launch gh-free. We deliberately don't kick a refresh here; an
+    // explicit tab open/switch/close still refreshes via `kick_active_gh_status`
+    // (itself 10s-gated, sharing dedup state through `gh_status_in_flight`).
 
     // NOTE: a remote-PR auto-swap loop used to live here (300s for remote
     // tabs, 60s otherwise), calling snapshot_for_remote_diff_refresh →
@@ -994,15 +1002,13 @@ fn main() {
         let probe_pr_cache = Arc::clone(&pr_cache);
         let probe_rev = Arc::clone(&desktop_revision);
         std::thread::spawn(move || {
-            // (slug, pr_number) -> (last-seen head OID, when we last actually
-            // probed). Throttles the gh subprocess to once per 60s per PR
-            // even though the loop ticks every 30s. The Instant is refreshed
-            // on EVERY successful probe, not only when the OID changed —
-            // recording it conditionally would make the throttle a no-op
-            // after the first window, since `elapsed()` would keep growing
+            // (slug, pr_number) -> when we last actually probed. Throttles the
+            // gh subprocess to once per 60s per PR even though the loop ticks
+            // every 30s. Refreshed on EVERY successful probe, not only when the
+            // OID changed — recording it conditionally would make the throttle a
+            // no-op after the first window, since `elapsed()` would keep growing
             // against a frozen Instant and never re-arm.
-            let mut probe_throttle: HashMap<(String, u64), (String, std::time::Instant)> =
-                HashMap::new();
+            let mut probe_throttle: HashMap<(String, u64), std::time::Instant> = HashMap::new();
             loop {
                 std::thread::sleep(std::time::Duration::from_secs(30));
 
@@ -1087,19 +1093,8 @@ fn main() {
                 let changed =
                     pr_cache::patch_pr_head_oid(&probe_pr_cache, &slug, pr_number, &oid);
 
-                // Always re-arm the 60s throttle window on a successful
-                // probe. Only overwrite the stored OID when it actually
-                // changed — an unchanged OID is already correct in the map.
-                let now = std::time::Instant::now();
-                probe_throttle
-                    .entry((slug.clone(), pr_number))
-                    .and_modify(|(stored_oid, last_at)| {
-                        *last_at = now;
-                        if changed {
-                            *stored_oid = oid.clone();
-                        }
-                    })
-                    .or_insert((oid.clone(), now));
+                // Re-arm the 60s throttle window on every successful probe.
+                probe_throttle.insert((slug.clone(), pr_number), std::time::Instant::now());
 
                 if changed {
                     profile_log::bump_desktop_revision(&probe_rev, "pr_head_probe");
@@ -1211,14 +1206,16 @@ fn main() {
         let comments_loading = Arc::clone(&loading);
         let comments_desktop_rev = Arc::clone(&desktop_revision);
         std::thread::spawn(move || {
-            // (owner, repo, number) -> (head OID synced against, when). Lets
-            // the 45s tick skip network I/O when nothing has moved upstream
-            // since the last successful sync. A real push updates head_oid
-            // via the pr-head-probe loop (main.rs ~950), so the next tick
-            // sees a mismatch and syncs again. Manual sync (`G` key →
-            // `pull_github_comments` → `App::sync_github_comments`) calls a
-            // separate synchronous path that never touches this loop or map,
-            // so it is completely unaffected.
+            // (owner, repo, number) -> (head OID synced against, when).
+            // Throttles the comment/review pull: within `ttl` of a sync against
+            // the same head OID the 45s tick skips the network I/O. Comments and
+            // reviews are independent of pushes, so `ttl` is the worst-case
+            // comment-panel latency on a push-idle PR — NOT a "nothing changed"
+            // guarantee. A push changes head_oid (via the pr-head-probe loop,
+            // itself throttled to ~60s), so a fresh push resyncs within ~1-2 min
+            // instead of waiting out `ttl`. Manual sync (`G` key →
+            // `pull_github_comments` → `App::sync_github_comments`) is a separate
+            // synchronous path that never touches this loop or map, unaffected.
             let mut last_synced: HashMap<(String, String, u64), (String, std::time::Instant)> =
                 HashMap::new();
             loop {
@@ -1255,17 +1252,19 @@ fn main() {
                             })
                         };
 
-                    // Skip-if-unchanged gate: same head OID synced <5 min ago
-                    // → nothing new to pull. An empty/unknown OID never skips
-                    // (fail open — keep syncing every tick until the probe
-                    // loop populates pr_cache).
+                    // Throttle gate: same head OID already synced within the
+                    // window → skip this tick (bounds comment-panel latency to
+                    // ~90s on a push-idle PR; does not guarantee nothing
+                    // changed). An empty/unknown OID never skips (fail open —
+                    // keep syncing every tick until the probe loop populates
+                    // pr_cache).
                     identity.and_then(|(owner, repo, number)| {
                         let head_oid = cached_head_oid(&comments_pr_cache, &owner, &repo, number);
                         let recently_synced = comment_sync_recently_synced(
                             last_synced.get(&(owner.clone(), repo.clone(), number)),
                             &head_oid,
                             std::time::Instant::now(),
-                            std::time::Duration::from_secs(300),
+                            std::time::Duration::from_secs(90),
                         );
                         if recently_synced {
                             None
@@ -2096,9 +2095,8 @@ mod tests {
     #[test]
     fn probe_skips_within_throttle_window() {
         let base = Instant::now();
-        let entry = ("oid".to_string(), base);
         assert!(probe_recently_done(
-            Some(&entry),
+            Some(&base),
             base + Duration::from_secs(30),
             Duration::from_secs(60),
         ));
@@ -2107,9 +2105,8 @@ mod tests {
     #[test]
     fn probe_runs_after_throttle_window() {
         let base = Instant::now();
-        let entry = ("oid".to_string(), base);
         assert!(!probe_recently_done(
-            Some(&entry),
+            Some(&base),
             base + Duration::from_secs(90),
             Duration::from_secs(60),
         ));
@@ -2119,9 +2116,8 @@ mod tests {
     fn probe_at_exactly_ttl_boundary_runs() {
         // age == ttl → `<` excludes it → not throttled (probe runs).
         let base = Instant::now();
-        let entry = ("oid".to_string(), base);
         assert!(!probe_recently_done(
-            Some(&entry),
+            Some(&base),
             base + Duration::from_secs(60),
             Duration::from_secs(60),
         ));

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -560,6 +560,52 @@ fn window_state_restore_flags() -> tauri_plugin_window_state::StateFlags {
     StateFlags::SIZE | StateFlags::POSITION | StateFlags::FULLSCREEN | StateFlags::DECORATIONS
 }
 
+/// Look up the cached head commit OID for `(owner, repo, number)` in the
+/// shared PR cache. Returns `""` when the remote/PR isn't cached yet —
+/// callers must treat that as "unknown" (fail open, never skip on it), since
+/// an empty OID is also `PrInfo::head_oid`'s `#[serde(default)]` value, not a
+/// real "no head" signal.
+fn cached_head_oid(pr_cache: &pr_cache::PrCacheMap, owner: &str, repo: &str, number: u64) -> String {
+    pr_cache
+        .lock()
+        .ok()
+        .and_then(|cache| {
+            cache
+                .get(&format!("{owner}/{repo}"))
+                .and_then(|prs| prs.iter().find(|p| p.number == number))
+                .map(|p| p.head_oid.clone())
+        })
+        .unwrap_or_default()
+}
+
+/// Whether the background comment-sync loop should SKIP this tick: the same PR
+/// head OID was already synced less than `ttl` ago, so nothing new can have been
+/// pushed. An empty/unknown `head_oid` never skips (fail open — keep syncing
+/// every tick until the probe loop populates a real OID). Pure so the skip
+/// decision is unit-testable without the surrounding thread/loop.
+fn comment_sync_recently_synced(
+    last_entry: Option<&(String, std::time::Instant)>,
+    head_oid: &str,
+    now: std::time::Instant,
+    ttl: std::time::Duration,
+) -> bool {
+    !head_oid.is_empty()
+        && last_entry.is_some_and(|(last_oid, last_at)| {
+            last_oid == head_oid && now.saturating_duration_since(*last_at) < ttl
+        })
+}
+
+/// Whether the pr-head-probe loop should SKIP the `gh` subprocess this tick: it
+/// already probed this PR less than `ttl` ago (the throttle), regardless of
+/// whether the OID changed. Pure so the throttle is unit-testable.
+fn probe_recently_done(
+    last_entry: Option<&(String, std::time::Instant)>,
+    now: std::time::Instant,
+    ttl: std::time::Duration,
+) -> bool {
+    last_entry.is_some_and(|(_, last_at)| now.saturating_duration_since(*last_at) < ttl)
+}
+
 fn main() {
     er_engine::env_path::init_cli_path();
     dev_log::init();
@@ -947,74 +993,117 @@ fn main() {
         let probe_app = Arc::clone(&app_arc);
         let probe_pr_cache = Arc::clone(&pr_cache);
         let probe_rev = Arc::clone(&desktop_revision);
-        std::thread::spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(30));
+        std::thread::spawn(move || {
+            // (slug, pr_number) -> (last-seen head OID, when we last actually
+            // probed). Throttles the gh subprocess to once per 60s per PR
+            // even though the loop ticks every 30s. The Instant is refreshed
+            // on EVERY successful probe, not only when the OID changed —
+            // recording it conditionally would make the throttle a no-op
+            // after the first window, since `elapsed()` would keep growing
+            // against a frozen Instant and never re-arm.
+            let mut probe_throttle: HashMap<(String, u64), (String, std::time::Instant)> =
+                HashMap::new();
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(30));
 
-            // Phase 1: brief lock — capture the active PR tab's identity.
-            // `(repo_root, owner, repo, pr_number)`. For remote tabs use
-            // `remote_repo`; for local-PR tabs resolve owner/repo from origin.
-            let identity = {
-                let guard = match probe_app.try_lock() {
-                    Ok(g) => g,
-                    Err(_) => continue,
-                };
-                let tab = guard.tab();
-                let pr_number = match tab.pr_number {
-                    Some(n) => n,
-                    None => continue,
-                };
-                if let Some(slug) = tab.remote_repo.as_ref() {
-                    if slug.split_once('/').is_some() {
-                        Some((tab.repo_root.clone(), slug.clone(), pr_number))
-                    } else {
-                        None
-                    }
-                } else if !tab.repo_root.is_empty() {
-                    match er_engine::github::get_repo_info(&tab.repo_root) {
-                        Ok((owner, repo)) => {
-                            Some((tab.repo_root.clone(), format!("{owner}/{repo}"), pr_number))
+                // Phase 1: brief lock — capture the active PR tab's identity.
+                // `(repo_root, owner, repo, pr_number)`. For remote tabs use
+                // `remote_repo`; for local-PR tabs resolve owner/repo from origin.
+                let identity = {
+                    let guard = match probe_app.try_lock() {
+                        Ok(g) => g,
+                        Err(_) => continue,
+                    };
+                    let tab = guard.tab();
+                    let pr_number = match tab.pr_number {
+                        Some(n) => n,
+                        None => continue,
+                    };
+                    if let Some(slug) = tab.remote_repo.as_ref() {
+                        if slug.split_once('/').is_some() {
+                            Some((tab.repo_root.clone(), slug.clone(), pr_number))
+                        } else {
+                            None
                         }
-                        Err(_) => None,
-                    }
-                } else {
-                    None
-                }
-            };
-            let Some((_repo_root, slug, pr_number)) = identity else {
-                continue;
-            };
-
-            // Phase 2: no lock — ask gh for the PR's latest head oid.
-            let out = std::process::Command::new("gh")
-                .args([
-                    "pr",
-                    "view",
-                    &pr_number.to_string(),
-                    "--repo",
-                    &slug,
-                    "--json",
-                    "headRefOid",
-                    "--jq",
-                    ".headRefOid",
-                ])
-                .output();
-            let oid = match out {
-                Ok(o) if o.status.success() => {
-                    let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                    if s.is_empty() {
-                        None
+                    } else if !tab.repo_root.is_empty() {
+                        match er_engine::github::get_repo_info(&tab.repo_root) {
+                            Ok((owner, repo)) => Some((
+                                tab.repo_root.clone(),
+                                format!("{owner}/{repo}"),
+                                pr_number,
+                            )),
+                            Err(_) => None,
+                        }
                     } else {
-                        Some(s)
+                        None
                     }
-                }
-                _ => None,
-            };
-            let Some(oid) = oid else { continue };
+                };
+                let Some((_repo_root, slug, pr_number)) = identity else {
+                    continue;
+                };
 
-            // Phase 3: brief lock — patch the cache entry; bump only on change.
-            let changed = pr_cache::patch_pr_head_oid(&probe_pr_cache, &slug, pr_number, &oid);
-            if changed {
-                profile_log::bump_desktop_revision(&probe_rev, "pr_head_probe");
+                // Throttle: skip the gh subprocess if this PR was probed
+                // within the last 60s, regardless of whether the OID changed
+                // last time.
+                if probe_recently_done(
+                    probe_throttle.get(&(slug.clone(), pr_number)),
+                    std::time::Instant::now(),
+                    std::time::Duration::from_secs(60),
+                ) {
+                    continue;
+                }
+
+                // Phase 2: no lock — ask gh for the PR's latest head oid.
+                let out = std::process::Command::new("gh")
+                    .args([
+                        "pr",
+                        "view",
+                        &pr_number.to_string(),
+                        "--repo",
+                        &slug,
+                        "--json",
+                        "headRefOid",
+                        "--jq",
+                        ".headRefOid",
+                    ])
+                    .output();
+                let oid = match out {
+                    Ok(o) if o.status.success() => {
+                        let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(s)
+                        }
+                    }
+                    _ => None,
+                };
+                // A failed/empty probe is NOT recorded into probe_throttle —
+                // a persistently-failing PR keeps retrying every 30s rather
+                // than being throttled to 60s on top of already being broken.
+                let Some(oid) = oid else { continue };
+
+                // Phase 3: brief lock — patch the cache entry; bump only on change.
+                let changed =
+                    pr_cache::patch_pr_head_oid(&probe_pr_cache, &slug, pr_number, &oid);
+
+                // Always re-arm the 60s throttle window on a successful
+                // probe. Only overwrite the stored OID when it actually
+                // changed — an unchanged OID is already correct in the map.
+                let now = std::time::Instant::now();
+                probe_throttle
+                    .entry((slug.clone(), pr_number))
+                    .and_modify(|(stored_oid, last_at)| {
+                        *last_at = now;
+                        if changed {
+                            *stored_oid = oid.clone();
+                        }
+                    })
+                    .or_insert((oid.clone(), now));
+
+                if changed {
+                    profile_log::bump_desktop_revision(&probe_rev, "pr_head_probe");
+                }
             }
         });
     }
@@ -1032,6 +1121,10 @@ fn main() {
         let gh_status_in_flight_bg = Arc::clone(&gh_status_in_flight);
         let gh_status_desktop_rev = Arc::clone(&desktop_revision);
         std::thread::spawn(move || loop {
+            // Sleep FIRST: kills the startup burst (this loop used to fire
+            // immediately on launch because the sleep sat at the bottom).
+            std::thread::sleep(std::time::Duration::from_secs(30));
+
             // Snapshot identity in a short critical section.
             let key: Option<(String, String, u64)> = match app_bg.lock() {
                 Ok(g) => {
@@ -1062,7 +1155,22 @@ fn main() {
                 }
                 Err(_) => None,
             };
-            // Lock released. Register in-flight and shell out — skip if already fetching.
+            // Lock released. Skip the fetch entirely when the cached snapshot
+            // for this key is still fresh (<90s old) — most ticks on an idle
+            // PR now do nothing at all.
+            let key = key.filter(|(owner, repo, number)| {
+                let last_updated = gh_status_bg.lock().ok().and_then(|cache| {
+                    cache
+                        .get(&(owner.clone(), repo.clone(), *number))
+                        .and_then(|snap| snap.last_updated.clone())
+                });
+                !gh_status_cache::status_is_fresh(
+                    last_updated.as_deref(),
+                    gh_status_cache::now_epoch_secs(),
+                    90,
+                )
+            });
+            // Register in-flight and shell out — skip if already fetching.
             if let Some((owner, repo, number)) = key {
                 let registered = gh_status_in_flight_bg
                     .lock()
@@ -1089,7 +1197,6 @@ fn main() {
                         .map(|mut s| s.remove(&(owner, repo, number)));
                 }
             }
-            std::thread::sleep(std::time::Duration::from_secs(30));
         });
     }
 
@@ -1103,76 +1210,116 @@ fn main() {
         let comments_pr_cache = Arc::clone(&pr_cache);
         let comments_loading = Arc::clone(&loading);
         let comments_desktop_rev = Arc::clone(&desktop_revision);
-        std::thread::spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(45));
+        std::thread::spawn(move || {
+            // (owner, repo, number) -> (head OID synced against, when). Lets
+            // the 45s tick skip network I/O when nothing has moved upstream
+            // since the last successful sync. A real push updates head_oid
+            // via the pr-head-probe loop (main.rs ~950), so the next tick
+            // sees a mismatch and syncs again. Manual sync (`G` key →
+            // `pull_github_comments` → `App::sync_github_comments`) calls a
+            // separate synchronous path that never touches this loop or map,
+            // so it is completely unaffected.
+            let mut last_synced: HashMap<(String, String, u64), (String, std::time::Instant)> =
+                HashMap::new();
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(45));
 
-            // Phase 1: brief lock — snapshot identity + files, then release.
-            let ctx = {
-                let guard = match comments_app.try_lock() {
-                    Ok(g) => g,
-                    Err(_) => continue,
-                };
-                let tab = guard.tab();
-                let identity: Option<(String, String, u64)> =
-                    if let (Some(slug), Some(n)) = (tab.remote_repo.as_ref(), tab.pr_number) {
-                        slug.split_once('/')
-                            .map(|(o, r)| (o.to_string(), r.to_string(), n))
-                    } else {
-                        let branch = tab
-                            .local_branch_view
-                            .as_deref()
-                            .unwrap_or(&tab.current_branch)
-                            .to_string();
-                        comments_pr_cache.lock().ok().and_then(|cache| {
-                            cache.iter().find_map(|(slug, prs)| {
-                                prs.iter()
-                                    .filter(|p| p.head_ref == branch)
-                                    .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
-                                    .and_then(|p| {
-                                        slug.split_once('/')
-                                            .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
-                                    })
-                            })
-                        })
+                // Phase 1: brief lock — snapshot identity + files, then release.
+                let resolved = {
+                    let guard = match comments_app.try_lock() {
+                        Ok(g) => g,
+                        Err(_) => continue,
                     };
-                // Snapshot all data needed for the fetch — releases lock after this block.
-                identity.map(|(owner, repo, number)| {
-                    guard.snapshot_for_comment_sync(owner, repo, number)
-                })
-            };
+                    let tab = guard.tab();
+                    let identity: Option<(String, String, u64)> =
+                        if let (Some(slug), Some(n)) = (tab.remote_repo.as_ref(), tab.pr_number) {
+                            slug.split_once('/')
+                                .map(|(o, r)| (o.to_string(), r.to_string(), n))
+                        } else {
+                            let branch = tab
+                                .local_branch_view
+                                .as_deref()
+                                .unwrap_or(&tab.current_branch)
+                                .to_string();
+                            comments_pr_cache.lock().ok().and_then(|cache| {
+                                cache.iter().find_map(|(slug, prs)| {
+                                    prs.iter()
+                                        .filter(|p| p.head_ref == branch)
+                                        .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
+                                        .and_then(|p| {
+                                            slug.split_once('/').map(|(o, r)| {
+                                                (o.to_string(), r.to_string(), p.number)
+                                            })
+                                        })
+                                })
+                            })
+                        };
 
-            // Phase 2: network I/O — no lock held.
-            if let Some(ctx) = ctx {
-                if let Ok(mut f) = comments_loading.lock() {
-                    f.gh_comments = true;
-                }
-                let applied = match er_engine::app::fetch_comment_sync_data(&ctx) {
-                    Ok(result) => {
-                        // Phase 3: brief lock — apply pre-fetched results to the correct tab.
-                        match comments_app.lock() {
-                            Ok(mut g) => {
-                                g.apply_comment_sync_result(result);
-                                true
-                            }
-                            Err(e) => {
-                                log::error!("comment sync apply lock failed: {e}");
-                                false
+                    // Skip-if-unchanged gate: same head OID synced <5 min ago
+                    // → nothing new to pull. An empty/unknown OID never skips
+                    // (fail open — keep syncing every tick until the probe
+                    // loop populates pr_cache).
+                    identity.and_then(|(owner, repo, number)| {
+                        let head_oid = cached_head_oid(&comments_pr_cache, &owner, &repo, number);
+                        let recently_synced = comment_sync_recently_synced(
+                            last_synced.get(&(owner.clone(), repo.clone(), number)),
+                            &head_oid,
+                            std::time::Instant::now(),
+                            std::time::Duration::from_secs(300),
+                        );
+                        if recently_synced {
+                            None
+                        } else {
+                            // Snapshot all data needed for the fetch — releases
+                            // the lock after this block. Carry the gate-time
+                            // head_oid forward (instead of re-reading it after
+                            // the fetch) so a push landing mid-fetch isn't
+                            // mistaken for "already synced" on the next tick.
+                            Some((
+                                guard.snapshot_for_comment_sync(owner, repo, number),
+                                head_oid,
+                            ))
+                        }
+                    })
+                };
+
+                // Phase 2: network I/O — no lock held.
+                if let Some((ctx, head_oid)) = resolved {
+                    if let Ok(mut f) = comments_loading.lock() {
+                        f.gh_comments = true;
+                    }
+                    let applied = match er_engine::app::fetch_comment_sync_data(&ctx) {
+                        Ok(result) => {
+                            // Phase 3: brief lock — apply pre-fetched results to the correct tab.
+                            match comments_app.lock() {
+                                Ok(mut g) => {
+                                    g.apply_comment_sync_result(result);
+                                    true
+                                }
+                                Err(e) => {
+                                    log::error!("comment sync apply lock failed: {e}");
+                                    false
+                                }
                             }
                         }
+                        Err(e) => {
+                            log::error!("github comment sync failed: {e}");
+                            false
+                        }
+                    };
+                    if let Ok(mut f) = comments_loading.lock() {
+                        f.gh_comments = false;
                     }
-                    Err(e) => {
-                        log::error!("github comment sync failed: {e}");
-                        false
+                    if applied {
+                        last_synced.insert(
+                            (ctx.owner.clone(), ctx.repo_name.clone(), ctx.pr_number),
+                            (head_oid, std::time::Instant::now()),
+                        );
+                        profile_log::bump_desktop_revision(
+                            &comments_desktop_rev,
+                            "comment_sync_applied",
+                        );
                     }
-                };
-                if let Ok(mut f) = comments_loading.lock() {
-                    f.gh_comments = false;
-                }
-                if applied {
-                    profile_log::bump_desktop_revision(
-                        &comments_desktop_rev,
-                        "comment_sync_applied",
-                    );
                 }
             }
         });
@@ -1878,6 +2025,116 @@ fn active_root_from_projects() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
+
+    // ── comment_sync_recently_synced (finding 2a skip gate) ──
+    // `base` is the synced-at instant; `base + elapsed` is "now", so the gate
+    // sees exactly `elapsed` since the last sync without depending on wall time.
+
+    #[test]
+    fn comment_sync_skips_when_same_oid_within_ttl() {
+        let base = Instant::now();
+        let entry = ("oid-abc".to_string(), base);
+        assert!(comment_sync_recently_synced(
+            Some(&entry),
+            "oid-abc",
+            base + Duration::from_secs(100),
+            Duration::from_secs(300),
+        ));
+    }
+
+    #[test]
+    fn comment_sync_syncs_when_same_oid_but_ttl_expired() {
+        let base = Instant::now();
+        let entry = ("oid-abc".to_string(), base);
+        assert!(!comment_sync_recently_synced(
+            Some(&entry),
+            "oid-abc",
+            base + Duration::from_secs(400),
+            Duration::from_secs(300),
+        ));
+    }
+
+    #[test]
+    fn comment_sync_syncs_when_oid_differs_even_if_recent() {
+        // A new push (different head OID) must sync immediately regardless of TTL.
+        let base = Instant::now();
+        let entry = ("oid-old".to_string(), base);
+        assert!(!comment_sync_recently_synced(
+            Some(&entry),
+            "oid-new",
+            base + Duration::from_secs(5),
+            Duration::from_secs(300),
+        ));
+    }
+
+    #[test]
+    fn comment_sync_never_skips_on_empty_oid() {
+        // Fail open: an unknown/empty cached OID must keep syncing every tick.
+        let base = Instant::now();
+        let entry = ("".to_string(), base);
+        assert!(!comment_sync_recently_synced(
+            Some(&entry),
+            "",
+            base + Duration::from_secs(1),
+            Duration::from_secs(300),
+        ));
+    }
+
+    #[test]
+    fn comment_sync_never_skips_with_no_prior_entry() {
+        assert!(!comment_sync_recently_synced(
+            None,
+            "oid-abc",
+            Instant::now(),
+            Duration::from_secs(300),
+        ));
+    }
+
+    // ── probe_recently_done (finding 3 throttle) ──
+
+    #[test]
+    fn probe_skips_within_throttle_window() {
+        let base = Instant::now();
+        let entry = ("oid".to_string(), base);
+        assert!(probe_recently_done(
+            Some(&entry),
+            base + Duration::from_secs(30),
+            Duration::from_secs(60),
+        ));
+    }
+
+    #[test]
+    fn probe_runs_after_throttle_window() {
+        let base = Instant::now();
+        let entry = ("oid".to_string(), base);
+        assert!(!probe_recently_done(
+            Some(&entry),
+            base + Duration::from_secs(90),
+            Duration::from_secs(60),
+        ));
+    }
+
+    #[test]
+    fn probe_at_exactly_ttl_boundary_runs() {
+        // age == ttl → `<` excludes it → not throttled (probe runs).
+        let base = Instant::now();
+        let entry = ("oid".to_string(), base);
+        assert!(!probe_recently_done(
+            Some(&entry),
+            base + Duration::from_secs(60),
+            Duration::from_secs(60),
+        ));
+    }
+
+    #[test]
+    fn probe_runs_with_no_prior_entry() {
+        assert!(!probe_recently_done(
+            None,
+            Instant::now(),
+            Duration::from_secs(60),
+        ));
+    }
 
     #[test]
     fn bounded_read_under_limit_succeeds() {

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -2079,6 +2079,33 @@ impl TabState {
     ///
     /// Returns `Err` if no PR number is set or the first-entry fetch fails.
     pub fn enter_pr_diff(&mut self) -> Result<()> {
+        self.enter_pr_diff_impl(false)
+    }
+
+    /// Same as `enter_pr_diff`, but for a caller that has *just* populated
+    /// `self.files`/`self.raw_diff`/`self.diff_hash` from the exact `gh pr diff`
+    /// output this entry would otherwise re-fetch — today only the desktop
+    /// cold-open path (`open_pr_review_impl` in `er-desktop/src/commands.rs`),
+    /// which builds the tab via `new_local_pr_from_github_diff` from a diff
+    /// fetched moments earlier in `load_pr_open_inputs`. Mirrors the trust
+    /// `enter_pr_diff_preloaded` already places in a cache-hit diff — this is
+    /// strictly weaker (it still does the first-entry ref fetch), so skipping
+    /// just the trailing `refresh_diff()` is no less safe.
+    ///
+    /// Skips `refresh_diff()` only when `self.files` is already non-empty;
+    /// falls back to a full refresh otherwise (e.g. a 0-file PR, or caller
+    /// misuse) so this can never silently leave a blank diff on screen.
+    ///
+    /// Do NOT use this for a mode switch on a tab whose `files` holds a
+    /// *different* diff (e.g. switching Unstaged → PR Diff) — `files` would be
+    /// non-empty but wrong-scope, and skipping would leave that stale diff on
+    /// screen. Use `enter_pr_diff` there instead (TUI `normal.rs`, desktop
+    /// `set_mode`).
+    pub fn enter_pr_diff_freshly_loaded(&mut self) -> Result<()> {
+        self.enter_pr_diff_impl(true)
+    }
+
+    fn enter_pr_diff_impl(&mut self, skip_refresh_if_loaded: bool) -> Result<()> {
         let pr_number = self
             .pr_number
             .ok_or_else(|| anyhow::anyhow!("No PR number set for this tab"))?;
@@ -2104,6 +2131,10 @@ impl TabState {
         self.apply_managed_root();
         self.reviewed = Self::load_reviewed_files_from_path(&self.er_root.reviewed_path());
         self.reload_ai_state();
+
+        if skip_refresh_if_loaded && !self.files.is_empty() {
+            return Ok(());
+        }
         self.refresh_diff()
     }
 
@@ -9051,6 +9082,83 @@ mod tests {
             .enter_pr_diff_preloaded("oid".to_string())
             .expect_err("missing PR number must error, not silently no-op");
         assert!(err.to_string().contains("No PR number"));
+    }
+
+    #[test]
+    fn enter_pr_diff_freshly_loaded_skips_refresh_when_files_already_loaded() {
+        // Simulates the desktop cold-open path: `new_local_pr_from_github_diff`
+        // has already parsed `inputs.raw_diff` into files/raw_diff/diff_hash
+        // before this call. Pre-set `pr_refs_fetched` so the first-entry
+        // git-fetch block (a separate, out-of-scope concern) is also skipped —
+        // this isolates the `refresh_diff()` guard. Outside a real git repo any
+        // `gh pr diff` call here would fail, so `Ok(())` is itself proof no
+        // refetch ran.
+        let raw = "diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+new\n";
+        let mut tab = TabState::new_for_test(vec![make_file(
+            "x",
+            vec![make_hunk(vec![make_line(LineType::Add, "new", Some(1))])],
+            1,
+            1,
+        )]);
+        tab.pr_number = Some(42);
+        tab.pr_refs_fetched = true;
+        tab.raw_diff = Some(raw.to_string());
+        let loaded_hash = crate::ai::compute_diff_hash(raw);
+        tab.diff_hash = loaded_hash.clone();
+
+        tab.enter_pr_diff_freshly_loaded()
+            .expect("freshly-loaded entry succeeds without a refetch");
+
+        assert_eq!(tab.mode, DiffMode::PrDiff);
+        assert_eq!(tab.files.len(), 1, "pre-loaded files are left intact");
+        assert_eq!(
+            tab.diff_hash, loaded_hash,
+            "diff_hash is not recomputed — refresh_diff() did not run"
+        );
+    }
+
+    #[test]
+    fn enter_pr_diff_freshly_loaded_falls_back_to_refresh_when_files_empty() {
+        // Defensive fallback: if `files` is empty (0-file PR, or caller
+        // misuse), the skip must not apply — a real refresh must still be
+        // attempted so the tab never silently shows a blank diff. Outside a
+        // real git repo this refetch attempt fails, which is itself proof the
+        // fallback path executed (not a silent no-op).
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.pr_number = Some(42);
+        tab.pr_refs_fetched = true;
+        tab.local_branch_view = Some("pr/42".to_string());
+
+        let err = tab
+            .enter_pr_diff_freshly_loaded()
+            .expect_err("empty files must not silently skip the refresh");
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn enter_pr_diff_always_refreshes_even_when_files_already_loaded() {
+        // Guards against widening the skip to the general entry point: TUI
+        // (normal.rs) and desktop `set_mode` call `enter_pr_diff()` when
+        // switching from another mode (e.g. Unstaged) whose `files` holds a
+        // *different*, wrong-scope diff. `enter_pr_diff()` must always
+        // refresh, never trust pre-existing `files`.
+        let raw = "diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+new\n";
+        let mut tab = TabState::new_for_test(vec![make_file(
+            "x",
+            vec![make_hunk(vec![make_line(LineType::Add, "new", Some(1))])],
+            1,
+            1,
+        )]);
+        tab.pr_number = Some(42);
+        tab.pr_refs_fetched = true;
+        tab.local_branch_view = Some("pr/42".to_string());
+        tab.raw_diff = Some(raw.to_string());
+        tab.diff_hash = crate::ai::compute_diff_hash(raw);
+
+        let err = tab
+            .enter_pr_diff()
+            .expect_err("must attempt a real refresh even with files already populated");
+        assert!(!err.to_string().is_empty());
     }
 
     #[test]

--- a/crates/er-engine/src/github.rs
+++ b/crates/er-engine/src/github.rs
@@ -939,6 +939,24 @@ pub fn gh_pr_approve(
 /// Fetch PR overview data: title, body, state, author, branches, reviewers.
 /// If `pr_number` is Some, fetches that specific PR; otherwise auto-detects from current branch.
 pub fn gh_pr_overview(repo_root: &str, pr_number: Option<u64>) -> Option<PrOverviewData> {
+    gh_pr_overview_impl(repo_root, pr_number, true)
+}
+
+/// Like `gh_pr_overview`, but skips the separate `gh pr checks` subprocess
+/// (`checks` is always empty in the result). Use this when the caller already
+/// has a fresher CI-checks source for the same PR — e.g. the desktop's 30s
+/// gh-status loop (`fetch_github_status` / `gh_status_cache`) — and only needs
+/// title/state/author/branch/reviewer metadata, to avoid a duplicate
+/// `gh pr checks` call on every tick.
+pub fn gh_pr_overview_no_checks(repo_root: &str, pr_number: Option<u64>) -> Option<PrOverviewData> {
+    gh_pr_overview_impl(repo_root, pr_number, false)
+}
+
+fn gh_pr_overview_impl(
+    repo_root: &str,
+    pr_number: Option<u64>,
+    include_checks: bool,
+) -> Option<PrOverviewData> {
     // Fetch core PR fields
     let mut args = vec!["pr", "view"];
     let pr_num_str;
@@ -978,8 +996,14 @@ pub fn gh_pr_overview(repo_root: &str, pr_number: Option<u64>) -> Option<PrOverv
         Vec::new()
     };
 
-    // Fetch CI checks (separate call — may fail if no checks configured)
-    let checks = gh_pr_checks_data(repo_root).unwrap_or_default();
+    // Fetch CI checks (separate call — may fail if no checks configured).
+    // Skipped when the caller already has a fresher checks source — see
+    // `gh_pr_overview_no_checks`.
+    let checks = if include_checks {
+        gh_pr_checks_data(repo_root).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
     Some(PrOverviewData {
         number,
@@ -2012,32 +2036,25 @@ pub fn gh_pr_commits_remote(
     parse_pr_commits_view_json(&output.stdout, limit).unwrap_or_default()
 }
 
-/// Fetch a rich PR overview (state, draft, review decision, mergeable, labels)
-/// for a remote PR. No local clone required.
-pub fn gh_pr_overview_remote_full(owner: &str, repo: &str, number: u64) -> Result<PrOverviewFull> {
-    let repo_slug = format!("{}/{}", owner, repo);
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            &repo_slug,
-            "--json",
-            "number,title,body,state,isDraft,author,reviewDecision,mergeable,headRefName,baseRefName,labels,url",
-        ])
-        .output()
-        .context("Failed to run gh pr view")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("gh pr view failed: {}", stderr.trim());
-    }
-    parse_pr_overview(&String::from_utf8_lossy(&output.stdout))
+/// Combined overview + conversation-comments + reviews for a remote PR, in
+/// ONE `gh pr view --json` subprocess. Collapses what used to be three
+/// separate `gh pr view` calls (`gh_pr_overview_remote_full` +
+/// `gh_pr_comments_overview` + `gh_pr_reviews`) into one GraphQL-backed call —
+/// verified empirically that requesting `comments`/`reviews` alongside other
+/// fields returns byte-identical data to requesting them alone (see
+/// internal-docs/gh-rate-limit-slimming.md, finding 5).
+///
+/// `gh pr checks` (CI status) is intentionally NOT folded in here — it's a
+/// different `gh` subcommand and must stay a separate call (`gh_pr_checks_remote`).
+pub struct PrStatusBundle {
+    pub overview: PrOverviewFull,
+    pub comments: Vec<PrComment>,
+    pub reviews: Vec<PrReview>,
 }
 
-/// Fetch general PR conversation comments (the issue-comments stream — NOT the
-/// per-line review comments fetched by `gh_pr_comments_remote`).
-pub fn gh_pr_comments_overview(owner: &str, repo: &str, number: u64) -> Result<Vec<PrComment>> {
+/// Fetch overview + comments + reviews for a remote PR in one `gh pr view` call.
+/// No local clone required.
+pub fn gh_pr_status_remote(owner: &str, repo: &str, number: u64) -> Result<PrStatusBundle> {
     let repo_slug = format!("{}/{}", owner, repo);
     let output = Command::new("gh")
         .args([
@@ -2047,37 +2064,27 @@ pub fn gh_pr_comments_overview(owner: &str, repo: &str, number: u64) -> Result<V
             "--repo",
             &repo_slug,
             "--json",
-            "comments",
+            "number,title,body,state,isDraft,author,reviewDecision,mergeable,headRefName,baseRefName,labels,url,comments,reviews",
         ])
         .output()
-        .context("Failed to run gh pr view (comments)")?;
+        .context("Failed to run gh pr view (status bundle)")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("gh pr view comments failed: {}", stderr.trim());
+        anyhow::bail!("gh pr view (status bundle) failed: {}", stderr.trim());
     }
-    parse_pr_comments(&String::from_utf8_lossy(&output.stdout))
-}
-
-/// Fetch reviews (APPROVED / CHANGES_REQUESTED / COMMENTED) for a remote PR.
-pub fn gh_pr_reviews(owner: &str, repo: &str, number: u64) -> Result<Vec<PrReview>> {
-    let repo_slug = format!("{}/{}", owner, repo);
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            &repo_slug,
-            "--json",
-            "reviews",
-        ])
-        .output()
-        .context("Failed to run gh pr view (reviews)")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("gh pr view reviews failed: {}", stderr.trim());
-    }
-    parse_pr_reviews(&String::from_utf8_lossy(&output.stdout))
+    let json = String::from_utf8_lossy(&output.stdout);
+    // overview parse failure is fatal (matches old gh_pr_overview_remote_full
+    // behavior — caller treats a failed overview as "no status available").
+    let overview = parse_pr_overview(&json)?;
+    // comments/reviews failures are non-fatal (matches old call sites, which
+    // wrapped these in `.unwrap_or_default()` at the spawn closure).
+    let comments = parse_pr_comments(&json).unwrap_or_default();
+    let reviews = parse_pr_reviews(&json).unwrap_or_default();
+    Ok(PrStatusBundle {
+        overview,
+        comments,
+        reviews,
+    })
 }
 
 /// Fetch CI check runs for a remote PR.
@@ -2469,6 +2476,70 @@ mod tests {
         assert_eq!(commits[0].author, "Grace Hopper");
         assert_eq!(commits[1].hash, "1111111111111111111111111111111111111111");
         assert_eq!(commits[1].author, "ada");
+    }
+
+    #[test]
+    fn combined_status_json_parses_overview_comments_reviews_independently() {
+        let json = r#"{
+            "number": 42,
+            "title": "Fix the bug",
+            "body": "Detailed description",
+            "state": "OPEN",
+            "isDraft": false,
+            "author": { "login": "contributor" },
+            "reviewDecision": "APPROVED",
+            "mergeable": "MERGEABLE",
+            "headRefName": "fix/the-bug",
+            "baseRefName": "main",
+            "labels": [{ "name": "bug" }, { "name": "p1" }],
+            "url": "https://github.com/owner/repo/pull/42",
+            "comments": [
+                {
+                    "author": { "login": "alice" },
+                    "body": "looks good",
+                    "createdAt": "2026-06-01T10:00:00Z",
+                    "url": "https://github.com/owner/repo/pull/42#issuecomment-1"
+                },
+                {
+                    "author": { "login": "bob" },
+                    "body": "one nit",
+                    "createdAt": "2026-06-02T11:00:00Z",
+                    "url": "https://github.com/owner/repo/pull/42#issuecomment-2"
+                }
+            ],
+            "reviews": [
+                {
+                    "author": { "login": "carol" },
+                    "state": "CHANGES_REQUESTED",
+                    "body": "needs work",
+                    "submittedAt": "2026-06-01T12:00:00Z"
+                },
+                {
+                    "author": { "login": "carol" },
+                    "state": "APPROVED",
+                    "body": "lgtm now",
+                    "submittedAt": "2026-06-03T09:00:00Z"
+                }
+            ]
+        }"#;
+
+        let overview = parse_pr_overview(json).unwrap();
+        assert_eq!(overview.number, 42);
+        assert_eq!(overview.author, "contributor");
+        assert_eq!(overview.review_decision.as_deref(), Some("APPROVED"));
+        assert_eq!(overview.labels, vec!["bug".to_string(), "p1".to_string()]);
+
+        let comments = parse_pr_comments(json).unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(comments[1].author, "bob");
+        assert_eq!(comments[1].body, "one nit");
+
+        let reviews = parse_pr_reviews(json).unwrap();
+        assert_eq!(reviews.len(), 2);
+        assert_eq!(reviews[0].state, "CHANGES_REQUESTED");
+        assert_eq!(reviews[1].state, "APPROVED");
+        assert_eq!(reviews[1].submitted_at, "2026-06-03T09:00:00Z");
     }
 
     #[test]

--- a/crates/er-engine/src/sync.rs
+++ b/crates/er-engine/src/sync.rs
@@ -261,7 +261,17 @@ pub fn fetch_comment_sync_data(ctx: &CommentSyncContext) -> Result<CommentSyncRe
     std::fs::write(&tmp_path, &json)?;
     std::fs::rename(&tmp_path, &ctx.comments_path)?;
 
-    // Refresh PR overview (still outside app lock)
+    // Refresh PR overview (still outside app lock).
+    // Remote PRs already skip the CI-checks subprocess inside
+    // `gh_pr_overview_remote` (no local clone for `gh pr checks` to target).
+    // Local-clone PRs use the checks-free variant: the desktop's 30s
+    // gh-status loop (`fetch_github_status`, er-desktop/src/commands.rs)
+    // already polls `gh pr checks` for this same (owner, repo, pr_number)
+    // every tick — re-fetching checks here every 45s was pure duplication
+    // (~80 calls/hr per open local-clone PR tab). `tab.pr_data.checks` is
+    // not read by any desktop code path (the desktop snapshot drops
+    // `checks`/`reviewers` when building `PrSnapshot`); only the TUI reads
+    // `pr.checks`, and the TUI never calls this function.
     let pr_data = if ctx.is_remote {
         github::gh_pr_overview_remote(
             &ctx.owner,
@@ -269,7 +279,7 @@ pub fn fetch_comment_sync_data(ctx: &CommentSyncContext) -> Result<CommentSyncRe
             ctx.pr_number_for_overview.unwrap_or(ctx.pr_number),
         )
     } else {
-        github::gh_pr_overview(&ctx.repo_root, ctx.pr_number_for_overview)
+        github::gh_pr_overview_no_checks(&ctx.repo_root, ctx.pr_number_for_overview)
     };
 
     Ok(CommentSyncResult {

--- a/docs/release-notes/gh-rate-limit-slimming.md
+++ b/docs/release-notes/gh-rate-limit-slimming.md
@@ -26,10 +26,11 @@ Steady state for one idle PR tab falls from ~900 calls/hr to well under ~50.
   to the standalone calls.
 - **Tab switches no longer re-burst.** `kick_active_gh_status` (fired on every tab open / switch /
   close) now returns early when the active tab's status is <10s old.
-- **Comment-sync loop is change-driven.** The 45s loop skips a tick when the PR's head commit
-  hasn't moved since the last successful sync and that sync was <5 min ago — turning an always-on
-  timer into one that only works when something actually changed. A real push moves the head OID
-  (detected within ≤60s) and the next tick syncs normally.
+- **Comment-sync loop is throttled.** The 45s loop skips a tick when the PR's head commit hasn't
+  moved since the last successful sync and that sync was <90s ago. Comments and reviews are posted
+  independently of any push, so this is a poll throttle (bounding comment-panel latency to ~90s on a
+  push-idle PR), not change-detection — a new push moves the head OID (detected within ≤60s) and
+  drops through the throttle so freshly-pushed review threads sync promptly.
 - **Dropped a duplicated CI fetch.** The comment-sync loop's local-clone PR-overview refresh was
   re-running `gh pr checks` every 45s — data the 30s status loop already owns. It now uses a
   checks-free overview variant (−~80 calls/hr per local-clone PR tab). Metadata (title / state /
@@ -55,7 +56,7 @@ Steady state for one idle PR tab falls from ~900 calls/hr to well under ~50.
 | Surface | Before | After (worst case) |
 |---|---|---|
 | CI / review status | ≤30s | **≤90s** when idle |
-| Auto-pull of teammate comments (no push) | ≤45s | **≤~5 min** when the head OID hasn't moved |
+| Auto-pull of teammate comments (no push) | ≤45s | **≤~90s** (poll throttle; a push resyncs within ~1–2 min) |
 | "PR head updated on origin" stale pill | ≤30s | **≤60s** |
 | Tab-switch status refresh | always | skipped if <10s old |
 

--- a/docs/release-notes/gh-rate-limit-slimming.md
+++ b/docs/release-notes/gh-rate-limit-slimming.md
@@ -1,0 +1,100 @@
+# gh CLI rate-limit slimming (desktop background loops)
+
+## In plain terms
+
+The desktop app keeps three background timers running the whole time a PR tab is open: every
+30s it asks GitHub four things at once (PR status, CI checks, comments, reviews), every 30s it
+asks "did the PR branch move?", and every 45s it pulls review comments. None of them checked
+whether the answer they already had was still fresh — they just re-asked on the clock. With one
+PR tab open that was roughly **760–920 GitHub calls/hour**, and it multiplied per open tab.
+GitHub's *secondary* rate limit punishes bursts and concurrency, and the 30s timer fired four
+calls at the same instant — exactly what trips it.
+
+This change makes each timer check freshness before it calls out ("is what I have recent enough?
+then skip"), drops one purely-duplicated CI fetch, and collapses the four-call burst into two.
+Steady state for one idle PR tab falls from ~900 calls/hr to well under ~50.
+
+## What changed
+
+- **30s PR-status loop now skips when fresh (≤90s).** The loop already computed a `last_updated`
+  timestamp and never read it; it's now the freshness gate. The startup burst is gone too (the
+  loop sleeps before its first fetch instead of after).
+- **PR-status fan-out collapsed 4 → 2 subprocesses.** The overview, conversation-comments, and
+  reviews calls were three separate `gh pr view --json` projections of the *same* PR object;
+  they're now one `gh pr view --json <14 fields>` parsed three ways. `gh pr checks` stays a
+  separate call (different subcommand). Verified the merged `comments`/`reviews` are byte-identical
+  to the standalone calls.
+- **Tab switches no longer re-burst.** `kick_active_gh_status` (fired on every tab open / switch /
+  close) now returns early when the active tab's status is <10s old.
+- **Comment-sync loop is change-driven.** The 45s loop skips a tick when the PR's head commit
+  hasn't moved since the last successful sync and that sync was <5 min ago — turning an always-on
+  timer into one that only works when something actually changed. A real push moves the head OID
+  (detected within ≤60s) and the next tick syncs normally.
+- **Dropped a duplicated CI fetch.** The comment-sync loop's local-clone PR-overview refresh was
+  re-running `gh pr checks` every 45s — data the 30s status loop already owns. It now uses a
+  checks-free overview variant (−~80 calls/hr per local-clone PR tab). Metadata (title / state /
+  reviewers) is still refreshed.
+- **PR-head probe throttled to 60s.** The 30s "did the PR head move on origin?" probe now skips
+  when it probed the same PR <60s ago (the throttle re-arms on every probe, so it never silently
+  reverts to firing every tick).
+- **Cold PR open no longer fetches the diff twice.** Opening a PR for the first time fetched the
+  diff once to build the tab, then `enter_pr_diff()` re-fetched the identical diff via
+  `refresh_diff()`. A new `enter_pr_diff_freshly_loaded()` trusts the just-loaded diff and skips
+  the redundant `gh pr diff` (with a fallback to a real refresh if the tab somehow has no files).
+
+> **Not included (finding 7).** Caching the submit-time head OID for review submission was prototyped
+> and then dropped: an adversarial review found the cached OID can be stale (the PR cache is persisted
+> across sessions, so it can be far behind right after launch), and submitting a review against a stale
+> commit can drop inline comments or anchor them to the wrong commit. It saves ~1 `gh` call per *manual*
+> submit and nothing in steady state, so it isn't worth a write-path correctness risk. Review submission
+> keeps fetching the head OID fresh, exactly as before. A safe version (anchor to the reviewed diff's
+> own head, `last_diff_head_oid`) is left as a follow-up.
+
+## Staleness tradeoffs (intentional)
+
+| Surface | Before | After (worst case) |
+|---|---|---|
+| CI / review status | ≤30s | **≤90s** when idle |
+| Auto-pull of teammate comments (no push) | ≤45s | **≤~5 min** when the head OID hasn't moved |
+| "PR head updated on origin" stale pill | ≤30s | **≤60s** |
+| Tab-switch status refresh | always | skipped if <10s old |
+
+Manual sync (`G` / "sync now") is untouched and still immediate; a real push is detected within
+≤60s and syncs on the next tick regardless of the 5-minute timer.
+
+## Why it's safe
+
+- The freshness gate is a pure `status_is_fresh()` that **fails open** — a missing, non-numeric,
+  or future timestamp is treated as stale (fetch), never as fresh (skip) — with unit tests on the
+  boundary and fail-open cases.
+- The fan-out merge keeps every existing pure parser unchanged and adds a test proving the
+  combined 14-field JSON extracts overview / comments / reviews independently (no cross-contamination).
+  One accepted tradeoff: overview + comments + reviews now share a single subprocess, so a failed call
+  yields no snapshot rather than a partial one — but a warm tab keeps its last-good snapshot (the cache
+  isn't cleared on a failed tick), and cold-open already required the overview call to succeed, so the
+  practical behavior is unchanged while total call volume drops.
+- The comment-sync gate carries the gate-time head OID forward so a push landing mid-fetch isn't
+  mistaken for "already synced," and falls open on an unknown OID.
+- The cold-open diff skip uses a dedicated entry point (not a blanket `files.is_empty()` guard
+  inside `enter_pr_diff`, which would have shown a wrong-scope diff when switching modes); tests
+  cover skip / fallback / always-refresh.
+- The submit head-OID cache returns `None` on miss or empty OID, so a stale/guessed OID is never
+  substituted into a submission; `submit_review`'s existing 422 fallback still applies.
+
+## Implementation
+
+- `crates/er-desktop/src/gh_status_cache.rs` — new pure `status_is_fresh()` / `now_epoch_secs()`
+  helpers + tests.
+- `crates/er-desktop/src/main.rs` — the three background loops gain freshness / OID / throttle
+  gates; `cached_head_oid()` helper; pure `comment_sync_recently_synced()` / `probe_recently_done()`
+  gate predicates with unit tests.
+- `crates/er-desktop/src/commands.rs` — `kick_active_gh_status` 10s gate; `fetch_github_status`
+  4→2 subprocesses; cold-open uses `enter_pr_diff_freshly_loaded()`.
+- `crates/er-engine/src/github.rs` — new `gh_pr_status_remote()` / `PrStatusBundle`;
+  `gh_pr_overview_no_checks()`.
+- `crates/er-engine/src/sync.rs` — comment-sync uses the checks-free overview for local clones.
+- `crates/er-engine/src/app/state/mod.rs` — `enter_pr_diff` split into `enter_pr_diff_impl` +
+  `enter_pr_diff_freshly_loaded`; tests.
+
+Design doc: `internal-docs/gh-rate-limit-slimming.md`. Findings 1–6 land here; finding 7 was reverted
+after review (see above) and the structural `run_gh` chokepoint (finding 8) is a separate follow-up.

--- a/internal-docs/gh-rate-limit-slimming.md
+++ b/internal-docs/gh-rate-limit-slimming.md
@@ -1,0 +1,205 @@
+# Spec: gh CLI rate-limit slimming (desktop background loops)
+
+**Status:** proposed
+**Branch target:** release branch (feature/perf change, not a `main` bugfix) — needs release notes
+**Depends on:** nothing landed; findings 1–4 are independent and can ship incrementally
+**Author:** (drafted from a trigger/frequency audit of all gh call sites, 2026-06-30)
+
+---
+
+## In plain terms
+
+**The problem now.** The desktop app keeps three background timers running the whole time a PR
+tab is open. Every 30 seconds it asks GitHub four separate questions at once (PR status, CI checks,
+comments, reviews); every 30 seconds it asks "did the PR branch move?"; every 45 seconds it pulls
+review comments. None of these timers check whether the answer they already have is still fresh —
+they just re-ask on the clock, forever.
+
+**Why it matters.** With **one** PR tab open that's roughly **760–920 GitHub calls per hour**, and it
+multiplies for every extra open tab. GitHub doesn't just cap you at 5,000/hour — it has a stricter
+"secondary" limit that punishes *bursts* and *concurrent* calls, and our 30s timer fires four calls
+at the same instant. That's exactly what trips the rate limiter. The data to avoid most of these
+calls is already sitting in memory — we compute a `last_updated` timestamp and then never look at it.
+
+**The fix.** Make each timer check freshness before it calls out: "is what I have less than N seconds
+old? then skip." Drop one call that's pure duplication (two timers both fetch CI status). And give all
+gh calls a single front door (`run_gh`) so we can cache, de-duplicate, and back off in one place
+instead of 40.
+
+**TL;DR.** Stop re-asking GitHub the same question every 30 seconds when we already have a fresh
+answer. Four small "skip if recent" gates cut ~900 calls/hour down to under ~50.
+
+---
+
+## Root cause (verified against source)
+
+All rate-limit pressure comes from **three ungated background loops in `crates/er-desktop/src/main.rs`**.
+The TUI poll/watch paths make **zero** gh calls; spawned AI agents are clean (arena has no gh
+permission, review agents use `git diff` with `prepared_diff=true`).
+
+Each loop is a bare `loop { …gh…; sleep(N) }` with no TTL / dirty-flag / freshness gate:
+
+| Loop | Location | Cadence | Per-tick gh calls | ~calls/hr |
+|---|---|---|---|---|
+| gh-status fan-out | `main.rs:1034` | 30s | **4 concurrent** (`gh_pr_overview_remote_full` + `gh_pr_checks_remote` + `gh_pr_comments_overview` + `gh_pr_reviews`) | ~480 |
+| comment sync | `main.rs:1106` | 45s | 2–4 (`gh_pr_comments_remote` + `gh_pr_review_threads_remote`; + `gh_pr_overview` for local-clone tabs) | ~240–320 |
+| pr-head probe | `main.rs:950` | 30s | 1 (`gh pr view --json headRefOid`) | ~120 |
+
+**Steady state ≈ 760–920 gh calls/hr per open PR tab.** The 30s loop's 4-way *concurrent* fan-out is
+the worst for GitHub *secondary* rate limits (concurrency/bursts throttle well below the 5000/hr ceiling).
+
+**Primary-evidence confirmation:**
+- `main.rs:1034` — sleep is at the *end* of the body (line 1092), so the first iteration fires
+  immediately on startup. The only gate is `gh_status_in_flight` (concurrent-overlap dedup), and the
+  key is removed on completion (`main.rs:1087`), so every tick re-registers and re-fires `fetch_github_status`.
+- `GithubStatusSnapshot.last_updated` is **written** (`commands.rs:626,651`) but its only other
+  reference is a test fixture (`gh_status_cache.rs:170`) — it is **never read as a freshness gate**.
+  The data for a TTL gate already exists; it's just unused.
+
+---
+
+## Ranked findings
+
+### 1. background gh-status loop — 4-subprocess fan-out (~480 calls/hr) — BIGGEST WIN
+- **Fires:** `main.rs:1034` loop; each tick → `fetch_github_status` → 4 parallel `gh` subprocesses via
+  `thread::scope` at `commands.rs:559–578`.
+- **Why eager:** `gh_status_in_flight` only blocks concurrent overlap; cleared on completion → every
+  tick re-fires. `last_updated` never read. No TTL.
+- **Feature relied on:** live PR status sidebar (CI checks, review decision, state, recent comments).
+- **Fix:** before `fetch_github_status` (`main.rs:1066`), read `GithubStatusSnapshot.last_updated`;
+  skip if `now − last_updated < 90s`. Move the sleep to the top of the loop to kill the startup burst.
+  **Risk:** CI completing in <90s shows stale state until the next eligible fetch — acceptable (CI runs minutes).
+
+### 2. background comment_sync loop (~240–320 calls/hr)
+- **Fires:** `main.rs:1106` `loop { sleep(45s); … }` (80 ticks/hr). Each tick: `gh_pr_comments_remote`
+  + `gh_pr_review_threads_remote`; plus `gh_pr_overview → gh_pr_checks_data` for local-clone tabs
+  (`sync.rs:265–273`). No leading sleep — first iteration immediate.
+- **Why eager:** `try_lock()` skips a tick only under mutex contention; no in-flight dedup, no TTL,
+  no `last_synced` read-back. The CI-checks call here **duplicates** what the 30s loop already fetches.
+- **Feature relied on:** auto-sync of teammates' PR review comments without pressing `G`.
+- **Fix (two parts):** (a) thread-local `last_synced_oid`; skip if head OID unchanged AND <5 min since
+  last sync — converts always-on → change-driven. (b) remove the `gh_pr_overview` CI call at
+  `sync.rs:265–273` (the 30s loop owns CI freshness) → −~80 calls/hr of pure duplication.
+
+### 3. pr_head_probe loop — `gh pr view --json headRefOid` (~120 calls/hr)
+- **Fires:** `main.rs:950` `loop { sleep(30s); … }`. Bails when `tab.pr_number` is None; otherwise
+  Phase 2 (`main.rs:988`) always spawns the gh subprocess.
+- **Why eager:** `patch_pr_head_oid` (`pr_cache.rs:122–137`) compares OIDs **after** the subprocess
+  returns — it controls only whether the snapshot revision bumps, not whether gh was called.
+- **Feature relied on:** the "PR head updated on origin" stale pill (30s detection of a collaborator push).
+- **Fix:** thread-local `HashMap<(slug, pr_number), (oid, Instant)>`; before Phase 2, if cached OID ==
+  stored OID AND <60s elapsed, skip. Update only when `patch_pr_head_oid` returns true. Cheaper
+  alternative: extend sleep 30s→120s (→30 calls/hr, still 5× faster than the 10-min cache sweep).
+
+### 4. kick_active_gh_status — fires on every tab switch / open / close (~4 calls/switch)
+- **Fires:** unconditionally from `select_tab` (`commands.rs:7086`), `close_tab` (`:7069`),
+  `open_local_branch_impl` (`:4973`), `open_pr_review_impl` (`:5723`), `open_branch_for_project` (`:6273`),
+  `set_active_project` (`:6629`). Each → full 4-subprocess fan-out.
+- **Why eager:** `kick_active_gh_status` (`commands.rs:659–671`) never reads `last_updated`; if the
+  background loop finished 5s ago, the in-flight set is empty and the switch fires a redundant 4-call burst.
+- **Fix:** read `last_updated` first; return early if <10s old. Zero UX risk.
+
+### 5. cold PR open — `gh pr diff` runs twice on cache miss (~1 extra call/cold open)
+- **Fires:** first-ever PR open: `load_pr_open_inputs` (`commands.rs:5297–5595`) fetches once, then the
+  cache-miss branch (`:5710`) calls `enter_pr_diff → refresh_diff → fetch_pr_diff_for_review → gh_pr_diff` again.
+- **Fix:** guard `refresh_diff()` in `enter_pr_diff` (`state/mod.rs:2081`) with `if self.files.is_empty()`
+  — files are already populated from the pre-loaded raw_diff.
+
+### 6. open_remote_pr — `gh_pr_overview_remote` fetched twice (~1 extra call/remote open)
+- `do_open_remote_pr` (`commands.rs:4490–4516`) calls `gh_pr_overview_remote`, then `kick_active_gh_status`
+  fires `gh_pr_overview_remote_full` (same endpoint, richer fields).
+- **Fix:** use `gh_pr_overview_remote_full` once, pre-seed it into the status cache; the Finding-4 TTL
+  gate then suppresses the redundant background fetch.
+
+---
+
+## Cross-call batching opportunities (synthesis over the full inventory)
+
+| Context | Current | Merge into |
+|---|---|---|
+| `new_remote()` open burst | `gh_pr_metadata_remote` (baseRefName, headRefName) + `gh_pr_overview_remote` (9 fields incl. same 2) | Drop `gh_pr_metadata_remote`; read from overview (strict subset) |
+| `fetch_github_status` fan-out | overview_full + reviews + comments_overview (3 separate `gh pr view`) | One `gh pr view --json <union of 14 fields>`; keep `gh_pr_checks_remote` separate (`gh pr checks`) → **4 subprocesses → 2** |
+| `open_pr_review` cold open | `gh_pr_for_current_branch` + `gh_pr_commits` + `gh_pr_overview` | One `gh pr view --json number,baseRefName,commits,title,body,state,author,url,headRefName,reviews` |
+| `refetch_and_refresh_diff` (lazy tab restore) | `gh_pr_base_branch` + `gh_pr_commits` (sequential) | `gh pr view --json baseRefName,commits` (extends `gh_pr_branch_names` pattern) |
+| headRefOid pre-steps (push_comment, submit_review + 3 remote variants) | 1 `gh pr view --json headRefOid` per submit | Read from `pr_cache` (already tracked by probe loop); fetch only on miss |
+
+Precedent already in the codebase: `gh_pr_branch_names` collapses two lookups into one `gh pr view`.
+
+---
+
+## Structural recommendation — `run_gh` chokepoint
+
+~40 raw `Command::new("gh")` sites in `github.rs`, no central wrapper → no place for caching, dedup,
+backoff, or instrumentation without touching all 40. Propose `run_gh(argv, cwd) -> Result<String>` as
+the single path:
+
+- **Short-TTL response cache** keyed by `(argv_canonical, cwd)` — cache read calls 30–90s; bypass
+  writes (`-X POST/PATCH/DELETE`, `gh pr edit`, `gh pr review --approve`); evict by key on any write to
+  the same PR.
+- **In-flight dedup** — second caller of an in-flight argv waits and gets the first result (kills the
+  4-way concurrent fan-out hitting the same endpoint).
+- **Exponential backoff on rate-limit** — detect stderr `API rate limit exceeded` / `secondary rate
+  limit`; back off 60s, doubling, capped 10 min; surface a `RateLimitError` for a UI indicator.
+- **Call counter behind `ER_DEBUG=1`** — one log line per call (argv, hit/miss, elapsed) to `/tmp/er_debug.log`.
+
+Per-loop TTL fixes (1–3) remain complementary — they stop calls reaching `run_gh`; the cache is the
+backstop. Migrate one function at a time, starting with the 4 fan-out callers and the 5 headRefOid pre-steps.
+
+**Scope limit (important): `run_gh` cannot throttle agent-spawned gh.** It wraps `gh` calls made by
+*the Rust process*. Spawned review/arena agents that are permitted `Bash(gh ...)` shell out to `gh` as
+their own subprocesses, entirely outside any Rust wrapper — `run_gh`'s cache / dedup / backoff never
+see them. Today this is moot because every desktop review runs `prepared_diff=true`, whose allowlist has
+no `gh` (so agents are *denied* gh in headless mode — see "Ruled out"). The load-bearing invariant is
+therefore the allowlist, not `run_gh`: if a future feature ever grants an agent `Bash(gh ...)`, it needs
+its *own* call cap (a wrapper script or a hard per-run limit) — the background-loop gates and `run_gh`
+will not cover it.
+
+---
+
+## Ruled out (verified gated / not contributors)
+
+- `run_gh_pr_diff_for_open` — `pr_open_cache` LRU (32) + in-flight dedup. ~0/hr idle.
+- `new_remote` (`gh_pr_metadata_remote`/`diff_remote`/`commits_remote`) — tab-existence dedup; once per
+  unique remote PR per session. The old 300s auto-refresh loop was explicitly removed (`main.rs:845–853`).
+- `prefetch_pr_open` — 150ms frontend debounce + cache hit + in-flight dedup.
+- **Spawned AI agents** — arena agents have **no** gh permission; review agents use `git diff`
+  (`prepared_diff=true`) on all desktop paths. (The `agent_runtime.rs:168` `Bash(gh pr *)` allowlist is
+  not exercised by the desktop review paths.) Verified at the permission layer: desktop review/expert/
+  triage/professor/validate spawns all use `build_*_prepared_diff` prompts whose `--allowedTools` list
+  (`comments.rs`, `prepared_diff` branch) has **no** `Bash(gh …)`; in headless `--print` mode a tool
+  outside the allowlist is *denied*, so a prepared review cannot call gh even if prompted to. Arena
+  access profiles are both `PreparedArtifacts` (no gh). The theoretical ceiling, if a gh-capable profile
+  (`RemoteArtifacts`, or the non-prepared review branch) were ever wired to a desktop review, is
+  *unbounded gh-per-agent* (the allowlist is a gate, not a quota) × the agent-slot cap
+  (`max_concurrent_reviews`, default 3, max 16) — and, per the `run_gh` scope note above, no Rust-side
+  mechanism would throttle it. The invariant that keeps reviews at **0** gh calls is "reviews stay
+  `prepared_diff` / gh stays off the agent allowlist."
+- **TUI event loop / watcher / input handlers** — **zero** gh calls in any poll/tick path; all TUI gh
+  calls are user-key-driven.
+- `ensure_gh_installed` / `gh auth status` — startup once-shot.
+
+---
+
+## Suggested order of work (cheapest-highest-impact first)
+
+1. **TTL gate on the 30s gh-status loop** (`main.rs:1034–1092`, read `last_updated`) — **−~400/hr.**
+2. **TTL gate on `kick_active_gh_status`** (`commands.rs:659–671`, 10s) — <10 lines; depends on #1. **−4/switch.**
+3. **Gate comment-sync loop on head-OID + drop CI duplication** (`main.rs:1106`, `sync.rs:265–273`) — **−~230/hr.**
+4. **Thread-local OID cache in pr_head_probe loop** (`main.rs:950`) — **−~120/hr on idle PRs.**
+5. **Collapse fan-out 4→2** (merge overview+reviews+comments into one `gh pr view --json`) — halves remaining subprocesses.
+6. **Fix cold-PR double diff-fetch** (`state/mod.rs:2081`) — low risk, −1/cold open.
+7. **Cache headRefOid for comment-push pre-steps** — −1/submit.
+8. **Introduce `run_gh` chokepoint** — structural backstop after per-loop fixes validate.
+
+**Fixes 1–4 are the rate-limit fix; 5–8 are reinforcing.**
+
+---
+
+## Audit method
+
+28-agent workflow keyed on **trigger/frequency** (the call site is never the finding — the trigger is).
+Phase 1: inventory all 41 gh wrappers + map 5 trigger-domains (desktop poll, desktop open/tab, TUI loop,
+sync loops, spawned agents) with gating + frequency. Phase 2: each eager candidate verified
+adversarially — the verifier's job was to *disconfirm* by finding an existing gate; **0 of 13 confirmed
+candidates turned out gated.** Phase 3: synthesis over the full table for batching + structural fixes.
+Highest-impact claims re-verified against source by primary read.


### PR DESCRIPTION
## The Problem

Three desktop background loops call the `gh` CLI on fixed timers with no freshness gate. For a single open PR tab sitting idle, that's ~760–920 `gh` calls/hour — enough to trip GitHub's secondary (burst) rate limit, after which every PR feature (status, comment sync, checks) starts failing.

**In plain terms:** the app was phoning GitHub every few seconds even when nothing had changed. GitHub eventually says "too many requests, slow down" and PR features break. This makes it only ask when something actually changed.

## How we fix

Freshness-gate the three loops so they skip the `gh` call when the cached data is still fresh or the PR head hasn't moved, and collapse a 4-subprocess fan-out into 2:

- **gh-status loop (30s):** skips when the cached snapshot is <90s old, and sleeps *before* the first fetch (kills the startup burst).
- **`fetch_github_status` fan-out:** 4 `gh` subprocesses → 2 (overview + comments + reviews merged into one `gh pr view --json`; verified byte-identical to the split calls). `gh pr checks` stays separate.
- **`kick_active_gh_status`** (fires on every tab open/switch/close): skips when status is <10s old.
- **comment-sync loop (45s):** now change-driven — skips when the PR head OID is unchanged and it synced <5min ago; also drops a duplicated `gh pr checks`.
- **pr-head probe (30s):** throttled to 60s, re-arming on every probe.
- **cold PR open:** trusts the just-loaded diff instead of re-fetching it.

Steady state per idle PR tab drops from ~900 to <50 `gh` calls/hour.

## Design choices

- **Fail-open gates.** Every freshness check treats unknown/unparseable timestamps as "stale → fetch", so a bad cache never suppresses a real refresh.
- **Staleness tradeoffs (bounded, documented):** CI status ≤90s, comment sync ≤5min, staleness pill ≤60s, tab-switch <10s. See `docs/release-notes/gh-rate-limit-slimming.md`.
- **Finding 7 (cache submit-time head OID) intentionally left out.** It put a possibly-stale OID onto the review-submit *write* path (the PR cache persists across sessions → can be far behind right after launch), risking dropped/misanchored inline comments, for ~zero steady-state benefit. Submission still fetches the head OID fresh, exactly as before.

## How to manually test

1. Open a PR tab in the desktop app and leave it idle.
2. Run with `ER_DEBUG=1` and watch the `gh` call counter — idle rate should sit well under ~50/hr (was ~900/hr).
3. Confirm PR features still work live: CI status updates within ~90s, comment sync within a few minutes, staleness pill within ~60s, and switching tabs refreshes status.
4. Push a new commit to the PR and confirm the head-OID gate lets the next sync through immediately.

## Verification

- `cargo check --workspace --all-targets` → exit 0
- `cargo test --workspace` → 1039 passed, 0 failed (23 new gate/predicate/parse tests)
- `cargo clippy --workspace --all-targets` → exit 0, no warnings

https://claude.ai/code/session_01Bd5Jk9T4FicdCAdsUmGsQX
