### PR TITLE
docs: fix accuracy and cohesion across the guide, landing page, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,24 +47,24 @@ Base branch is auto-detected from upstream tracking, falling back to main/master
 
 1. Open the **AI Hub** — TUI: press `a`; Desktop: <kbd>Cmd+A</kbd> (macOS) / <kbd>Ctrl+A</kbd> (Windows/Linux)
 2. Run a review — TUI: select **Review work**; Desktop: select **Run review** — findings appear inline once complete
-3. Press `v` / `V` in the TUI to cycle AI view modes; Desktop switches views in the sidebar
+3. Findings appear inline — in the TUI toggle the findings layer with `A` and cycle the side panel with `p`; Desktop switches views in the sidebar
 4. Leave questions (`q`) or comments (`c`). In the TUI, open the Hub and select **Answer questions** to get AI responses. On Desktop, questions are managed in the Notes panel (no Hub action for answering)
 5. Watch mode is on by default — diffs refresh automatically as code changes
 
 ## Features
 
 - **Live watch mode** — Auto-refreshes on file edits, staging, and commits. Reviewed files auto-unmark when their diff changes.
-- **AI-powered review** — Open the **AI Hub** (`a` / <kbd>Cmd+A</kbd>) to run a full review (TUI: **Review work** / Desktop: **Run review**), a fast **Triage branch** scan, one of eight **Specialized review** lenses (Security, Performance, Reliability, Testing, API/Contracts, Patterns, Simplifying, Mentorship), or a **Professor** session for learning insights. Generates per-file risk levels, inline findings, and a review checklist. Four AI view modes: Default, Overlay, Side Panel, AI Review.
-- **Two comment types** — Personal questions (`q`/`Q`, yellow) for your own notes, and GitHub comments (`c`/`C`, cyan) for PR discussions. Reply with `r`, delete with `d`.
-- **GitHub PR sync** — Pull review comments with `G`, push yours back with `P`. Two-way sync via `gh` CLI.
-- **Six diff modes** — Branch diff (`1`), unstaged (`2`), staged (`3`), commit history (`4`), merge conflicts (`5`), hidden/ignored files (`6`). Sort by recency with `Shift+R`.
+- **AI-powered review** — Open the **AI Hub** (`a` / <kbd>Cmd+A</kbd>) to run a full review (TUI: **Review work** / Desktop: **Run review**), a fast **Triage branch** scan, one of eight **Specialized review** lenses (Security, Performance, Reliability, Testing, API/Contracts, Patterns, Simplifying, Mentorship), or a **Professor** session for learning insights. Generates per-file risk levels, inline findings, and a review checklist. Toggle inline layers with `A` (findings), `C` (comments), `Q` (questions); cycle the side panel with `p`.
+- **Three comment types** — Personal questions (`q`, yellow) and notes (cycle the draft type with `Ctrl+t`, 📝) stay local; GitHub comments (`c`, cyan) sync to PR discussions. Reply with `r`, delete a focused comment with `x`.
+- **GitHub PR sync** — Pull review comments with `G`; push yours back from the Git hub (`g` → **Push comments to GitHub**). Two-way sync via `gh` CLI.
+- **Six diff modes** — Branch diff (`1`), unstaged (`2`), staged (`3`), commit history (`4`), merge conflicts, hidden/watched files — plus PR Diff and an AI guided tour. Tabs are numbered dynamically. Sort by recency with `m`.
 - **Large diff performance** — Auto-compacts lock files and generated code. Lazy-parses 5,000+ line diffs. Viewport-based rendering only builds visible lines.
-- **Review tracking** — Mark files reviewed with `Space`, filter to unreviewed with `u`, jump to next unreviewed with `U`.
+- **Review tracking** — Mark files reviewed with `Space`, filter to unreviewed with `!`, jump to next unreviewed with `U`.
 - **Composable filters** — `f` to filter by glob/status/size (`+*.rs,-*.lock,>50`). `F` for presets and history.
 - **Multi-repo tabs** — Open multiple repos or worktrees as tabs. Switch with `]`/`[`.
 - **Syntax highlighting** — TUI: syntect with content-hash caching. Desktop: Shiki in a Web Worker with per-file LRU cache.
-- **Editor integration** — Jump to the current file in `$EDITOR` with `e`. Copy hunk with `y`.
-- **Configurable** — Per-repo or global `.er-config.toml`. In-app settings overlay (`S`) with live preview.
+- **Editor integration** — Jump to the current file in `$EDITOR` with `e`. Copy hub (file / path / hunk / line) with `y`.
+- **Configurable** — Per-repo or global `.er-config.toml`. In-app settings hub (`,`) with live preview.
 
 ## Keybindings
 
@@ -72,23 +72,20 @@ Base branch is auto-detected from upstream tracking, falling back to main/master
 
 | Key | Action |
 |-----|--------|
-| `j` / `k` | Next / prev file |
+| `k` / `j` | Next / prev file |
 | `n` / `N` | Next / prev hunk |
 | `Down` / `Up` | Next / prev line (within hunks) |
 | `h` / `l` | Scroll left / right |
-| `Ctrl-d` / `Ctrl-u` | Half page down / up |
+| `d` / `u` (or `Ctrl-d` / `Ctrl-u`) | Scroll down / up |
+| `J` / `K` | Prev / next inline item (comments, findings) across files |
 
 ### Diff Modes
 
 | Key | Action |
 |-----|--------|
-| `1` | Branch diff (vs base branch) |
-| `2` | Unstaged changes |
-| `3` | Staged changes |
-| `4` | Commit history |
-| `5` | Merge conflicts |
-| `6` | Hidden / ignored files |
-| `Shift+R` | Toggle sort by recency |
+| `1`–`9` | Switch to the Nth visible mode tab (Branch, Unstaged, Staged, History, … — numbered dynamically) |
+| `m` | Toggle sort by recency |
+| `R` | Refresh diff |
 
 ### Actions
 
@@ -96,45 +93,49 @@ Base branch is auto-detected from upstream tracking, falling back to main/master
 |-----|--------|
 | `s` | Stage / unstage file |
 | `Space` | Toggle file as reviewed |
-| `u` | Filter to unreviewed files |
+| `!` | Filter to unreviewed files |
 | `U` | Jump to next unreviewed file |
 | `q` | Question on current line (personal, yellow) |
-| `Q` | Question on current hunk |
-| `c` | Comment on current line (GitHub, cyan) |
-| `C` | Comment on current hunk |
-| `y` | Copy current hunk to clipboard |
-| `e` | Open file in `$EDITOR` |
-| `r` | Refresh diff |
+| `c` | Comment on current line (GitHub, cyan) — commits in Staged mode |
+| `Ctrl+t` | While composing: cycle draft type (question → note → comment) |
+| `Q` / `C` / `A` | Toggle question / comment / AI-finding layer visibility |
+| `X` | Hide / show resolved items |
+| `y` | Copy hub (file, path, hunk, or line) |
+| `e` | Open file in `$EDITOR` (or edit focused own comment) |
 | `w` | Toggle watch mode |
 | `W` | Toggle watched files section |
 | `/` | Search files by name |
 | `f` | Filter files (glob, status, size) |
 | `F` | Filter presets & history |
 | `Enter` | Expand compacted file |
-| `S` | Open settings |
+| `,` | Open settings hub |
 
-### Comments (when focused with `Tab`)
+### Comments (when focused with `J` / `K`)
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Toggle comment focus mode |
-| `Down` / `Up` | Navigate between comments |
-| `r` | Reply to comment |
-| `d` | Delete comment |
-| `R` | Toggle resolved |
+| `J` / `K` | Focus prev / next inline item |
+| `r` | Reply to focused comment or finding |
+| `x` | Delete focused comment |
+| `e` | Edit focused comment (your own, top-level) |
 
 ### GitHub Sync (requires `gh` CLI)
 
 | Key | Action |
 |-----|--------|
 | `G` | Pull PR comments from GitHub |
-| `P` | Push local comments to GitHub |
+| `g` → Push comments to GitHub | Push local comments — as one review (`r`) or individually (`i`) |
+| `Ctrl+P` | Git push (Staged mode) |
 
-### AI Views
+### Hubs
 
 | Key | Action |
 |-----|--------|
-| `v` / `V` | Cycle AI view mode forward / backward |
+| `a` | AI Hub (review, triage, experts, professor, …) |
+| `g` | Git hub (push, stage, comment sync, PR actions) |
+| `v` | Verify hub (tests, lint, typecheck via `[commands]`) |
+| `o` | Open hub (repos, worktrees, recent projects) |
+| `?` | Help hub (all keys) |
 
 ### Tabs & Repos
 
@@ -142,8 +143,7 @@ Base branch is auto-detected from upstream tracking, falling back to main/master
 |-----|--------|
 | `]` / `[` | Next / prev tab |
 | `x` | Close tab |
-| `t` | Worktree picker |
-| `o` | Directory browser |
+| `o` | Open hub (repos, worktrees) |
 
 ### General
 
@@ -160,15 +160,15 @@ Base branch is auto-detected from upstream tracking, falling back to main/master
 2. `~/.config/er/config.toml` (global)
 3. Built-in defaults
 
-Press `S` to open the settings overlay. Changes apply immediately. Press `s` to save, `Esc` to revert.
+Press `,` to open the settings hub. Changes apply immediately and can be persisted to the global config.
 
 ```toml
 [features]
-view_branch = true        # branch diff mode (1)
-view_unstaged = true      # unstaged mode (2)
-view_staged = true        # staged mode (3)
-ai_overlays = true        # AI view cycling (v/V)
-blame_annotations = false # git blame on findings
+view_branch = true        # branch diff mode
+view_unstaged = true      # unstaged mode
+view_staged = true        # staged mode
+view_history = true       # commit history mode
+view_tour = true          # AI guided tour (tab appears when a tour exists)
 
 [display]
 tab_width = 4
@@ -240,7 +240,7 @@ Filenames are the same in managed storage and repo-local `.er/`:
 
 Each JSON sidecar stores a SHA-256 `diff_hash` of the diff it was generated against. When the diff changes, AI data is dimmed with a stale warning.
 
-The AI Hub (TUI: `a` / Desktop: <kbd>Cmd+A</kbd>) writes all review artifacts directly to managed storage — no manual steps needed. If you use external tools that write to `<repo>/.er/` in the working tree, set `ER_REPO_LOCAL=1` so `er` reads from there instead, or import via TUI `I` / Desktop **Import local review files**.
+The AI Hub (TUI: `a` / Desktop: <kbd>Cmd+A</kbd>) writes all review artifacts directly to managed storage — no manual steps needed. If you use external tools that write to `<repo>/.er/` in the working tree, set `ER_REPO_LOCAL=1` so `er` reads from there instead.
 
 ## Development
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -15,24 +15,24 @@ Per-repo only needs to specify fields that differ from your global config. Unspe
 
 ## Live Editing
 
-Press `S` inside `er` to open the settings overlay. Changes apply immediately. Press `s` to persist to `~/.config/er/config.toml`, or `Esc` to revert.
+Press `,` inside `er` to open the settings hub. Changes apply immediately and can be persisted to `~/.config/er/config.toml` from inside the hub.
 
 ## All Options
 
 ### `[features]`
 
-Feature toggles. All default to `true` except `blame_annotations`.
+Feature toggles. All default to `true`.
 
 ```toml
 [features]
-split_diff = true          # Side-by-side diff view
-exit_heatmap = true        # Show review heatmap on exit
-blame_annotations = false  # Show git blame inline (off by default)
-bookmarks = true           # Enable diff bookmarks
-view_branch = true         # Enable branch diff mode (key: 1)
-view_unstaged = true       # Enable unstaged diff mode (key: 2)
-view_staged = true         # Enable staged diff mode (key: 3)
-ai_overlays = true         # Enable AI overlay views (key: v/V)
+view_branch = true         # Enable branch diff mode
+view_unstaged = true       # Enable unstaged diff mode
+view_staged = true         # Enable staged diff mode
+view_history = true        # Enable commit history mode
+view_conflicts = true      # Enable merge conflicts mode (tab appears during a merge)
+view_hidden = true         # Enable hidden/watched files mode (tab appears when [watched] paths exist)
+view_tour = true           # Enable AI guided tour mode (tab appears when a tour.json exists)
+arena = true               # Enable the multi-reviewer arena (desktop)
 ```
 
 ### `[display]`
@@ -41,9 +41,11 @@ Rendering options.
 
 ```toml
 [display]
+theme = "graphite"   # graphite | slate | midnight | ember | paper | daylight | contrast-dark | contrast-light
 tab_width = 4        # Spaces per tab character (1-16)
 line_numbers = true  # Show line numbers in diff view
 wrap_lines = false   # Wrap long lines instead of horizontal scroll
+split_diff = false   # Side-by-side diff view
 ```
 
 ### `[agent]`
@@ -124,7 +126,7 @@ Rules:
 - Model `args` are appended after provider args.
 - If `[ai_hub]` is absent, `er` falls back to the single `[agent]` configuration.
 - On load, `er` merges any missing built-in catalog models (e.g. new Opus releases) into your config in memory without rewriting your TOML file.
-- The selected provider/model applies to AI Hub actions such as review, questions, quiz, wizard, and summary.
+- The selected provider/model applies to AI Hub actions such as review, triage, experts, professor, questions, and summary.
 - `[ai_hub.reviewer_models]` overrides the hub model for specific reviewer kinds. Triage uses `triage = "haiku-4.5"` by default in the example config; when unset, triage falls back to the fastest model in the active provider list.
 
 ### `[watched]`
@@ -147,7 +149,7 @@ Shared preferences across all repos:
 
 ```toml
 [features]
-blame_annotations = true
+view_conflicts = false
 
 [display]
 tab_width = 2
@@ -170,7 +172,7 @@ paths = [".work/**/*", ".er/**/*", "logs/**/*.log"]
 diff_mode = "snapshot"
 ```
 
-Result: `blame_annotations = true` and `wrap_lines = true` from global, `tab_width = 4` and extra watched paths from local.
+Result: `view_conflicts = false` and `wrap_lines = true` from global, `tab_width = 4` and extra watched paths from local.
 
 ## `.er/` AI artifacts
 

--- a/docs/guide/ai-review.html
+++ b/docs/guide/ai-review.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Review — easy-review docs</title>
-  <meta name="description" content="How easy-review's AI review loop works: sidecar artifacts, risk levels, inline findings, expert agents, the professor, view modes, staleness, and the AI Hub.">
+  <meta name="description" content="How easy-review's AI review loop works: sidecar artifacts, risk levels, inline findings, expert agents, the professor, triage, staleness, and the AI Hub.">
   <link rel="stylesheet" href="assets/docs.css">
 </head>
 <body>
@@ -51,11 +51,11 @@
       <thead><tr><th>Step</th><th>Where</th><th>What happens</th></tr></thead>
       <tbody>
         <tr><td>1</td><td>AI Hub</td><td>Open the Hub (<kbd>a</kbd> / <kbd>Cmd</kbd>+<kbd>A</kbd>) and choose <strong>Run review</strong> (TUI: <code>Review work</code>). The agents analyze the diff and write sidecar files.</td></tr>
-        <tr><td>2</td><td><code>er</code></td><td>Detects the new files automatically; press <kbd>v</kbd> to show findings inline.</td></tr>
+        <tr><td>2</td><td><code>er</code></td><td>Detects the new files automatically; findings appear inline (toggle the layer with <kbd>A</kbd> in the TUI).</td></tr>
         <tr><td>3</td><td><code>er</code></td><td>You read findings, leave questions with <kbd>q</kbd>, comments with <kbd>c</kbd>.</td></tr>
-        <tr><td>4</td><td>AI Hub</td><td>TUI: open the Hub and choose <code>Answer questions</code> (enabled once you have added a question). Desktop: questions are managed in the Notes panel — no Hub action needed.</td></tr>
+        <tr><td>4</td><td>AI Hub</td><td>TUI: open the Hub and choose <code>Answer questions</code> (enabled once you have added a question). Desktop: questions are managed in the Notes panel — each has its own AI actions.</td></tr>
         <tr><td>5</td><td><code>er</code></td><td>Auto-refreshes; AI responses appear inline. Continue reviewing.</td></tr>
-        <tr><td>6</td><td><code>er</code></td><td>Publish to GitHub: TUI press <kbd>P</kbd> to push comments to the PR. Desktop: use the Comments card <strong>Push to GitHub</strong> → "Push as review" or push individual comments.</td></tr>
+        <tr><td>6</td><td><code>er</code></td><td>Publish to GitHub: TUI open the Git hub (<kbd>g</kbd>) → <strong>Push comments to GitHub</strong>. Desktop: use the Comments card <strong>Push to GitHub</strong> → "Push as review" or push individual comments.</td></tr>
       </tbody>
     </table>
 
@@ -82,7 +82,7 @@
         </div>
         <div class="body">
           <div class="diff">
-            <div class="dhead"><span>src/auth/token.rs</span><span class="c-muted">v · AI view ON</span></div>
+            <div class="dhead"><span>src/auth/token.rs</span><span class="c-muted">A · AI findings ON</span></div>
             <div class="code">
               <div class="dl del"><span class="ln">14</span><span class="tx c-red">−   fn verify(t: Token) -&gt; bool {</span></div>
               <div class="dl add"><span class="ln">14</span><span class="tx c-green">+   async fn verify(t: Token) -&gt; Result&lt;()&gt; {</span></div>
@@ -127,7 +127,7 @@
           </div>
         </div>
       </div>
-      <figcaption>Findings appear as inline banners on the lines they touch — color-coded by agent (Security/Performance in orange, <strong>Professor</strong> in blue) — beside an AI summary panel with the risk rating, finding counts, and checklist. Press <kbd>v</kbd> to dial how much of this is shown.</figcaption>
+      <figcaption>Findings appear as inline banners on the lines they touch — color-coded by agent (Security/Performance in orange, <strong>Professor</strong> in blue) — beside an AI summary panel with the risk rating, finding counts, and checklist. Toggle the findings layer with <kbd>A</kbd> and cycle the panel with <kbd>p</kbd> to dial how much of this is shown.</figcaption>
     </figure>
 
     <h2>Severity model</h2>
@@ -181,11 +181,14 @@
       review a branch actually warrants.
     </p>
 
-    <h2>AI view modes <span class="pill tui">terminal</span></h2>
+    <h2>Dialing AI context up and down <span class="pill tui">terminal</span></h2>
     <p>
-      In the terminal, press <kbd>v</kbd> (or <kbd>V</kbd> to cycle backward) to move through the AI presentation modes —
-      from a plain diff, to findings overlaid inline, to a side panel with the summary and risk breakdown, to a
-      dedicated AI review layout. Cycling lets you dial the amount of AI context up or down without leaving the diff.
+      In the terminal, inline AI findings are a toggleable <strong>layer</strong>: <kbd>A</kbd> shows or hides them
+      (comments and questions have their own layers on <kbd>C</kbd> and <kbd>Q</kbd>, and <kbd>X</kbd> hides resolved
+      items). The right-hand context panel cycles with <kbd>p</kbd> / <kbd>P</kbd> through file details, the AI
+      summary with the risk breakdown, and the PR overview. Together they let you move from a plain diff to a fully
+      annotated one without leaving the keyboard. In the desktop app the equivalent switches live in the diff
+      toolbar and right panel.
     </p>
 
     <h2>Staleness</h2>
@@ -208,8 +211,11 @@
     <h2>Trying it without an AI tool</h2>
     <p>To explore how the overlays render without running a real review, generate sample artifacts:</p>
     <pre><code>cd your-repo
-bash /path/to/easy-review/scripts/generate-test-fixtures.sh</code></pre>
-    <p>This writes <code>.er/</code> files with a matching diff hash so the AI views light up against your current diff.</p>
+bash /path/to/easy-review/scripts/generate-test-fixtures.sh
+ER_REPO_LOCAL=1 er   <span class="cmt"># read sidecars from the repo's .er/ directory</span></code></pre>
+    <p>The script writes repo-local <code>.er/</code> files with a matching diff hash, so run <code>er</code> with
+    <code>ER_REPO_LOCAL=1</code> (see <a href="storage.html">Review Storage</a>) and the AI views light up against
+    your current diff.</p>
 
     <div class="callout tip">
       <span class="ico">✦</span>

--- a/docs/guide/comments.html
+++ b/docs/guide/comments.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Comments &amp; Questions — easy-review docs</title>
-  <meta name="description" content="Two comment types in easy-review: private questions answered by AI, and GitHub comments that sync to a PR. Replies, deletion, staleness, and comment focus mode.">
+  <meta name="description" content="Three comment types in easy-review: private questions, private notes for agent hand-off, and GitHub comments that sync to a PR. Replies, deletion, staleness, and focusing comments.">
   <link rel="stylesheet" href="assets/docs.css">
 </head>
 <body>
@@ -12,47 +12,57 @@
     <p class="eyebrow">Core Concepts</p>
     <h1>Comments &amp; Questions</h1>
     <p class="lead">
-      <code>er</code> keeps two separate streams of inline notes: <strong>questions</strong> you keep to yourself (and
-      hand to your AI), and <strong>GitHub comments</strong> that sync to a pull request. They look different, use
-      different keys, and never get confused with one another — so a private thought can't accidentally end up on a PR.
+      <code>er</code> keeps three separate streams of inline annotations: <strong>questions</strong> you keep to
+      yourself (and hand to your AI), <strong>notes</strong> — private instructions framed for hand-off to an agent —
+      and <strong>GitHub comments</strong> that sync to a pull request. They look different and never get confused
+      with one another — so a private thought can't accidentally end up on a PR.
     </p>
 
-    <h2>Why two kinds?</h2>
+    <h2>Why three kinds?</h2>
     <table>
-      <thead><tr><th></th><th>Questions <span style="color:var(--yellow)">●</span></th><th>GitHub comments <span style="color:var(--cyan)">●</span></th></tr></thead>
+      <thead><tr><th></th><th>Questions <span style="color:var(--yellow)">●</span></th><th>Notes <span style="color:var(--yellow)">📝</span></th><th>GitHub comments <span style="color:var(--cyan)">●</span></th></tr></thead>
       <tbody>
-        <tr><td>Color</td><td>Yellow</td><td>Cyan</td></tr>
-        <tr><td>Keys</td><td><kbd>q</kbd> line · <kbd>Q</kbd> hunk</td><td><kbd>c</kbd> line · <kbd>C</kbd> hunk</td></tr>
-        <tr><td>Audience</td><td>You and your AI tools</td><td>Your PR reviewers</td></tr>
-        <tr><td>Stored in</td><td><code>questions.json</code></td><td><code>github-comments.json</code></td></tr>
-        <tr><td>Replies?</td><td>No (use AI to answer)</td><td>Yes — single-level threads</td></tr>
-        <tr><td>Synced upstream?</td><td>Never — stays local</td><td>Yes, two-way via <code>gh</code></td></tr>
+        <tr><td>Color</td><td>Yellow</td><td>Yellow, with a 📝 icon</td><td>Cyan</td></tr>
+        <tr><td>Intent</td><td>Something you want answered</td><td>An instruction to hand to an agent</td><td>Feedback for your team on the PR</td></tr>
+        <tr><td>Stored in</td><td><code>questions.json</code></td><td><code>notes.json</code></td><td><code>github-comments.json</code></td></tr>
+        <tr><td>Replies?</td><td>No (use AI to answer)</td><td>No</td><td>Yes — single-level threads</td></tr>
+        <tr><td>Synced upstream?</td><td>Never — stays local</td><td>Never — stays local</td><td>Yes, two-way via <code>gh</code></td></tr>
       </tbody>
     </table>
     <p>
       Questions are your scratchpad: “why is this here?”, “does this handle the empty case?”. In the TUI, the
-      AI Hub <strong>Answer questions</strong> action reads them, answers, and updates the file in place (in the desktop
-      app, questions live in the Notes panel). GitHub comments are the things you actually want your team to see on the PR.
+      AI Hub <strong>Answer questions</strong> action reads them, answers, and updates the file in place. Notes are
+      the same private, local-only mechanism with a different intent — “rename this before merging”, “add a test for
+      the empty case” — phrased so you can hand them straight to a coding agent. GitHub comments are the things you
+      actually want your team to see on the PR.
+    </p>
+    <p>
+      In the desktop app, questions and notes share the <strong>Notes panel</strong> (sub-tabs
+      <em>All | Notes | Questions</em>) with the same actions: resolve, delete, reply, promote to a GitHub comment,
+      and export. Each also has one AI action of its own — a question can be <strong>elaborated</strong> by the AI,
+      a note can be <strong>validated</strong> against the current diff. <strong>Promoting</strong> a question or
+      note to a comment is the deliberate one-way bridge from your private stream into the shared PR space.
     </p>
 
     <h2>Leaving a note</h2>
     <p>
-      Navigate to a line (with the arrow keys) or sit on a hunk, then press the matching key. <strong>Lowercase targets
-      the current line; uppercase targets the whole hunk.</strong>
+      Navigate to a line with the arrow keys (extend a multi-line selection with <kbd>Shift</kbd>+<kbd>↓</kbd>/<kbd>↑</kbd>),
+      then press the matching key to start a draft:
     </p>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>q</kbd></td><td>Add a question on the current line</td></tr>
-        <tr><td><kbd>Q</kbd></td><td>Add a question on the current hunk</td></tr>
-        <tr><td><kbd>c</kbd></td><td>Add a GitHub comment on the current line</td></tr>
-        <tr><td><kbd>C</kbd></td><td>Add a GitHub comment on the current hunk</td></tr>
+        <tr><td><kbd>q</kbd></td><td>Start a question on the current line</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Start a GitHub comment on the current line</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>t</kbd></td><td>While composing: cycle the draft type — question → note → comment</td></tr>
+        <tr><td><kbd>Q</kbd> / <kbd>C</kbd></td><td>Toggle the <em>visibility</em> of the questions/notes layer and the comments layer</td></tr>
       </tbody>
     </table>
     <p>
-      A small input opens at the bottom; type your note and confirm. The note then renders <strong>inline</strong>,
-      right after its target line in the diff — not bundled at the end of the hunk — so the conversation sits exactly
-      where the code is.
+      A small input opens at the bottom; type your note and confirm. There is no dedicated key for notes — start a
+      question or comment draft and press <kbd>Ctrl</kbd>+<kbd>t</kbd> until the draft type reads <em>note</em>. The
+      annotation then renders <strong>inline</strong>, right after its target line in the diff — not bundled at the
+      end of the hunk — so the conversation sits exactly where the code is.
     </p>
 
     <figure class="fig">
@@ -82,30 +92,31 @@
             </div>
           </div>
           <div class="bottom">
-            <span><b>c</b>/<b>C</b> GitHub comment</span><span class="sep">·</span>
-            <span><b>q</b>/<b>Q</b> question</span><span class="sep">·</span>
+            <span><b>c</b> GitHub comment</span><span class="sep">·</span>
+            <span><b>q</b> question</span><span class="sep">·</span>
             <span><b>r</b> reply</span><span class="sep">·</span>
-            <span><b>d</b> delete</span><span class="sep">·</span>
-            <span><b>Tab</b> focus comments</span>
+            <span><b>x</b> delete</span><span class="sep">·</span>
+            <span><b>J/K</b> focus comments</span>
           </div>
         </div>
       </div>
-      <figcaption>Two streams, never confused: <span style="color:var(--cyan)">cyan</span> GitHub comments (with single-level replies) sync to the PR, while <span style="color:var(--yellow)">yellow</span> private questions stay local for your AI. A comment whose target line vanished is dimmed and marked <strong>stale</strong>.</figcaption>
+      <figcaption>Separate streams, never confused: <span style="color:var(--cyan)">cyan</span> GitHub comments (with single-level replies) sync to the PR, while <span style="color:var(--yellow)">yellow</span> private questions and 📝 notes stay local for you and your AI. A comment whose target line vanished is dimmed and marked <strong>stale</strong>.</figcaption>
     </figure>
 
-    <h2>Comment focus mode</h2>
+    <h2>Acting on existing comments</h2>
     <p>
-      To act on existing notes rather than the diff, enter <strong>comment focus mode</strong> with <kbd>Tab</kbd>. Now
-      the arrow keys move between comments instead of lines, and these actions apply to the focused comment:
+      To act on existing annotations rather than the diff, <strong>focus</strong> one with <kbd>J</kbd> /
+      <kbd>K</kbd> — these jump backward / forward through every inline item (comments, questions, notes, findings),
+      across files. These actions then apply to the focused item:
     </p>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>Tab</kbd></td><td>Enter / leave comment focus mode</td></tr>
-        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Move between comments</td></tr>
-        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment (GitHub comments only)</td></tr>
-        <tr><td><kbd>d</kbd></td><td>Delete the focused comment</td></tr>
-        <tr><td><kbd>R</kbd></td><td>Toggle resolved</td></tr>
+        <tr><td><kbd>J</kbd> / <kbd>K</kbd></td><td>Focus the previous / next inline item</td></tr>
+        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment or finding</td></tr>
+        <tr><td><kbd>e</kbd></td><td>Edit the focused comment (your own, top-level)</td></tr>
+        <tr><td><kbd>x</kbd></td><td>Delete the focused comment (with confirmation)</td></tr>
+        <tr><td><kbd>X</kbd></td><td>Hide / show resolved items</td></tr>
       </tbody>
     </table>
 
@@ -113,8 +124,9 @@
     <p>
       GitHub comments support a reply thread: a parent comment plus any number of replies. Replies cannot themselves
       have replies — the model is intentionally flat (parent + children, no recursive nesting) to keep it simple and to
-      match how GitHub PR review threads behave. Questions do not have replies; the way you “answer” a question is to use
-      the AI Hub <strong>Answer questions</strong> action (TUI) and let the AI respond.
+      match how GitHub PR review threads behave. Questions and notes do not have replies; the way you “answer” a
+      question is to use the AI Hub <strong>Answer questions</strong> action (TUI) or the per-question AI actions in
+      the desktop Notes panel, and let the AI respond.
     </p>
 
     <h2>Comments follow the code (and warn when stale)</h2>
@@ -132,7 +144,7 @@
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>G</kbd></td><td>Pull review comments <em>from</em> GitHub into your diff</td></tr>
-        <tr><td><kbd>P</kbd></td><td>Push your local comments <em>to</em> GitHub</td></tr>
+        <tr><td><kbd>g</kbd> → <em>Push comments to GitHub</em></td><td>Push your local comments <em>to</em> GitHub — as one review (<kbd>r</kbd>) or as individual comments (<kbd>i</kbd>)</td></tr>
       </tbody>
     </table>
     <p>
@@ -144,9 +156,10 @@
 
     <div class="callout tip">
       <span class="ico">✦</span>
-      <div><p>Rule of thumb: use <kbd>q</kbd> while you are still figuring out whether something is a problem, and
-      <kbd>c</kbd> once you are ready to say it out loud on the PR. Publishing — <kbd>P</kbd> in the TUI, or the desktop
-      Comments card <strong>Push to GitHub</strong> — includes your GitHub comments when it posts the review.</p></div>
+      <div><p>Rule of thumb: use <kbd>q</kbd> while you are still figuring out whether something is a problem, a
+      <em>note</em> once you know what should change, and <kbd>c</kbd> once you are ready to say it out loud on the PR.
+      Publishing — the Git hub's <strong>Push comments to GitHub</strong> in the TUI, or the desktop Comments card
+      <strong>Push to GitHub</strong> — includes your GitHub comments when it posts the review.</p></div>
     </div>
   </main>
   <script src="assets/docs.js"></script>

--- a/docs/guide/concepts.html
+++ b/docs/guide/concepts.html
@@ -69,12 +69,13 @@
       <a href="reviewing.html">Reviewing &amp; Navigation</a>.
     </p>
 
-    <h2>Two kinds of notes</h2>
+    <h2>Private notes vs. public comments</h2>
     <p>
-      <code>er</code> deliberately separates <strong>private questions</strong> (notes to yourself or to your AI, kept
-      local) from <strong>GitHub comments</strong> (PR discussion that syncs upstream). They use different keys and
-      different colors so you never accidentally publish a private thought. Both anchor to an exact line and follow it
-      as the code shifts. Details in <a href="comments.html">Comments &amp; Questions</a>.
+      <code>er</code> deliberately separates your private stream — <strong>questions</strong> (things you want
+      answered) and <strong>notes</strong> (instructions to hand to an agent), both kept local — from
+      <strong>GitHub comments</strong> (PR discussion that syncs upstream). They use different colors and are stored
+      in different files, so you never accidentally publish a private thought. All of them anchor to an exact line
+      and follow it as the code shifts. Details in <a href="comments.html">Comments &amp; Questions</a>.
     </p>
 
     <h2>The AI loop reads sidecar files</h2>
@@ -86,12 +87,13 @@
     </p>
     <pre><code>  you / AI Hub                             er
   ────────────                             ──
-  AI Hub: Run review      ──writes──&gt;  review.json, checklist.json, …
-                                           reads &amp; renders findings inline
+  AI Hub: run a review    ──writes──&gt;  review.json, checklist.json, …
+  (TUI "Review work" /                     reads &amp; renders findings inline
+   desktop "Run review")
   press q to ask          ──writes──&gt;  questions.json
   AI Hub: Answer questions (TUI only) ──reads───&gt;  responds, updates files
                                            refreshes, shows answers inline
-  publish (TUI P / desktop Push to GitHub) ──reads───&gt;  posts review to your GitHub PR</code></pre>
+  publish (TUI Git hub / desktop Push to GitHub) ──&gt;  posts review to your GitHub PR</code></pre>
     <p>
       Each sidecar records a SHA-256 hash of the diff it was generated against. When the underlying diff changes, that
       AI data is dimmed with a <strong>stale</strong> warning, so you always know whether the analysis still matches the

--- a/docs/guide/configuration.html
+++ b/docs/guide/configuration.html
@@ -34,41 +34,50 @@
 
     <h2>Live editing <span class="pill tui">terminal</span></h2>
     <p>
-      Press <kbd>S</kbd> inside <code>er</code> to open the settings overlay. Changes apply immediately so you can see
-      the effect. Press <kbd>s</kbd> to persist them to your global config, or <kbd>Esc</kbd> to revert. The desktop app
-      has a dedicated settings page covering the same options plus desktop-only ones.
+      Press <kbd>,</kbd> inside <code>er</code> to open the settings hub. Changes apply immediately so you can see
+      the effect, and <kbd>s</kbd> persists them to your global config.
+    </p>
+
+    <h2>Settings GUI <span class="pill desktop">desktop</span></h2>
+    <p>
+      The desktop app has a dedicated settings page (command palette → <em>Open settings</em>) covering the same
+      options organized into scopes — general options shared with the terminal (theme, display, AI Hub providers
+      and models, concurrency), desktop-only options, and embedded-terminal options. Changes apply live and are
+      written back to the same TOML files, so the two apps always agree.
     </p>
 
     <h2><code>[features]</code> — which modes and features are on</h2>
-    <p>Feature toggles. All default to <code>true</code> except <code>blame_annotations</code>.</p>
+    <p>Feature toggles. All default to <code>true</code>.</p>
     <pre><code>[features]
-view_branch    = <span class="tok-key">true</span>   <span class="cmt"># Branch diff (key 1)</span>
-view_unstaged  = <span class="tok-key">true</span>   <span class="cmt"># Unstaged changes (key 2)</span>
-view_staged    = <span class="tok-key">true</span>   <span class="cmt"># Staged changes (key 3)</span>
-view_history   = <span class="tok-key">true</span>   <span class="cmt"># Commit history (key 4)</span>
-view_conflicts = <span class="tok-key">true</span>   <span class="cmt"># Merge conflicts (key 5)</span>
-view_hidden    = <span class="tok-key">true</span>   <span class="cmt"># Hidden / ignored files (key 6)</span>
-ai_overlays    = <span class="tok-key">true</span>   <span class="cmt"># AI view cycling (v / V)</span>
-split_diff        = <span class="tok-key">true</span>    <span class="cmt"># Side-by-side diff view</span>
-exit_heatmap      = <span class="tok-key">true</span>    <span class="cmt"># Review heatmap on exit</span>
-bookmarks         = <span class="tok-key">true</span>    <span class="cmt"># Diff bookmarks</span>
-blame_annotations = <span class="tok-key">false</span>   <span class="cmt"># Inline git blame (off by default)</span></code></pre>
+view_branch    = <span class="tok-key">true</span>   <span class="cmt"># Branch diff</span>
+view_unstaged  = <span class="tok-key">true</span>   <span class="cmt"># Unstaged changes</span>
+view_staged    = <span class="tok-key">true</span>   <span class="cmt"># Staged changes</span>
+view_history   = <span class="tok-key">true</span>   <span class="cmt"># Commit history</span>
+view_conflicts = <span class="tok-key">true</span>   <span class="cmt"># Merge conflicts (tab appears during a merge)</span>
+view_hidden    = <span class="tok-key">true</span>   <span class="cmt"># Hidden / watched files (tab appears when [watched] paths exist)</span>
+view_tour      = <span class="tok-key">true</span>   <span class="cmt"># Guided Tour walkthrough (tab appears when a tour.json exists)</span>
+arena          = <span class="tok-key">true</span>   <span class="cmt"># Multi-reviewer arena (desktop)</span></code></pre>
     <p>Disabling a view mode removes its tab and renumbers the rest — there are no gaps in the number keys.</p>
 
     <h2><code>[display]</code> — rendering</h2>
     <pre><code>[display]
-theme        = <span class="tok-str">"ocean-depth"</span>  <span class="cmt"># ocean-depth | moonlight | daybreak | high-contrast</span>
+theme        = <span class="tok-str">"graphite"</span>  <span class="cmt"># graphite (default) | slate | midnight | ember | paper | daylight | contrast-dark | contrast-light</span>
 line_numbers = <span class="tok-key">true</span>
-wrap_lines   = <span class="tok-key">false</span>         <span class="cmt"># wrap long lines instead of scrolling horizontally</span>
-split_diff   = <span class="tok-key">false</span>
-tab_width    = <span class="tok-key">4</span>             <span class="cmt"># spaces per tab (1–16)</span>
-auto_context_threshold = <span class="tok-key">50</span>  <span class="cmt"># auto-expand full context for files with ≤ N diff lines (0 disables)</span></code></pre>
-    <p>The theme drives both the terminal and desktop UIs. Each maps to a matching syntax-highlighting theme.</p>
+wrap_lines   = <span class="tok-key">false</span>       <span class="cmt"># wrap long lines instead of scrolling horizontally</span>
+split_diff   = <span class="tok-key">false</span>       <span class="cmt"># side-by-side diff view</span>
+tab_width    = <span class="tok-key">4</span>           <span class="cmt"># spaces per tab (1–16)</span>
+auto_context_threshold = <span class="tok-key">100</span>  <span class="cmt"># auto-expand context for small files, tiered by diff size (0 disables)</span></code></pre>
+    <p>
+      The theme drives both the terminal and desktop UIs: four dark themes (<strong>Graphite</strong>, the default,
+      plus Slate, Midnight, Ember), two light (Paper, Daylight), and two AAA high-contrast variants (Contrast Dark,
+      Contrast Light). Each maps to a matching syntax-highlighting theme. Older theme names (ocean-depth, moonlight,
+      daybreak, high-contrast, …) still resolve via aliases.
+    </p>
 
     <h2><code>[hints]</code> — bottom-bar key hints <span class="pill tui">terminal</span></h2>
     <pre><code>[hints]
 navigation = <span class="tok-key">true</span>   <span class="cmt"># j/k, n/N, Space, /</span>
-comments   = <span class="tok-key">true</span>   <span class="cmt"># r, d</span>
+comments   = <span class="tok-key">true</span>   <span class="cmt"># q, c, r, x</span>
 staging    = <span class="tok-key">true</span>   <span class="cmt"># s, commit</span>
 verbose    = <span class="tok-key">false</span>  <span class="cmt"># show all keybindings</span></code></pre>
 
@@ -88,6 +97,8 @@ args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"--outp
     <pre><code>[ai_hub]
 default_provider = <span class="tok-str">"claude"</span>
 default_model    = <span class="tok-str">"sonnet-4.6"</span>
+default_effort   = <span class="tok-str">"medium"</span>  <span class="cmt"># reasoning effort passed to providers that support it</span>
+max_concurrent_reviews = <span class="tok-key">3</span>  <span class="cmt"># queue further reviews beyond this many at once (1–16)</span>
 
 [ai_hub.reviewer_models]
 triage = <span class="tok-str">"haiku-4.5"</span>          <span class="cmt"># pin specific reviewer kinds to specific models</span>
@@ -108,7 +119,7 @@ args  = [<span class="tok-str">"--model"</span>, <span class="tok-str">"claude-s
       <li>On load, <code>er</code> merges any missing built-in catalog models into your config <em>in memory</em> — it does
       not rewrite your file.</li>
       <li>Providers in the example config include Claude, Codex, and Cursor.</li>
-      <li>The selected provider/model applies to AI Hub actions: review, questions, quiz, wizard, and summary.</li>
+      <li>The selected provider/model applies to AI Hub actions: review, triage, experts, professor, questions, and summary.</li>
     </ul>
 
     <h2><code>[summary]</code> — diff summaries</h2>
@@ -142,11 +153,16 @@ diff_mode = <span class="tok-str">"content"</span>                  <span class=
 <span class="cmt"># lint      = "cargo clippy"</span>
 <span class="cmt"># typecheck = "cargo check"</span>
 <span class="cmt"># security  = "cargo audit"</span></code></pre>
+    <p>
+      In a mono-repo, an optional <code>[packages]</code> section defines the same commands per package — each key
+      (e.g. <code>[packages.api]</code>) takes its own <code>label</code>, <code>test</code>, <code>lint</code>,
+      <code>typecheck</code>, and <code>security</code> commands, and the Verify hub groups them by package.
+    </p>
 
     <h2>Worked example</h2>
     <p>Global (<code>~/.config/er/config.toml</code>) holds preferences shared across repos:</p>
     <pre><code>[features]
-blame_annotations = <span class="tok-key">true</span>
+view_conflicts = <span class="tok-key">false</span>
 
 [display]
 tab_width  = <span class="tok-key">2</span>
@@ -162,7 +178,7 @@ tab_width = <span class="tok-key">4</span>
 paths     = [<span class="tok-str">".work/**/*"</span>, <span class="tok-str">".er/**/*"</span>, <span class="tok-str">"logs/**/*.log"</span>]
 diff_mode = <span class="tok-str">"snapshot"</span></code></pre>
     <p>
-      Result: <code>blame_annotations</code> and <code>wrap_lines</code> come from global; <code>tab_width = 4</code> and
+      Result: <code>view_conflicts</code> and <code>wrap_lines</code> come from global; <code>tab_width = 4</code> and
       the extra watched path come from the repo file.
     </p>
   </main>

--- a/docs/guide/desktop.html
+++ b/docs/guide/desktop.html
@@ -144,6 +144,15 @@
     </table>
     <p>Each of these is covered in depth on the next page.</p>
 
+    <h2>Working beside an AI assistant</h2>
+    <p>
+      The desktop app supports the same live loop as the terminal: watch mode keeps the diff current while an
+      assistant edits, stages, and commits. The embedded <strong>terminal drawer</strong> means the assistant can run
+      <em>inside</em> the app — open Claude Code in the drawer, review its changes in the diff above, and drop
+      questions or notes inline as they come up. Run reviews from the AI Hub (<kbd>Cmd</kbd>+<kbd>A</kbd>); findings,
+      triage, and the guided tour land in the Review panel and the Guide tab automatically.
+    </p>
+
     <h2>Running it</h2>
     <pre><code><span class="cmt"># development shell with hot reload</span>
 ./scripts/tauri-dev.sh
@@ -151,7 +160,7 @@
 <span class="cmt"># with extra logging (e.g. the review arena)</span>
 ./scripts/tauri-dev.sh --logs arena
 
-<span class="cmt"># build a release bundle (.app + .dmg on macOS)</span>
+<span class="cmt"># build a release bundle (.app on macOS; a .dmg is produced when ER_SKIP_DMG=0)</span>
 ./scripts/tauri-build.sh</code></pre>
 
     <div class="callout tip">

--- a/docs/guide/diff-modes.html
+++ b/docs/guide/diff-modes.html
@@ -12,9 +12,9 @@
     <p class="eyebrow">Core Concepts</p>
     <h1>Diff Modes</h1>
     <p class="lead">
-      A “mode” is simply <em>which set of changes</em> <code>er</code> is showing you. There are six built-in modes plus
-      a pull-request mode. In the terminal you switch with the number keys; in the desktop app you switch from the
-      branch context bar.
+      A “mode” is simply <em>which set of changes</em> <code>er</code> is showing you. There are six built-in modes
+      plus a pull-request mode and an AI-generated guided tour. In the terminal you switch with the number keys; in
+      the desktop app you switch from the branch context bar.
     </p>
 
     <figure class="fig">
@@ -38,7 +38,7 @@
         </div>
         <div class="bottom">
           <span><b>1</b>–<b>6</b> switch mode</span><span class="sep">·</span>
-          <span><b>Shift+R</b> sort by recency</span><span class="sep">·</span>
+          <span><b>m</b> sort by recency</span><span class="sep">·</span>
           <span class="c-muted">enabled modes are numbered in order — disabling one closes the gap</span>
         </div>
       </div>
@@ -54,7 +54,7 @@
         <tr><td><kbd>3</kbd></td><td>Staged</td><td>Changes in the index, ready to commit (<code>git diff --cached</code>).</td></tr>
         <tr><td><kbd>4</kbd></td><td>History</td><td>Commit-by-commit view of your branch's history.</td></tr>
         <tr><td><kbd>5</kbd></td><td>Conflicts</td><td>Files with unresolved merge conflicts.</td></tr>
-        <tr><td><kbd>6</kbd></td><td>Hidden</td><td>Hidden / git-ignored files that <code>er</code> can still surface.</td></tr>
+        <tr><td><kbd>6</kbd></td><td>Hidden</td><td>Watched git-ignored files that <code>er</code> can still surface (appears when <code>[watched]</code> paths are configured).</td></tr>
       </tbody>
     </table>
     <div class="callout note">
@@ -97,10 +97,11 @@
       rebase.
     </p>
 
-    <h2>Hidden / ignored <span class="pill both">both</span></h2>
+    <h2>Hidden / watched files <span class="pill both">both</span></h2>
     <p>
-      Files git normally hides — ignored paths and the like. This is distinct from the <strong>watched files</strong>
-      feature (configurable globs for git-ignored paths such as agent sync folders), which you toggle with <kbd>W</kbd>.
+      Files git normally hides: the git-ignored paths you listed in the <code>[watched]</code> config (agent sync
+      folders, generated docs, and the like). The tab only appears when watched paths are configured. In other
+      modes you can also toggle a watched-files section into the file tree with <kbd>W</kbd>.
       See <a href="configuration.html#watched">Watched files</a>.
     </p>
 
@@ -116,9 +117,19 @@ er https://github.com/owner/repo/pull/42</code></pre>
       refs without checking out the branch. See <a href="github.html">GitHub &amp; Pull Requests</a>.
     </p>
 
+    <h2>Guided tour <span class="pill both">both</span></h2>
+    <p>
+      When a guided tour exists for the branch (generated in the desktop app — see
+      <a href="skills.html">AI Hub Actions → Generate guided tour</a>), a <strong>Tour</strong> tab appears next to
+      the working-tree modes. It presents the same branch diff reordered and grouped into narrative
+      <em>pillars</em>, so you can walk the change story-first. In the terminal, <kbd>k</kbd>/<kbd>j</kbd> move
+      between pillars, <kbd>n</kbd>/<kbd>N</kbd> between files, <kbd>Space</kbd> marks a file reviewed, and
+      <kbd>b</kbd> marks the whole pillar reviewed. The desktop app presents the tour in its Guide tab.
+    </p>
+
     <h2>Sorting by recency</h2>
     <p>
-      In any mode, press <kbd>Shift</kbd>+<kbd>R</kbd> to toggle sorting files by modification time. When an AI tool just
+      In any mode, press <kbd>m</kbd> to toggle sorting files by modification time. When an AI tool just
       touched a handful of files, this floats them to the top of the list so you review the freshest changes first.
     </p>
 

--- a/docs/guide/github.html
+++ b/docs/guide/github.html
@@ -57,12 +57,12 @@ er https://github.com/owner/repo/pull/42</code></pre>
     </ul>
 
     <h2>Two-way comment sync</h2>
-    <p>GitHub comments (the cyan <kbd>c</kbd>/<kbd>C</kbd> notes) sync in both directions:</p>
+    <p>GitHub comments (the cyan <kbd>c</kbd> notes) sync in both directions. In the terminal:</p>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>G</kbd></td><td><strong>Pull</strong> review comments from the PR into your diff view</td></tr>
-        <tr><td><kbd>P</kbd></td><td><strong>Push</strong> your local comments up to the PR</td></tr>
+        <tr><td><kbd>g</kbd> → <em>Push comments to GitHub</em></td><td><strong>Push</strong> your local comments up to the PR — <kbd>r</kbd> posts them as one review, <kbd>i</kbd> as individual comments</td></tr>
       </tbody>
     </table>
     <p>
@@ -75,8 +75,8 @@ er https://github.com/owner/repo/pull/42</code></pre>
 
     <h2>Publishing an AI review to a PR</h2>
     <p>
-      Publishing happens inside <code>er</code> itself. In the <strong>TUI</strong>, press <kbd>P</kbd> to push your
-      comments to the PR; in the <strong>Desktop app</strong>, open the Comments card and use
+      Publishing happens inside <code>er</code> itself. In the <strong>TUI</strong>, open the Git hub (<kbd>g</kbd>)
+      and choose <strong>Push comments to GitHub</strong>; in the <strong>Desktop app</strong>, open the Comments card and use
       <em>Push to GitHub</em> — either <em>Push as review</em> (all at once) or push individual comments. Both paths
       validate freshness against the current diff before posting, and send your AI findings plus GitHub comments as
       inline review comments — the bridge from a local <code>er</code> session to a review your team sees on GitHub.

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -132,7 +132,7 @@
       <li><strong>Read diffs in six modes</strong> — branch, unstaged, staged, commit history, merge conflicts, and hidden/ignored files.</li>
       <li><strong>Follow changes live</strong> — watch mode refreshes the diff as files are saved, staged, and committed.</li>
       <li><strong>Track your progress</strong> — mark files reviewed, filter to what is left, jump to the next unreviewed file.</li>
-      <li><strong>Leave two kinds of notes</strong> — private questions for yourself or your AI, and GitHub comments that sync to a pull request.</li>
+      <li><strong>Leave three kinds of notes</strong> — private questions for yourself or your AI, private notes for agent hand-off, and GitHub comments that sync to a pull request.</li>
       <li><strong>Layer in AI analysis</strong> — per-file risk levels, inline findings, a review checklist, and specialized expert agents.</li>
       <li><strong>Work with pull requests</strong> — open a PR by number or URL, see CI and reviewer status, and sync comments two ways.</li>
     </ul>
@@ -157,7 +157,7 @@
         <tr><td>Understand the mental model</td><td><a href="concepts.html">How er Works</a></td></tr>
         <tr><td>Learn the diff modes</td><td><a href="diff-modes.html">Diff Modes</a></td></tr>
         <tr><td>Comment and ask questions</td><td><a href="comments.html">Comments &amp; Questions</a></td></tr>
-        <tr><td>Set up the AI review loop</td><td><a href="ai-review.html">AI Review</a> &amp; <a href="skills.html">Skills</a></td></tr>
+        <tr><td>Set up the AI review loop</td><td><a href="ai-review.html">AI Review</a> &amp; <a href="skills.html">AI Hub Actions</a></td></tr>
         <tr><td>Connect a GitHub pull request</td><td><a href="github.html">GitHub &amp; Pull Requests</a></td></tr>
         <tr><td>Customize behavior</td><td><a href="configuration.html">Configuration</a></td></tr>
         <tr><td>Memorize the keyboard</td><td><a href="tui-keybindings.html">Keybinding Reference</a></td></tr>

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -84,8 +84,9 @@ cd easy-review
 
     <h3>Build a release bundle</h3>
     <pre><code>./scripts/tauri-build.sh</code></pre>
-    <p>On macOS this produces an <code>Easy Review.app</code> and a <code>.dmg</code> under the desktop build target.
-    Building requires <code>cargo-tauri</code> and the platform WebView dependencies (WebKit/GTK on Linux).</p>
+    <p>On macOS this produces an <code>Easy Review.app</code> under the desktop build target (set
+    <code>ER_SKIP_DMG=0</code> to also produce a <code>.dmg</code>). Building requires <code>cargo-tauri</code> and
+    the platform WebView dependencies (WebKit/GTK on Linux).</p>
 
     <div class="callout tip">
       <span class="ico">✦</span>

--- a/docs/guide/quick-start.html
+++ b/docs/guide/quick-start.html
@@ -33,10 +33,10 @@
     <table>
       <thead><tr><th>Keys</th><th>Move</th></tr></thead>
       <tbody>
-        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>k</kbd> / <kbd>j</kbd></td><td>Next / previous file</td></tr>
         <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
         <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line within hunks</td></tr>
-        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+        <tr><td><kbd>d</kbd> / <kbd>u</kbd></td><td>Scroll down / up</td></tr>
         <tr><td><kbd>/</kbd></td><td>Search files by name</td></tr>
       </tbody>
     </table>
@@ -53,22 +53,24 @@
     <p>As you finish a file, mark it reviewed:</p>
     <ul>
       <li><kbd>Space</kbd> — toggle the current file as reviewed.</li>
-      <li><kbd>u</kbd> — filter the list down to files you have <em>not</em> reviewed.</li>
+      <li><kbd>!</kbd> — filter the list down to files you have <em>not</em> reviewed.</li>
       <li><kbd>U</kbd> — jump straight to the next unreviewed file.</li>
     </ul>
     <p>If a file's diff changes underneath you (because watch mode picked up an edit), its reviewed mark clears
     automatically so you never miss new changes.</p>
 
     <h2>5. Leave notes</h2>
-    <p><code>er</code> has two kinds of inline notes, on two different keys:</p>
+    <p><code>er</code> has three kinds of inline annotations:</p>
     <table>
-      <thead><tr><th>Key</th><th>Note type</th><th>Goes to</th></tr></thead>
+      <thead><tr><th>Key</th><th>Type</th><th>Goes to</th></tr></thead>
       <tbody>
-        <tr><td><kbd>q</kbd> / <kbd>Q</kbd></td><td>Private <strong>question</strong> (yellow)</td><td>Stays local; read by your AI tools</td></tr>
-        <tr><td><kbd>c</kbd> / <kbd>C</kbd></td><td><strong>GitHub comment</strong> (cyan)</td><td>Syncs to a pull request</td></tr>
+        <tr><td><kbd>q</kbd></td><td>Private <strong>question</strong> (yellow)</td><td>Stays local; read by your AI tools</td></tr>
+        <tr><td><kbd>q</kbd> or <kbd>c</kbd>, then <kbd>Ctrl</kbd>+<kbd>t</kbd></td><td>Private <strong>note</strong> (yellow, 📝)</td><td>Stays local; an instruction to hand to an agent</td></tr>
+        <tr><td><kbd>c</kbd></td><td><strong>GitHub comment</strong> (cyan)</td><td>Syncs to a pull request</td></tr>
       </tbody>
     </table>
-    <p>Lowercase targets the current line; uppercase targets the whole hunk. Read more in
+    <p>Each anchors to the current line (extend the selection with <kbd>Shift</kbd>+<kbd>↓</kbd>/<kbd>↑</kbd>);
+    while composing, <kbd>Ctrl</kbd>+<kbd>t</kbd> cycles the draft type. Read more in
     <a href="comments.html">Comments &amp; Questions</a>.</p>
 
     <h2>6. Add AI analysis (optional)</h2>
@@ -77,16 +79,16 @@
     AI tool for you — Claude Code by default, if the <code>claude</code> CLI is on your <code>PATH</code> — so you do not
     need a second terminal.</p>
     <ol>
-      <li>Press <kbd>a</kbd> and choose <strong>run review</strong>. Per-file risk levels, inline findings, and a
-      checklist appear as the agent writes them; press <kbd>v</kbd> to cycle how much AI context is shown.</li>
+      <li>Press <kbd>a</kbd> and choose <strong>Review work</strong> (called <strong>Run review</strong> in the desktop
+      app). Per-file risk levels, inline findings, and a checklist appear as the agent writes them; toggle the findings
+      layer with <kbd>A</kbd> and cycle the side panel with <kbd>p</kbd>.</li>
       <li>Leave questions with <kbd>q</kbd>, then use the Hub's <strong>Answer questions</strong> action (TUI only — in the
       desktop app, questions are managed in the Notes panel) to have the AI respond inline.</li>
       <li>Re-open the Hub any time to re-run the review or launch a single expert, the professor, or a fast triage.</li>
     </ol>
     <p>The Hub can drive Codex, Cursor, or another tool too — see <a href="ai-review.html#ai-hub">AI Review → the AI
-    Hub</a> for every action and how to configure providers.</p>
-    <p>See <a href="ai-review.html#ai-hub">AI Hub Actions</a> for the full list of Hub actions — review, specialized/expert
-    review, triage, professor — and what each one writes.</p>
+    Hub</a> for how to configure providers, and <a href="skills.html">AI Hub Actions</a> for the full catalog of
+    actions — review, specialized/expert review, triage, professor — and what each one writes.</p>
 
     <h2>7. Watch it stay live</h2>
     <p>

--- a/docs/guide/reviewing.html
+++ b/docs/guide/reviewing.html
@@ -13,8 +13,9 @@
     <h1>Reviewing &amp; Navigation</h1>
     <p class="lead">
       The day-to-day of a review: moving through files and hunks, tracking what you have covered, narrowing the list to
-      what matters, and jumping out to your editor when you need to. Keys below are the terminal defaults; the desktop
-      app offers the same actions through its UI and its own shortcuts.
+      what matters, and jumping out to your editor when you need to. The concepts on this page apply to both apps;
+      the keys shown are the terminal defaults. The desktop app offers the same actions through its UI and its own
+      shortcuts — see <a href="desktop-features.html">Desktop Features</a>.
     </p>
 
     <h2>Navigating the diff</h2>
@@ -22,11 +23,11 @@
     <table>
       <thead><tr><th>Keys</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>k</kbd> / <kbd>j</kbd></td><td>Next / previous file</td></tr>
         <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
         <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line within hunks</td></tr>
         <tr><td><kbd>h</kbd> / <kbd>l</kbd></td><td>Scroll the diff left / right</td></tr>
-        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+        <tr><td><kbd>d</kbd> / <kbd>u</kbd></td><td>Scroll down / up (also <kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd>)</td></tr>
       </tbody>
     </table>
     <p>
@@ -41,7 +42,7 @@
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>Space</kbd></td><td>Toggle the current file as reviewed</td></tr>
-        <tr><td><kbd>u</kbd></td><td>Filter the list to unreviewed files only</td></tr>
+        <tr><td><kbd>!</kbd></td><td>Filter the list to unreviewed files only</td></tr>
         <tr><td><kbd>U</kbd></td><td>Jump to the next unreviewed file</td></tr>
       </tbody>
     </table>
@@ -88,11 +89,11 @@
 
     <h2>Sorting</h2>
     <ul>
-      <li><strong>By recency</strong> — <kbd>Shift</kbd>+<kbd>R</kbd> toggles modification-time sorting in any mode, so
+      <li><strong>By recency</strong> — <kbd>m</kbd> toggles modification-time sorting in any mode, so
       the files your AI just touched rise to the top.</li>
       <li><strong>By risk</strong> — when an AI review has run, files carry risk indicators (high / medium / low) in the
-      list. Running a review from the AI Hub also produces <code>order.json</code>, which reorders files highest-risk
-      first. See <a href="ai-review.html">AI Review</a>.</li>
+      list. Running a review from the AI Hub also produces <code>order.json</code>, a suggested review order with
+      groupings. See <a href="ai-review.html">AI Review</a>.</li>
     </ul>
 
     <h2>Editor &amp; clipboard integration</h2>
@@ -100,8 +101,8 @@
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>e</kbd></td><td>Open the current file in <code>$EDITOR</code></td></tr>
-        <tr><td><kbd>y</kbd></td><td>Copy the current hunk to the clipboard</td></tr>
-        <tr><td><kbd>r</kbd></td><td>Manually refresh the diff</td></tr>
+        <tr><td><kbd>y</kbd></td><td>Open the copy hub — copy the file, its path, the current hunk, or the current line</td></tr>
+        <tr><td><kbd>R</kbd></td><td>Manually refresh the diff</td></tr>
       </tbody>
     </table>
     <p>
@@ -119,8 +120,7 @@
       <tbody>
         <tr><td><kbd>]</kbd> / <kbd>[</kbd></td><td>Next / previous tab</td></tr>
         <tr><td><kbd>x</kbd></td><td>Close the current tab</td></tr>
-        <tr><td><kbd>t</kbd></td><td>Worktree picker</td></tr>
-        <tr><td><kbd>o</kbd></td><td>Directory browser (open another repo)</td></tr>
+        <tr><td><kbd>o</kbd></td><td>Open hub — switch repository, worktree, or recent project</td></tr>
       </tbody>
     </table>
     <p>
@@ -129,10 +129,10 @@
       <a href="desktop-features.html">Desktop Features</a>.
     </p>
 
-    <h2>Settings overlay</h2>
+    <h2>Settings hub</h2>
     <p>
-      Press <kbd>S</kbd> to open the settings overlay and adjust display and feature options live. Changes apply
-      immediately; <kbd>s</kbd> persists them, <kbd>Esc</kbd> reverts. The full list of options is in
+      Press <kbd>,</kbd> to open the settings hub and adjust display and feature options live. Changes apply
+      immediately and can be persisted to the global config from inside the hub. The full list of options is in
       <a href="configuration.html">Configuration</a>.
     </p>
   </main>

--- a/docs/guide/skills.html
+++ b/docs/guide/skills.html
@@ -30,8 +30,8 @@
         <tr>
           <td>2</td>
           <td><code>er</code></td>
-          <td><kbd>v</kbd></td>
-          <td>Cycle review panel; browse findings and inline comments</td>
+          <td><kbd>A</kbd> / <kbd>J</kbd> / <kbd>K</kbd></td>
+          <td>Findings appear inline (toggle the layer with <kbd>A</kbd>); jump between them with <kbd>J</kbd>/<kbd>K</kbd></td>
         </tr>
         <tr>
           <td>3</td>
@@ -58,7 +58,7 @@
           <td>6</td>
           <td>Not a Hub action</td>
           <td>
-            TUI: <kbd>P</kbd> key<br>
+            TUI: Git hub (<kbd>g</kbd>) → <strong>Push comments to GitHub</strong><br>
             Desktop: Comments card → <strong>Push to GitHub</strong>
           </td>
           <td>Validates freshness, posts findings to the GitHub PR as inline comments</td>
@@ -220,20 +220,20 @@
       operation in both apps:
     </p>
     <ul>
-      <li><strong>TUI:</strong> Press <kbd>P</kbd> to push local comments to the PR; press <kbd>G</kbd> to pull comments from GitHub.</li>
+      <li><strong>TUI:</strong> Open the Git hub (<kbd>g</kbd>) → <strong>Push comments to GitHub</strong> to push local comments to the PR — as one review or as individual comments; press <kbd>G</kbd> to pull comments from GitHub.</li>
       <li><strong>Desktop:</strong> Open the <strong>Comments card</strong> → <strong>Push to GitHub</strong>, then choose <strong>Push as review</strong> or push individual comments. Comments are pulled automatically when you open a PR tab.</li>
     </ul>
 
-    <h2>Comprehension quiz</h2>
+    <h2>Per-item AI actions <span class="pill desktop">desktop</span></h2>
     <p>
-      Quizzes have <strong>no in-app generation</strong>. Quiz content comes from the external
-      <strong>TechProfessor</strong> integration or from imported sidecar files. The TUI Quiz mode
-      (press <kbd>8</kbd>) only <em>renders</em> an existing <code>quiz.json</code> — it cannot create one.
+      Beyond the Hub-level actions above, the desktop app attaches small AI actions to individual items:
     </p>
-    <p>
-      To import quiz sidecars written by an external tool: press <kbd>I</kbd> in the TUI or use
-      <strong>Import local review files</strong> in the desktop app.
-    </p>
+    <ul>
+      <li><strong>Elaborate</strong> — on a question or finding: ask the AI to expand on it and answer any question directly.</li>
+      <li><strong>Validate with AI</strong> — on a note or finding: check whether it still holds against the current diff.</li>
+      <li><strong>Promote to comment</strong> — turn a private question, note, or AI finding into a GitHub comment; the original keeps a "Promoted to" link. This is the deliberate one-way bridge from your private stream into the shared PR space.</li>
+    </ul>
+    <p>See <a href="comments.html">Comments &amp; Questions</a> for how questions, notes, and comments differ.</p>
 
     <h2>Review philosophy</h2>
     <p>
@@ -259,7 +259,8 @@
     <h2>Testing without running a review</h2>
     <p>To see the overlays without invoking an AI tool, generate fixtures with a matching diff hash:</p>
     <pre><code>cd your-repo
-bash /path/to/easy-review/scripts/generate-test-fixtures.sh</code></pre>
+bash /path/to/easy-review/scripts/generate-test-fixtures.sh
+ER_REPO_LOCAL=1 er   <span class="cmt"># read sidecars from the repo's .er/ directory</span></code></pre>
   </main>
   <script src="assets/docs.js"></script>
 </body>

--- a/docs/guide/storage.html
+++ b/docs/guide/storage.html
@@ -57,15 +57,17 @@
     <table>
       <thead><tr><th>File</th><th>Written by</th><th>Purpose</th></tr></thead>
       <tbody>
-        <tr><td><code>review.json</code></td><td>AI Hub: Run review</td><td>Per-file risk levels and inline findings</td></tr>
-        <tr><td><code>order.json</code></td><td>AI Hub: Run review</td><td>Suggested review order</td></tr>
-        <tr><td><code>checklist.json</code></td><td>AI Hub: Run review</td><td>Review checklist items</td></tr>
-        <tr><td><code>summary.md</code></td><td>AI Hub: Run review</td><td>Markdown summary of changes</td></tr>
+        <tr><td><code>review.json</code></td><td>AI Hub: review (TUI “Review work” / desktop “Run review”)</td><td>Per-file risk levels and inline findings</td></tr>
+        <tr><td><code>order.json</code></td><td>AI Hub: review</td><td>Suggested review order</td></tr>
+        <tr><td><code>checklist.json</code></td><td>AI Hub: review</td><td>Review checklist items</td></tr>
+        <tr><td><code>summary.md</code></td><td>AI Hub: review</td><td>Markdown summary of changes</td></tr>
         <tr><td><code>triage.json</code></td><td>AI Hub: Triage branch</td><td>Fast branch scan / routing</td></tr>
         <tr><td><code>professor.json</code></td><td>AI Hub: Professor</td><td>Teaching / learning insights</td></tr>
         <tr><td><code>experts/*.json</code></td><td>AI Hub: Specialized review</td><td>Domain-specific expert findings</td></tr>
-        <tr><td><code>questions.json</code></td><td><code>er</code> (<kbd>q</kbd>/<kbd>Q</kbd>)</td><td>Personal review questions</td></tr>
-        <tr><td><code>github-comments.json</code></td><td><code>er</code> (<kbd>c</kbd>/<kbd>C</kbd>)</td><td>GitHub PR comments</td></tr>
+        <tr><td><code>tour.json</code></td><td>AI Hub: Generate tour (desktop)</td><td>Guided-tour pillars and file order</td></tr>
+        <tr><td><code>questions.json</code></td><td><code>er</code> (<kbd>q</kbd>)</td><td>Personal review questions</td></tr>
+        <tr><td><code>notes.json</code></td><td><code>er</code> (draft type cycled with <kbd>Ctrl</kbd>+<kbd>t</kbd>)</td><td>Local actionable notes for agent hand-off</td></tr>
+        <tr><td><code>github-comments.json</code></td><td><code>er</code> (<kbd>c</kbd>)</td><td>GitHub PR comments</td></tr>
         <tr><td><code>session.json</code></td><td><code>er</code></td><td>Session metadata</td></tr>
         <tr><td><code>reviewed</code></td><td><code>er</code></td><td>Per-file reviewed markers</td></tr>
       </tbody>
@@ -79,7 +81,7 @@
     <h2>Repo-local mode</h2>
     <p>
       Set <code>ER_REPO_LOCAL=1</code> to read and write a <code>.er/</code> directory inside the repository instead of
-      managed storage. This is useful for debugging, or for external tools (such as the TechProfessor integration) that
+      managed storage. This is useful for debugging, or for external tools that
       write sidecar files into <code>.er/</code> relative to the repo.
     </p>
     <pre><code>ER_REPO_LOCAL=1 er</code></pre>

--- a/docs/guide/troubleshooting.html
+++ b/docs/guide/troubleshooting.html
@@ -28,29 +28,29 @@
     <h3>AI findings do not appear</h3>
     <ul>
       <li><strong>Check where the artifacts went.</strong> By default <code>er</code> reads from managed storage, not the
-      repo's <code>.er/</code>. External tools (such as TechProfessor) may write to <code>.er/</code> in the repo
+      repo's <code>.er/</code>. External tools may write to <code>.er/</code> in the repo
       instead. To bridge the gap: run reviews via the AI Hub (<kbd>a</kbd> in the TUI, <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd>
-      in the desktop), or launch <code>er</code> with <code>ER_REPO_LOCAL=1</code> to read the repo directory directly,
-      or import the sidecar files with <kbd>I</kbd> in the TUI (<strong>Import local review files</strong> in the desktop).
+      in the desktop), or launch <code>er</code> with <code>ER_REPO_LOCAL=1</code> to read the repo directory directly.
       See <a href="storage.html">Review Storage</a>.</li>
       <li><strong>Check freshness.</strong> If the diff changed after the review ran, the data is dimmed as
       <em>stale</em>. Re-run the relevant action from the AI Hub.</li>
-      <li><strong>Cycle the view.</strong> In the terminal, press <kbd>v</kbd> to make sure you are in an AI view mode.</li>
+      <li><strong>Check the layer.</strong> In the terminal, press <kbd>A</kbd> to make sure the AI-findings layer is
+      visible.</li>
       <li><strong>Try fixtures.</strong> Run <code>scripts/generate-test-fixtures.sh</code> in your repo to confirm the
       overlay renders at all.</li>
     </ul>
 
     <h3>GitHub features are missing or failing</h3>
     <p>
-      GitHub integration requires the <code>gh</code> CLI, authenticated with <code>gh auth login</code>. If <kbd>G</kbd>
-      / <kbd>P</kbd> do nothing or PR data is absent, run <code>gh auth status</code> to confirm you are logged in and
+      GitHub integration requires the <code>gh</code> CLI, authenticated with <code>gh auth login</code>. If pulling
+      comments (<kbd>G</kbd>) or the Git hub's sync actions do nothing, or PR data is absent, run <code>gh auth status</code> to confirm you are logged in and
       that <code>gh</code> is on your <code>PATH</code>.
     </p>
 
     <h3>The diff is not updating</h3>
     <p>
       Watch mode should refresh on saves, staging, and commits. Confirm the <span style="color:var(--green)">● WATCH</span>
-      indicator is on (toggle with <kbd>w</kbd>), and press <kbd>r</kbd> to force a manual refresh. Watch uses a ~500ms
+      indicator is on (toggle with <kbd>w</kbd>), and press <kbd>R</kbd> to force a manual refresh. Watch uses a ~500ms
       debounce, so a burst of changes lands as one update.
     </p>
 
@@ -121,8 +121,9 @@
 
     <h3>Is the desktop app released?</h3>
     <p>
-      Not yet — published releases are the <code>er</code> terminal binary only. Build the desktop app from source with
-      <code>./scripts/tauri-dev.sh</code> or <code>./scripts/tauri-build.sh</code>.
+      Yes, for Apple Silicon Macs — releases include a prebuilt <code>.dmg</code> alongside the <code>er</code>
+      terminal binaries. Other platforms build from source with <code>./scripts/tauri-dev.sh</code> or
+      <code>./scripts/tauri-build.sh</code>. See <a href="installation.html#desktop-app">Installation → Desktop app</a>.
     </p>
 
     <h3>How do I report a bug or request a feature?</h3>

--- a/docs/guide/tui-keybindings.html
+++ b/docs/guide/tui-keybindings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Keybinding Reference — easy-review docs</title>
-  <meta name="description" content="The complete keyboard reference for the er terminal UI: navigation, diff modes, actions, comments, GitHub sync, AI views, tabs, and general keys.">
+  <meta name="description" content="The complete keyboard reference for the er terminal UI: navigation, diff modes, review tracking, comments, hubs, GitHub sync, panels, tabs, and general keys.">
   <link rel="stylesheet" href="assets/docs.css">
 </head>
 <body>
@@ -13,72 +13,100 @@
     <h1>Keybinding Reference</h1>
     <p class="lead">
       The complete key map for the <code>er</code> terminal UI, grouped by task. Bottom-bar hints show a subset; this is
-      the full list. Hint groups are configurable — see <a href="configuration.html">Configuration</a>.
+      the full list. Hint groups are configurable — see <a href="configuration.html">Configuration</a>. Press
+      <kbd>?</kbd> inside <code>er</code> for the built-in help hub, which always reflects the running version.
     </p>
 
     <h2>Navigation</h2>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>j</kbd> / <kbd>k</kbd></td><td>Next / previous file</td></tr>
+        <tr><td><kbd>k</kbd> / <kbd>j</kbd></td><td>Next / previous file</td></tr>
         <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous hunk</td></tr>
         <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Next / previous line (within hunks)</td></tr>
-        <tr><td><kbd>h</kbd> / <kbd>l</kbd></td><td>Scroll left / right</td></tr>
-        <tr><td><kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd></td><td>Half page down / up</td></tr>
+        <tr><td><kbd>Shift</kbd>+<kbd>↓</kbd> / <kbd>Shift</kbd>+<kbd>↑</kbd></td><td>Extend the line selection (for multi-line comments)</td></tr>
+        <tr><td><kbd>h</kbd> / <kbd>l</kbd> or <kbd>←</kbd> / <kbd>→</kbd></td><td>Scroll left / right (long lines)</td></tr>
+        <tr><td><kbd>d</kbd> / <kbd>u</kbd> (also <kbd>Ctrl</kbd>+<kbd>d</kbd> / <kbd>Ctrl</kbd>+<kbd>u</kbd>)</td><td>Scroll down / up 10 lines</td></tr>
+        <tr><td><kbd>PageDown</kbd> / <kbd>PageUp</kbd></td><td>Scroll down / up 20 lines</td></tr>
+        <tr><td><kbd>Home</kbd></td><td>Reset horizontal scroll</td></tr>
+        <tr><td><kbd>J</kbd> / <kbd>K</kbd></td><td>Previous / next inline item (comments, questions, findings) across files</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>j</kbd> / <kbd>Ctrl</kbd>+<kbd>k</kbd></td><td>Previous / next AI finding across files</td></tr>
       </tbody>
     </table>
 
     <h2>Diff modes</h2>
+    <p>
+      Number keys <kbd>1</kbd>–<kbd>9</kbd> switch between the visible mode tabs. Numbering is
+      <strong>dynamic</strong>: tabs are numbered in the order they appear, and modes that do not apply are hidden
+      without leaving gaps. On a typical local branch that means <kbd>1</kbd> Branch, <kbd>2</kbd> Unstaged,
+      <kbd>3</kbd> Staged, <kbd>4</kbd> History — with extra tabs appearing when available: PR Diff (when the branch
+      has a known PR), Guided Tour (when a <code>tour.json</code> exists), Conflicts (during a merge), and
+      Hidden / watched files (when <code>[watched]</code> paths are configured). See
+      <a href="diff-modes.html">Diff Modes</a>.
+    </p>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>1</kbd></td><td>Branch diff (vs base branch)</td></tr>
-        <tr><td><kbd>2</kbd></td><td>Unstaged changes</td></tr>
-        <tr><td><kbd>3</kbd></td><td>Staged changes</td></tr>
-        <tr><td><kbd>4</kbd></td><td>Commit history</td></tr>
-        <tr><td><kbd>5</kbd></td><td>Merge conflicts</td></tr>
-        <tr><td><kbd>6</kbd></td><td>Hidden / ignored files</td></tr>
-        <tr><td><kbd>8</kbd></td><td>Quiz mode (when a quiz exists)</td></tr>
-        <tr><td><kbd>Shift</kbd>+<kbd>R</kbd></td><td>Toggle sort by recency</td></tr>
+        <tr><td><kbd>1</kbd>–<kbd>9</kbd></td><td>Switch to the Nth visible mode tab</td></tr>
+        <tr><td><kbd>m</kbd></td><td>Toggle sort by recency (modification time)</td></tr>
+        <tr><td><kbd>R</kbd></td><td>Refresh the diff</td></tr>
+        <tr><td><kbd>w</kbd></td><td>Toggle watch mode</td></tr>
+        <tr><td><kbd>W</kbd></td><td>Toggle the watched-files section</td></tr>
       </tbody>
     </table>
 
-    <h2>Actions</h2>
+    <h2>Review tracking</h2>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>s</kbd></td><td>Stage / unstage the current file</td></tr>
         <tr><td><kbd>Space</kbd></td><td>Toggle the current file as reviewed</td></tr>
-        <tr><td><kbd>u</kbd></td><td>Filter to unreviewed files</td></tr>
+        <tr><td><kbd>!</kbd></td><td>Filter the file list to unreviewed files</td></tr>
         <tr><td><kbd>U</kbd></td><td>Jump to the next unreviewed file</td></tr>
-        <tr><td><kbd>q</kbd></td><td>Question on the current line (private, yellow)</td></tr>
-        <tr><td><kbd>Q</kbd></td><td>Question on the current hunk</td></tr>
-        <tr><td><kbd>c</kbd></td><td>Comment on the current line (GitHub, cyan)</td></tr>
-        <tr><td><kbd>C</kbd></td><td>Comment on the current hunk</td></tr>
-        <tr><td><kbd>y</kbd></td><td>Copy the current hunk to the clipboard</td></tr>
-        <tr><td><kbd>e</kbd></td><td>Open the current file in <code>$EDITOR</code></td></tr>
-        <tr><td><kbd>r</kbd></td><td>Refresh the diff</td></tr>
-        <tr><td><kbd>w</kbd></td><td>Toggle watch mode</td></tr>
-        <tr><td><kbd>W</kbd></td><td>Toggle the watched-files section</td></tr>
         <tr><td><kbd>/</kbd></td><td>Search files by name</td></tr>
         <tr><td><kbd>f</kbd></td><td>Filter files (glob, status, size)</td></tr>
         <tr><td><kbd>F</kbd></td><td>Filter presets &amp; history</td></tr>
-        <tr><td><kbd>Enter</kbd></td><td>Expand a compacted file</td></tr>
-        <tr><td><kbd>z</kbd></td><td>Clean AI artifacts for the current file</td></tr>
-        <tr><td><kbd>Z</kbd></td><td>Clean all AI artifacts</td></tr>
-        <tr><td><kbd>S</kbd></td><td>Open settings</td></tr>
       </tbody>
     </table>
 
-    <h2>Comments (in comment focus mode)</h2>
+    <h2>Comments, questions &amp; notes</h2>
+    <p>
+      Lowercase keys start a draft anchored to the current line (or selection). While composing, <kbd>Ctrl</kbd>+<kbd>t</kbd>
+      cycles the draft type — question → note → GitHub comment — and <kbd>Tab</kbd> pauses the draft (press
+      <kbd>Tab</kbd> again in normal mode to resume it). Uppercase keys toggle layer <em>visibility</em>, not
+      creation. See <a href="comments.html">Comments &amp; Questions</a>.
+    </p>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>Tab</kbd></td><td>Toggle comment focus mode</td></tr>
-        <tr><td><kbd>↓</kbd> / <kbd>↑</kbd></td><td>Navigate between comments</td></tr>
-        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment</td></tr>
-        <tr><td><kbd>d</kbd></td><td>Delete the focused comment</td></tr>
-        <tr><td><kbd>R</kbd></td><td>Toggle resolved</td></tr>
+        <tr><td><kbd>q</kbd></td><td>Start a private question on the current line (yellow)</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Start a GitHub comment on the current line (cyan) — in Staged mode, <kbd>c</kbd> commits instead</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>t</kbd></td><td>While composing: cycle draft type (question → note → comment)</td></tr>
+        <tr><td><kbd>Q</kbd></td><td>Toggle visibility of the questions/notes layer</td></tr>
+        <tr><td><kbd>C</kbd></td><td>Toggle visibility of the GitHub-comments layer</td></tr>
+        <tr><td><kbd>A</kbd></td><td>Toggle visibility of the AI-findings layer</td></tr>
+        <tr><td><kbd>X</kbd></td><td>Hide / show resolved items</td></tr>
+        <tr><td><kbd>J</kbd> / <kbd>K</kbd></td><td>Focus the previous / next inline item</td></tr>
+        <tr><td><kbd>r</kbd></td><td>Reply to the focused comment, question, or finding</td></tr>
+        <tr><td><kbd>e</kbd></td><td>Edit the focused comment (your own, top-level) — otherwise opens the file in <code>$EDITOR</code></td></tr>
+        <tr><td><kbd>x</kbd></td><td>Delete the focused comment (with confirmation)</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Hubs</h2>
+    <p>
+      Most one-off actions live in small modal hubs rather than on dedicated keys. Each hub lists its own options
+      with single-key shortcuts.
+    </p>
+    <table>
+      <thead><tr><th>Key</th><th>Hub</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>a</kbd></td><td>AI Hub — Review work, Triage branch, Specialized review, Professor, Answer questions, summaries, cleanup (see <a href="skills.html">AI Hub Actions</a>)</td></tr>
+        <tr><td><kbd>g</kbd></td><td>Git hub — push to remote, stage files, refresh, pull / push GitHub comments, comment on or approve the PR</td></tr>
+        <tr><td><kbd>v</kbd></td><td>Verify hub — run tests, linter, type check, and other configured <code>[commands]</code></td></tr>
+        <tr><td><kbd>y</kbd></td><td>Copy hub — copy the file, path, hunk, or line to the clipboard</td></tr>
+        <tr><td><kbd>o</kbd></td><td>Open hub — switch repository, worktree, or recent project</td></tr>
+        <tr><td><kbd>,</kbd></td><td>Settings hub — live-edit configuration (see <a href="configuration.html">Configuration</a>)</td></tr>
+        <tr><td><kbd>?</kbd></td><td>Help hub — searchable list of every key and action</td></tr>
       </tbody>
     </table>
 
@@ -87,16 +115,44 @@
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>G</kbd></td><td>Pull PR comments from GitHub</td></tr>
-        <tr><td><kbd>P</kbd></td><td>Push local comments to GitHub</td></tr>
-        <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Git push (from staged mode)</td></tr>
+        <tr><td><kbd>g</kbd> → <em>Push comments to GitHub</em></td><td>Push local comments — then <kbd>r</kbd> publishes them as one review, <kbd>i</kbd> as individual comments, <kbd>n</kbd> cancels</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Git push the branch to the remote (Staged mode)</td></tr>
       </tbody>
     </table>
 
-    <h2>AI views</h2>
+    <h2>Staging &amp; committing</h2>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>v</kbd> / <kbd>V</kbd></td><td>Cycle AI view mode forward / backward</td></tr>
+        <tr><td><kbd>s</kbd></td><td>Stage / unstage the current file (on a watched file: update its snapshot)</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Commit (Staged mode only — elsewhere <kbd>c</kbd> starts a GitHub comment)</td></tr>
+        <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Push to the remote (Staged mode)</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Panels &amp; layout</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>p</kbd> / <kbd>P</kbd></td><td>Cycle the context panel forward / backward (file detail, AI summary, PR overview, off)</td></tr>
+        <tr><td><kbd>Tab</kbd></td><td>Toggle focus into the panel (or switch sides in split diff); with a paused draft, resumes it</td></tr>
+        <tr><td><kbd>Esc</kbd></td><td>Leave panel focus</td></tr>
+        <tr><td><kbd>&lt;</kbd> / <kbd>&gt;</kbd></td><td>Shrink / grow the file tree</td></tr>
+        <tr><td><kbd>{</kbd> / <kbd>}</kbd></td><td>Shrink / grow the side panel</td></tr>
+        <tr><td><kbd>+</kbd> / <kbd>=</kbd></td><td>Expand context lines for the current file</td></tr>
+        <tr><td><kbd>-</kbd></td><td>Collapse context lines</td></tr>
+        <tr><td><kbd>Enter</kbd></td><td>Expand a compacted file (or jump to the focused finding when the panel is focused)</td></tr>
+      </tbody>
+    </table>
+
+    <h2>History &amp; Tour modes</h2>
+    <table>
+      <thead><tr><th>Key</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td><kbd>k</kbd> / <kbd>j</kbd></td><td>Next / previous commit (History) or pillar (Tour)</td></tr>
+        <tr><td><kbd>n</kbd> / <kbd>N</kbd></td><td>Next / previous file within the commit or tour</td></tr>
+        <tr><td><kbd>Space</kbd></td><td>Toggle the current tour file as reviewed (Tour)</td></tr>
+        <tr><td><kbd>b</kbd></td><td>Mark every file in the current pillar reviewed (Tour)</td></tr>
       </tbody>
     </table>
 
@@ -105,25 +161,28 @@
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
         <tr><td><kbd>]</kbd> / <kbd>[</kbd></td><td>Next / previous tab</td></tr>
-        <tr><td><kbd>x</kbd></td><td>Close the current tab</td></tr>
-        <tr><td><kbd>t</kbd></td><td>Worktree picker</td></tr>
-        <tr><td><kbd>o</kbd></td><td>Directory browser</td></tr>
+        <tr><td><kbd>x</kbd></td><td>Close the current tab (when no comment is focused)</td></tr>
+        <tr><td><kbd>o</kbd></td><td>Open hub — repositories, worktrees, recent projects</td></tr>
       </tbody>
     </table>
 
-    <h2>General</h2>
+    <h2>Cleanup &amp; general</h2>
     <table>
       <thead><tr><th>Key</th><th>Action</th></tr></thead>
       <tbody>
-        <tr><td><kbd>Esc</kbd></td><td>Clear search / filter (innermost first)</td></tr>
+        <tr><td><kbd>z</kbd></td><td>Clean up local draft questions &amp; notes (with confirmation)</td></tr>
+        <tr><td><kbd>Z</kbd></td><td>Clean up AI reviews (with confirmation)</td></tr>
+        <tr><td><kbd>Esc</kbd></td><td>Clear search, then filter (innermost first)</td></tr>
         <tr><td><kbd>Ctrl</kbd>+<kbd>q</kbd></td><td>Quit</td></tr>
       </tbody>
     </table>
 
     <div class="callout note">
       <span class="ico">◆</span>
-      <div><p>Some keys are mode-dependent: <kbd>r</kbd> refreshes the diff normally but replies to a comment in comment
-      focus mode, and <kbd>R</kbd> toggles resolved there. The status bar always reflects what is available right now.</p></div>
+      <div><p>Some keys are context-dependent: <kbd>c</kbd> comments everywhere except Staged mode, where it commits;
+      <kbd>x</kbd> deletes a focused comment but closes the tab when nothing is focused; <kbd>e</kbd> edits a focused
+      comment of your own but otherwise opens the file in your editor. The bottom bar and the <kbd>?</kbd> help hub
+      always reflect what is available right now.</p></div>
     </div>
   </main>
   <script src="assets/docs.js"></script>

--- a/docs/guide/tui.html
+++ b/docs/guide/tui.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terminal UI Overview — easy-review docs</title>
-  <meta name="description" content="The er terminal UI: launching, command-line flags, the three-panel layout, AI view modes, watch mode, and how it fits beside an AI coding assistant.">
+  <meta name="description" content="The er terminal UI: launching, command-line flags, the three-panel layout, inline layers and panels, watch mode, and how it fits beside an AI coding assistant.">
   <link rel="stylesheet" href="assets/docs.css">
 </head>
 <body>
@@ -24,7 +24,8 @@
 er --pr 42                                <span class="cmt"># open a GitHub PR by number</span>
 er https://github.com/owner/repo/pull/42  <span class="cmt"># open a PR by URL</span>
 er ~/projects/api ~/projects/frontend     <span class="cmt"># open multiple repos as tabs</span>
-er --filter '*.rs'                        <span class="cmt"># pre-filter the file list</span></code></pre>
+er --filter '+*.rs,-*.lock'               <span class="cmt"># pre-filter the file list</span>
+er --target release/v2                    <span class="cmt"># diff against a specific base branch</span></code></pre>
     <table>
       <thead><tr><th>Flag / argument</th><th>Effect</th></tr></thead>
       <tbody>
@@ -32,6 +33,8 @@ er --filter '*.rs'                        <span class="cmt"># pre-filter the fil
         <tr><td>a PR URL</td><td>Open that pull request (any repo)</td></tr>
         <tr><td>one or more paths</td><td>Open each repository / worktree as a tab</td></tr>
         <tr><td><code>--filter &lt;expr&gt;</code></td><td>Apply a <a href="reviewing.html#filtering">filter</a> at startup</td></tr>
+        <tr><td><code>--remote</code></td><td>Review a PR from any directory, without a local clone (requires <code>gh</code>)</td></tr>
+        <tr><td><code>--target &lt;branch&gt;</code></td><td>Override the detected base branch (useful for stacked branches)</td></tr>
         <tr><td><code>--help</code></td><td>Show all options</td></tr>
       </tbody>
     </table>
@@ -111,11 +114,11 @@ er --filter '*.rs'                        <span class="cmt"># pre-filter the fil
               <span><b>↑/↓</b> line</span><span class="sep">·</span>
               <span><b>c</b> comment</span><span class="sep">·</span>
               <span><b>q</b> question</span><span class="sep">·</span>
-              <span><b>v</b> AI view</span><span class="sep">·</span>
+              <span><b>a</b> AI hub</span><span class="sep">·</span>
               <span><b>Tab</b> focus</span><span class="sep">·</span>
               <span><b>U</b> next unreviewed</span><span class="sep">·</span>
               <span><b>G</b> pull</span><span class="sep">·</span>
-              <span><b>P</b> push</span>
+              <span><b>p</b> panel</span>
             </div>
           </div>
           <div class="panel">
@@ -164,11 +167,22 @@ er --filter '*.rs'                        <span class="cmt"># pre-filter the fil
       the AI Hub with <kbd>a</kbd> and run a review — findings appear in <code>er</code> automatically.
     </p>
 
-    <h2>AI view modes</h2>
+    <h2>Layers and panels: dialing AI density up and down</h2>
     <p>
-      Press <kbd>v</kbd> (forward) or <kbd>V</kbd> (backward) to cycle how much AI context is shown — from a plain diff,
-      through inline findings, to a side panel with the summary and risk breakdown, to a dedicated AI review layout. This
-      is the terminal's way of dialing AI density up and down. See <a href="ai-review.html">AI Review</a>.
+      Inline annotations are organized as toggleable <strong>layers</strong>: <kbd>A</kbd> shows or hides AI findings,
+      <kbd>C</kbd> GitHub comments, <kbd>Q</kbd> questions and notes, and <kbd>X</kbd> hides resolved items. The
+      right-hand <strong>context panel</strong> cycles with <kbd>p</kbd> (backward with <kbd>P</kbd>) through file
+      details, the AI summary with the risk breakdown, and the PR overview. Together they are the terminal's way of
+      dialing review context up and down — from a plain diff to a fully annotated one. See
+      <a href="ai-review.html">AI Review</a>.
+    </p>
+
+    <h2>Hubs: everything else is one key away</h2>
+    <p>
+      Less frequent actions live in modal <strong>hubs</strong>: <kbd>a</kbd> opens the AI Hub (reviews, triage,
+      experts, professor), <kbd>g</kbd> the Git hub (push, stage, comment sync), <kbd>v</kbd> the Verify hub
+      (tests, linters, and other configured commands), <kbd>y</kbd> the copy hub, <kbd>o</kbd> the open hub
+      (repositories and worktrees), <kbd>,</kbd> the settings hub, and <kbd>?</kbd> the searchable help hub.
     </p>
 
     <h2>Syntax highlighting</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>easy-review — Terminal diff review for the AI era</title>
-  <meta name="description" content="A fast, keyboard-driven TUI for reviewing git diffs. Built for developers who work with AI coding assistants.">
+  <title>easy-review — Git diff review for the AI era</title>
+  <meta name="description" content="A fast git diff review tool — keyboard-driven terminal UI and a desktop app sharing one review engine. Built for developers who work with AI coding assistants.">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -440,7 +440,7 @@
       </h1>
 
       <p class="fade-up fade-up-3 text-lg sm:text-xl text-text-dim max-w-2xl mx-auto mb-10 font-light leading-relaxed">
-        A keyboard-driven terminal UI for reviewing git diffs — leave comments, sync with GitHub, and get AI-powered risk analysis. Built for developers who use Claude Code and need to review faster than they can code.
+        Review git diffs at speed — leave comments, sync with GitHub, and get AI-powered risk analysis. A keyboard-driven terminal UI and a desktop app sharing one review engine, built for developers who use Claude Code and need to review faster than they can code.
       </p>
 
       <!-- Install command -->
@@ -463,7 +463,7 @@
       </div>
 
       <p class="fade-up fade-up-5 text-xs text-text-muted font-mono">
-        Requires Rust 1.70+ · Single binary · Zero runtime dependencies
+        Prebuilt binaries, or build with Rust 1.85+ · Single binary · Zero runtime dependencies
       </p>
     </div>
   </section>
@@ -636,9 +636,9 @@
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">q</span> question</span>
                 <span class="text-text-dim">·</span>
-                <span class="text-text-dim"><span class="text-text">v</span> AI view</span>
+                <span class="text-text-dim"><span class="text-text">a</span> AI hub</span>
                 <span class="text-text-dim">·</span>
-                <span class="text-text-dim"><span class="text-text">V</span> back</span>
+                <span class="text-text-dim"><span class="text-text">p</span> panel</span>
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">Tab</span> focus</span>
                 <span class="text-text-dim">·</span>
@@ -646,7 +646,7 @@
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">G</span> pull</span>
                 <span class="text-text-dim">·</span>
-                <span class="text-text-dim"><span class="text-text">P</span> push</span>
+                <span class="text-text-dim"><span class="text-text">g</span> git hub</span>
                 <span class="text-text-dim">·</span>
                 <span class="text-text-dim"><span class="text-text">^p</span> git push</span>
               </div>
@@ -695,7 +695,7 @@
   <section class="border-y border-border/50 reveal-up">
     <div class="max-w-5xl mx-auto stats-strip">
       <div class="stat-item">
-        <div class="stat-value" data-target="5" data-suffix="">5</div>
+        <div class="stat-value" data-target="6" data-suffix="">6</div>
         <div class="stat-label">diff modes</div>
       </div>
       <div class="stat-item">
@@ -733,7 +733,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-green mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">Five diff modes</strong> — Branch, Unstaged, Staged, History, Conflicts. Switch instantly with <span class="keycap">1</span>–<span class="keycap">5</span></span>
+              <span><strong class="text-text">Six diff modes</strong> — Branch, Unstaged, Staged, History, Conflicts, Hidden — plus PR Diff and an AI guided tour. Switch instantly with <span class="keycap">1</span>–<span class="keycap">6</span></span>
             </li>
             <li class="flex gap-3">
               <span class="text-green mt-0.5 shrink-0">✓</span>
@@ -875,12 +875,12 @@
           <span class="font-mono text-xs text-cyan uppercase tracking-widest">Comments</span>
           <h2 class="text-3xl sm:text-4xl font-body font-500 mt-3 mb-5 leading-tight">Leave comments<br>where they matter</h2>
           <p class="text-text-dim leading-relaxed mb-6">
-            Two comment types, one keyboard. GitHub comments sync to your PR. Private questions go to AI review. Both anchor to the exact line — and follow it through 3-pass relocation when code shifts underneath.
+            Three comment types, one keyboard. GitHub comments sync to your PR. Private questions and notes stay local for you and your AI. All anchor to the exact line — and follow it through 3-pass relocation when code shifts underneath.
           </p>
           <ul class="space-y-3 text-sm text-text-dim mb-7">
             <li class="flex gap-3">
               <span class="text-cyan mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">Two comment types</strong> — <span class="keycap">c</span> for cyan GitHub comments that sync to your PR, <span class="keycap">q</span> for yellow private questions answered by AI</span>
+              <span><strong class="text-text">Three comment types</strong> — <span class="keycap">c</span> for cyan GitHub comments that sync to your PR, <span class="keycap">q</span> for yellow private questions answered by AI, and <span class="keycap">Ctrl+t</span> while composing to switch to a 📝 note for agent hand-off</span>
             </li>
             <li class="flex gap-3">
               <span class="text-cyan mt-0.5 shrink-0">✓</span>
@@ -888,7 +888,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-cyan mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">Line-level navigation</strong> — arrow keys move between lines. Comment on exact lines, not just hunks. Tab to enter comment focus mode</span>
+              <span><strong class="text-text">Line-level navigation</strong> — arrow keys move between lines. Comment on exact lines, not just hunks. <span class="keycap">J</span>/<span class="keycap">K</span> jump between existing comments</span>
             </li>
           </ul>
           <div class="flex flex-wrap gap-2 items-center">
@@ -917,7 +917,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-blue mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">Two-way GitHub sync</strong> — <span class="keycap">G</span> pulls review comments from GitHub into your diff view. <span class="keycap">P</span> pushes your local comments back. Powered by the <span class="font-mono text-xs text-cyan">gh</span> CLI</span>
+              <span><strong class="text-text">Two-way GitHub sync</strong> — <span class="keycap">G</span> pulls review comments from GitHub into your diff view; the Git hub (<span class="keycap">g</span>) pushes your local comments back. Powered by the <span class="font-mono text-xs text-cyan">gh</span> CLI</span>
             </li>
             <li class="flex gap-3">
               <span class="text-blue mt-0.5 shrink-0">✓</span>
@@ -927,7 +927,7 @@
           <div class="flex flex-wrap gap-2 items-center">
             <span class="text-xs text-text-muted">Keys:</span>
             <span class="keycap">G</span>
-            <span class="keycap">P</span>
+            <span class="keycap">g</span>
             <span class="keycap">p</span>
             <span class="keycap">Ctrl+P</span>
           </div>
@@ -1062,7 +1062,7 @@
           <span class="font-mono text-xs text-orange uppercase tracking-widest">AI review</span>
           <h2 class="text-3xl sm:text-4xl font-body font-500 mt-3 mb-5 leading-tight">AI reads the diff<br>so you don't have<br>to guess</h2>
           <p class="text-text-dim leading-relaxed mb-6">
-            Open the AI Hub — press <span class="keycap">a</span> in the TUI or <kbd class="keycap">Cmd+A</kbd> in the desktop app — and run <strong class="text-text">Run review</strong>. Risk ratings and hunk-level findings appear inline. Press <span class="keycap">v</span> to cycle AI views — from a plain diff, to findings inline, to a side panel with the summary and risk breakdown. To get answers to your private questions without a full review, open the Hub and choose <strong class="text-text">Answer questions</strong> (TUI only; questions are managed in the Notes panel in the desktop app).
+            Open the AI Hub — press <span class="keycap">a</span> in the TUI or <kbd class="keycap">Cmd+A</kbd> in the desktop app — and run a review (<strong class="text-text">Review work</strong> in the TUI, <strong class="text-text">Run review</strong> on desktop). Risk ratings and hunk-level findings appear inline — toggle the findings layer with <span class="keycap">A</span>, and cycle the side panel with <span class="keycap">p</span> for the summary and risk breakdown. To get answers to your private questions without a full review, open the Hub and choose <strong class="text-text">Answer questions</strong> (TUI only; questions are managed in the Notes panel in the desktop app).
           </p>
           <ul class="space-y-3 text-sm text-text-dim mb-7">
             <li class="flex gap-3">
@@ -1071,7 +1071,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-orange mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">AI Summary panel</strong> — cycle with <span class="keycap">v</span> to the panel view: risk rating, findings count, and a file-by-file risk breakdown side-by-side with your diff</span>
+              <span><strong class="text-text">AI Summary panel</strong> — cycle with <span class="keycap">p</span> to the panel view: risk rating, findings count, and a file-by-file risk breakdown side-by-side with your diff</span>
             </li>
             <li class="flex gap-3">
               <span class="text-orange mt-0.5 shrink-0">✓</span>
@@ -1080,8 +1080,9 @@
           </ul>
           <div class="flex flex-wrap gap-2 items-center">
             <span class="text-xs text-text-muted">Keys:</span>
-            <span class="keycap">v</span>
-            <span class="keycap">V</span>
+            <span class="keycap">a</span>
+            <span class="keycap">A</span>
+            <span class="keycap">p</span>
             <span class="keycap">z</span>
             <span class="keycap">Z</span>
           </div>
@@ -1108,7 +1109,7 @@
             </li>
             <li class="flex gap-3">
               <span class="text-cyan mt-0.5 shrink-0">✓</span>
-              <span><strong class="text-text">Symbol references</strong> — press <span class="keycap">g</span> to run git grep for the word at cursor. Results appear in the context panel so you see all usages without leaving the diff</span>
+              <span><strong class="text-text">Copy hub</strong> — press <span class="keycap">y</span> to copy the file, its path, the current hunk, or the current line — ready to paste into a chat with your AI assistant</span>
             </li>
           </ul>
           <div class="flex flex-wrap gap-2 items-center">
@@ -1116,7 +1117,7 @@
             <span class="keycap">f</span>
             <span class="keycap">F</span>
             <span class="keycap">/</span>
-            <span class="keycap">g</span>
+            <span class="keycap">y</span>
           </div>
         </div>
 
@@ -1436,13 +1437,13 @@
         <div class="timeline-step" style="transition-delay: 400ms;">
           <div class="timeline-node key"><span class="font-mono text-xs text-accent font-bold">3</span></div>
           <h3 class="font-body font-500 text-base mb-1">Run a review from the AI Hub</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">a</span> (TUI) or <kbd class="keycap">Cmd+A</kbd> (desktop) to open the AI Hub, then choose <strong class="text-text">Run review</strong>. Risk ratings, hunk-level findings, and a review checklist appear inline. Press <span class="keycap">v</span> to cycle how much AI context is shown — from a plain diff to findings inline to a side panel.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">a</span> (TUI) or <kbd class="keycap">Cmd+A</kbd> (desktop) to open the AI Hub, then run a review (<strong class="text-text">Review work</strong> / <strong class="text-text">Run review</strong>). Risk ratings, hunk-level findings, and a review checklist appear inline. Toggle the findings layer with <span class="keycap">A</span> and cycle the side panel with <span class="keycap">p</span> to dial how much AI context is shown.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 600ms;">
           <div class="timeline-node"><span class="font-mono text-xs text-text-muted">4</span></div>
           <h3 class="font-body font-500 text-base mb-1">Comment and iterate</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Cycle with <span class="keycap">v</span> to a side panel for the AI summary and PR overview alongside your diff. Re-run the review from the AI Hub (<span class="keycap">a</span> → <strong class="text-text">Run review</strong> in the TUI, or <kbd class="keycap">Cmd+A</kbd> → <strong class="text-text">Run review</strong> in the desktop app) — the AI reads your questions and updates its analysis.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Cycle with <span class="keycap">p</span> to a side panel for the AI summary and PR overview alongside your diff. Re-run the review from the AI Hub (<span class="keycap">a</span> → <strong class="text-text">Review work</strong> in the TUI, or <kbd class="keycap">Cmd+A</kbd> → <strong class="text-text">Run review</strong> in the desktop app) — the AI reads your questions and updates its analysis.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 800ms;">
@@ -1454,7 +1455,7 @@
         <div class="timeline-step" style="transition-delay: 1000ms; padding-bottom: 0;">
           <div class="timeline-node key-cyan"><span class="font-mono text-xs text-cyan font-bold">6</span></div>
           <h3 class="font-body font-500 text-base mb-1">Sync with GitHub</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">G</span> to pull review comments from the PR into your diff view. Press <span class="keycap">P</span> to push your local comments back to GitHub. The full review loop, without leaving the terminal.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">G</span> to pull review comments from the PR into your diff view. Push your local comments back from the Git hub (<span class="keycap">g</span> → <strong class="text-text">Push comments to GitHub</strong>) — as one review or individually. The full review loop, without leaving the terminal.</p>
         </div>
 
       </div>
@@ -1495,7 +1496,7 @@
       </div>
 
       <p class="reveal-up text-sm text-text-muted mt-6">
-        Requires <span class="text-text-dim">Rust 1.70+</span> and <span class="text-text-dim">git</span>. Single binary, no runtime dependencies.
+        Requires <span class="text-text-dim">git</span>; building from source needs <span class="text-text-dim">Rust 1.85+</span>. Single binary, no runtime dependencies.
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Summary

A full audit of the external documentation (`docs/guide/`, `docs/index.html`, `README.md`, `docs/config-reference.md`) against the codebase, fixing everywhere the docs had drifted from shipped behavior and tightening the shared-concepts vs. terminal vs. desktop structure. The guide's overall shape was already right (Getting Started → Core Concepts → Terminal UI → Desktop App → Help); this PR makes the content match it — and match the code.

Targeting `main` since these are documentation bug fixes: every substantive change corrects something that was factually wrong against the current release.

## Keybinding corrections (verified against `crates/er-tui/src/input/normal.rs`)

The keybinding reference and every page quoting keys documented a key map that no longer exists:

- Unreviewed filter is <kbd>!</kbd>, not <kbd>u</kbd> (<kbd>u</kbd>/<kbd>d</kbd> scroll)
- Recency sort is <kbd>m</kbd>, not <kbd>Shift+R</kbd>; <kbd>R</kbd> refreshes, not <kbd>r</kbd>
- <kbd>r</kbd> replies to a focused comment; <kbd>x</kbd> deletes; <kbd>J</kbd>/<kbd>K</kbd> focus inline items (there is no "comment focus mode" on <kbd>Tab</kbd>)
- <kbd>Q</kbd>/<kbd>C</kbd> toggle layer *visibility* — they never created hunk comments
- <kbd>v</kbd> opens the Verify hub; the documented v/V "AI view mode" cycle was removed long ago — inline layers are <kbd>A</kbd>/<kbd>C</kbd>/<kbd>Q</kbd>/<kbd>X</kbd> and the panel cycles with <kbd>p</kbd>/<kbd>P</kbd>
- Settings are on <kbd>,</kbd>, not <kbd>S</kbd>; there is no <kbd>t</kbd> worktree picker (the open hub is <kbd>o</kbd>)
- Comment push is Git hub (<kbd>g</kbd>) → **Push comments to GitHub** (confirm <kbd>r</kbd> as review / <kbd>i</kbd> individually), not <kbd>P</kbd>
- `tui-keybindings.html` rewritten from source: hubs, layers, Tour/History keys, panel resize, context expansion, dynamic tab numbering, <kbd>Ctrl+t</kbd> draft-type cycling

## Content & structure

- **Comments docs now cover all three annotation types** — questions, notes (`notes.json`, 📝, `Ctrl+t`), and GitHub comments — including the desktop Notes panel (All | Notes | Questions), Elaborate/Validate, and promote-to-comment. Quick Start, How er Works, and both index pages updated from "two kinds" to three.
- **Removed fictional features**: the "Comprehension quiz" section, TUI Quiz mode (key 8 is the Guided Tour), the <kbd>I</kbd> import key, and TechProfessor references — none exist in the code.
- **Added missing features**: Guided Tour mode on the Diff Modes page, `--remote`/`--target` CLI flags, per-item desktop AI actions in the AI Hub Actions catalog, and a desktop Settings GUI section.
- **Configuration page corrected against `config.rs`**: real theme list (`graphite` default … `contrast-light`, with legacy aliases noted), real `[features]` flags (`view_*`, `arena`) replacing phantom keys (`ai_overlays`, `exit_heatmap`, `bookmarks`, `blame_annotations`, duplicate `split_diff`), `auto_context_threshold` default 100, `ai_hub.default_effort` / `max_concurrent_reviews`, `[packages]`. Same fixes in `docs/config-reference.md`.
- **Cross-page contradictions resolved**: troubleshooting FAQ said the desktop app isn't released while installation documents the v0.4.0 `.dmg` (verified against the GitHub release — the DMG exists); DMG-by-default build claims corrected (`ER_SKIP_DMG=1`); Hidden mode description now matches its actual behavior (watched `[watched]` files); TUI/desktop review-action labels ("Review work" vs "Run review") used consistently.
- **Landing page** now presents both products instead of terminal-only, says six diff modes (was 5), Rust 1.85+ (was 1.70+), and its demo key hints match the real key map.

## Not changed

- The `docs.js` sidebar structure (already matches the requested organization).
- Anchor links like `concepts.html#watch-mode-keeps-the-diff-live` — these looked broken in static HTML but `docs.js` assigns slugified ids to every heading at load time, so they resolve at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KD1488H9LUTKxp1pwtJmvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KD1488H9LUTKxp1pwtJmvv)_