### PR TITLE
Fix reviews silently dropped when the agent writes head_branch 'unknown'

### DIFF
--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3035,7 +3035,12 @@ fn spawn_ai_review_with_diff(
     std::fs::write(std::path::Path::new(er_dir).join("diff-tmp"), &raw)
         .map_err(|e| format!("Failed to write diff-tmp: {e}"))?;
 
-    let prompt = er_engine::ai::prompts::build_review_prompt_prepared_diff(scope, er_dir);
+    let prompt = er_engine::ai::prompts::build_review_prompt_prepared_diff(
+        scope,
+        er_dir,
+        &base_branch,
+        &branch_label,
+    );
 
     let target = er_engine::app::BackgroundTaskTarget {
         repo_root,
@@ -3428,7 +3433,12 @@ fn spawn_scoped_reviewers(
                 app.spawn_background_triage_review(target.clone(), prompt, true)
             }
             ReviewerKind::General => {
-                let mut prompt = prompts::build_review_prompt_prepared_diff(scope, er_dir);
+                let mut prompt = prompts::build_review_prompt_prepared_diff(
+                    scope,
+                    er_dir,
+                    &target.base_branch,
+                    &target.branch_label,
+                );
                 if scoped_files {
                     prompt = prompts::append_file_scope_if_present(prompt, er_dir);
                 }

--- a/crates/er-engine/src/ai/loader.rs
+++ b/crates/er-engine/src/ai/loader.rs
@@ -113,12 +113,22 @@ pub fn summary_declares_branch(summary: &str) -> Option<String> {
     None
 }
 
+/// True when a stored branch declaration carries real information. Review
+/// agents that can't determine the branch (prepared-diff reviews of remote
+/// PRs) write "unknown" or leave the prompt template's `<head branch if
+/// known>` placeholder — neither identifies another branch, so neither may
+/// disqualify the sidecar.
+fn branch_declaration_is_real(branch: &str) -> bool {
+    !branch.is_empty() && !branch.eq_ignore_ascii_case("unknown") && !branch.starts_with('<')
+}
+
 /// True when sidecars in `er_dir` clearly belong to another branch than `scope`.
 pub fn artifacts_branch_mismatch(er_dir: &Path, scope: &str) -> bool {
     let review_path = er_dir.join("review.json");
     if let Ok(content) = read_sidecar(&review_path) {
         if let Ok(review) = serde_json::from_str::<ErReview>(&content) {
-            if !review.head_branch.is_empty() && !storage_branches_match(scope, &review.head_branch)
+            if branch_declaration_is_real(&review.head_branch)
+                && !storage_branches_match(scope, &review.head_branch)
             {
                 return true;
             }
@@ -127,7 +137,7 @@ pub fn artifacts_branch_mismatch(er_dir: &Path, scope: &str) -> bool {
     let summary_path = er_dir.join("summary.md");
     if let Ok(content) = read_sidecar(&summary_path) {
         if let Some(declared) = summary_declares_branch(&content) {
-            if !storage_branches_match(scope, &declared) {
+            if branch_declaration_is_real(&declared) && !storage_branches_match(scope, &declared) {
                 return true;
             }
         }
@@ -379,6 +389,67 @@ mod tests {
         let state = load_ai_state(er_dir, "abc", Some("dependabot/npm_and_yarn/foo"));
         assert!(state.review.is_none());
         assert!(state.summary.is_none());
+    }
+
+    #[test]
+    fn load_ai_state_keeps_review_with_unknown_head_branch() {
+        // Regression: a prepared-diff review agent that can't determine the
+        // branch writes head_branch "unknown"; the branch-mismatch guard must
+        // not discard the review over it.
+        let dir = tempfile::tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let review = serde_json::json!({
+            "version": 1,
+            "diff_hash": "abc",
+            "head_branch": "unknown",
+            "files": {
+                "a.rs": {
+                    "risk": "low",
+                    "findings": [{
+                        "id": "f1",
+                        "title": "t",
+                        "description": "d",
+                        "severity": "low",
+                        "category": "logic",
+                        "hunk_index": 0
+                    }]
+                }
+            }
+        });
+        std::fs::write(
+            dir.path().join("review.json"),
+            serde_json::to_string(&review).unwrap(),
+        )
+        .unwrap();
+
+        let state = load_ai_state(er_dir, "abc", Some("mikkelam/dev-5713-add-outbox"));
+        let review = state
+            .review
+            .expect("review must survive unknown head_branch");
+        assert_eq!(review.files["a.rs"].findings.len(), 1);
+        assert!(!state.is_stale);
+    }
+
+    #[test]
+    fn load_ai_state_keeps_review_with_placeholder_head_branch() {
+        // An agent that copies the prompt template literally leaves
+        // "<head branch if known>" — also not a real declaration.
+        let dir = tempfile::tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let review = serde_json::json!({
+            "version": 1,
+            "diff_hash": "abc",
+            "head_branch": "<head branch if known>",
+            "files": {}
+        });
+        std::fs::write(
+            dir.path().join("review.json"),
+            serde_json::to_string(&review).unwrap(),
+        )
+        .unwrap();
+
+        let state = load_ai_state(er_dir, "abc", Some("feature/x"));
+        assert!(state.review.is_some());
     }
 
     #[test]

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -393,17 +393,32 @@ pub fn build_review_prompt_local_managed(
 ///
 /// Desktop uses this after materializing the tab's UI diff. The agent must not
 /// run `git diff` or `gh pr diff` — it hashes and annotates the prepared file.
-pub fn build_review_prompt_prepared_diff(scope: &str, output_dir: &str) -> String {
+///
+/// `base_branch` / `head_branch` are baked verbatim into the review.json the
+/// agent writes. The head branch matters: `artifacts_branch_mismatch` discards
+/// the whole review when a stored `head_branch` doesn't match the tab's branch
+/// scope, so the agent must never have to guess it.
+pub fn build_review_prompt_prepared_diff(
+    scope: &str,
+    output_dir: &str,
+    base_branch: &str,
+    head_branch: &str,
+) -> String {
     let safe_output_dir = sanitize_for_shell(output_dir)
         .replace('{', "{{")
         .replace('}', "}}");
+    let base_hint = if base_branch.trim().is_empty() {
+        "<base branch if known>".to_string()
+    } else {
+        base_branch.replace('{', "{{").replace('}', "}}")
+    };
+    let head_hint = if head_branch.trim().is_empty() {
+        "<head branch if known>".to_string()
+    } else {
+        head_branch.replace('{', "{{").replace('}', "}}")
+    };
     let preamble = review_rules_preamble(output_dir, true, FindingCaps::general(), None);
-    let outputs = general_review_outputs_section(
-        output_dir,
-        scope,
-        "<base branch if known>",
-        "<head branch if known>",
-    );
+    let outputs = general_review_outputs_section(output_dir, scope, &base_hint, &head_hint);
     format!(
         r#"You are a code reviewer. Perform a thorough review of the prepared diff and write results to `{safe_output_dir}/`.
 
@@ -1656,7 +1671,8 @@ mod tests {
 
     #[test]
     fn prepared_review_prompt_hashes_existing_diff_tmp() {
-        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/er-managed");
+        let prompt =
+            build_review_prompt_prepared_diff("branch", "/tmp/er-managed", "main", "feat/x");
         assert!(prompt.contains("'/tmp/er-managed/diff-tmp'"));
         assert!(prompt.contains("sha256sum"));
         assert!(prompt.contains("do **not** run `git diff`"));
@@ -1665,9 +1681,30 @@ mod tests {
 
     #[test]
     fn prepared_review_prompt_annotates_from_diff_tmp() {
-        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/out");
+        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/out", "main", "feat/x");
         assert!(prompt.contains("'/tmp/out/diff-tmp'"));
         assert!(prompt.contains("'/tmp/out/diff-annotated'"));
+    }
+
+    #[test]
+    fn prepared_review_prompt_bakes_known_branches_into_template() {
+        let prompt = build_review_prompt_prepared_diff(
+            "branch",
+            "/tmp/out",
+            "main",
+            "mikkelam/dev-5713-add-outbox",
+        );
+        assert!(prompt.contains(r#""head_branch": "mikkelam/dev-5713-add-outbox""#));
+        assert!(prompt.contains(r#""base_branch": "main""#));
+        assert!(!prompt.contains("<head branch if known>"));
+        assert!(!prompt.contains("<base branch if known>"));
+    }
+
+    #[test]
+    fn prepared_review_prompt_falls_back_to_placeholders_when_unknown() {
+        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/out", "", "  ");
+        assert!(prompt.contains(r#""head_branch": "<head branch if known>""#));
+        assert!(prompt.contains(r#""base_branch": "<base branch if known>""#));
     }
 
     #[test]
@@ -1752,7 +1789,7 @@ mod tests {
 
     #[test]
     fn general_prompt_still_requests_four_output_files() {
-        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/out");
+        let prompt = build_review_prompt_prepared_diff("branch", "/tmp/out", "main", "feat/x");
         assert!(prompt.contains("review.json"));
         assert!(prompt.contains("order.json"));
         assert!(prompt.contains("checklist.json"));


### PR DESCRIPTION
## The Problem
A completed AI review can be on disk with findings, yet the AI Review card shows **"No findings written"** with a **"fresh"** badge. Repro'd on a "To Review" PR tab (reshapebiotech-discovery PR #1332): the agent wrote `review.json` with 2 findings into `prs/pr-1332/`, and the UI never showed them.

Root cause chain:
1. `build_review_prompt_prepared_diff` gave the agent the literal placeholder `<head branch if known>` for `review.json`'s `head_branch`. Prepared-diff agents are told not to run git, so they fill in `"unknown"`.
2. `artifacts_branch_mismatch` (loader.rs) treats any non-empty `head_branch` that doesn't match the tab's branch scope as a foreign-branch sidecar and discards the **entire** `AiState` before loading anything.
3. An empty `AiState` defaults `is_stale = false` — hence "fresh" + zero findings, which looks like the review was never written.

Whether it bites depends on what the agent happens to write for `head_branch`, which is why reviews only sometimes vanished.

## How we fix
- **Prompt:** thread the tab's real `base_branch`/`branch_label` into `build_review_prompt_prepared_diff` (both desktop spawn sites already have them — and `branch_label` is the same value `storage_branch_scope()` validates against later, so the written `head_branch` is consistent by construction). Falls back to the old placeholders when empty.
- **Guard:** `artifacts_branch_mismatch` now treats `"unknown"` and unfilled `<...>` placeholders as "no declaration" instead of a mismatch, for both `review.json` and `summary.md`. Real cross-branch mismatches are still discarded (existing tests unchanged).

## Tests
- `load_ai_state_keeps_review_with_unknown_head_branch` — reproduces the exact failure: fails on the old guard (review discarded), passes now.
- `load_ai_state_keeps_review_with_placeholder_head_branch` — same for the literal template placeholder.
- `prepared_review_prompt_bakes_known_branches_into_template` / `..._falls_back_to_placeholders_when_unknown` — prompt embeds real branches, placeholder fallback intact.
- Existing negative tests (`load_ai_state_ignores_review_for_wrong_branch_scope`, summary-only variant) still pass — the guard still catches real mismatches.

## How to manually test
1. Open a PR tab (e.g. via To Review) and run an AI review from the AI Hub.
2. If the agent writes `head_branch: "unknown"` (check the PR bucket's `review.json`), findings now render instead of "No findings written".
3. With the prompt fix, new runs write the real head branch, so step 2's fallback rarely triggers.