### PR TITLE
fix: show experts that only contributed a summary in the reviewer dropdown

### DIFF
--- a/desktop-ui/src/lib/aiReviewAgents.test.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.test.ts
@@ -51,6 +51,14 @@ describe("uniqueAgentLabels", () => {
     ]);
     expect(labels).toEqual(["General", "Professor"]);
   });
+
+  it("includes experts that only contributed a summary, no findings", () => {
+    const labels = uniqueAgentLabels(
+      [mkFinding({ agent_label: "Patterns" })],
+      ["Patterns", "Testing"],
+    );
+    expect(labels).toEqual(["Testing", "Patterns"]);
+  });
 });
 
 describe("countBySeverity", () => {

--- a/desktop-ui/src/lib/aiReviewAgents.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.ts
@@ -18,10 +18,16 @@ export const AGENT_LABEL_ORDER: readonly string[] = [
 export const ALL_REVIEWERS = "all" as const;
 export type AgentFilter = typeof ALL_REVIEWERS | string;
 
-export function uniqueAgentLabels(findings: FlatFinding[]): string[] {
+export function uniqueAgentLabels(
+  findings: FlatFinding[],
+  agentSummaryLabels: string[] = [],
+): string[] {
   const seen = new Set<string>();
   for (const f of findings) {
     seen.add(f.agent_label ?? f.expert_label ?? "General");
+  }
+  for (const label of agentSummaryLabels) {
+    seen.add(label);
   }
   return sortAgentLabels([...seen]);
 }

--- a/desktop-ui/src/lib/components/AiReviewCard.svelte
+++ b/desktop-ui/src/lib/components/AiReviewCard.svelte
@@ -35,11 +35,17 @@
   let staleHelpOpen = $state(false);
   let filter = $state<"all" | "high" | "med" | "low">("all");
 
-  const agentLabels = $derived(uniqueAgentLabels(ai.findings));
+  const agentLabels = $derived(
+    uniqueAgentLabels(ai.findings, Object.keys(ai.agent_summaries ?? {})),
+  );
 
   $effect(() => {
     ai.findings;
-    aiReviewFilter.syncFromFindings(ai.findings);
+    ai.agent_summaries;
+    aiReviewFilter.syncFromFindings(
+      ai.findings,
+      Object.keys(ai.agent_summaries ?? {}),
+    );
   });
 
   function basename(p: string): string {
@@ -55,7 +61,9 @@
     filterByAgent(ai.findings, aiReviewFilter.filter),
   );
   const scopedCounts = $derived(countBySeverity(agentScopedFindings));
-  const showAgentDropdown = $derived(ai.findings.length > 0);
+  const showAgentDropdown = $derived(
+    ai.findings.length > 0 || agentLabels.length > 1,
+  );
   const showAgentPills = $derived(
     aiReviewFilter.filter === ALL_REVIEWERS && agentLabels.length > 1,
   );

--- a/desktop-ui/src/lib/stores/aiReviewFilter.svelte.ts
+++ b/desktop-ui/src/lib/stores/aiReviewFilter.svelte.ts
@@ -10,8 +10,11 @@ class AiReviewFilterStore {
   filter = $state<AgentFilter>(ALL_REVIEWERS);
   private labelsKey = "";
 
-  syncFromFindings(findings: FlatFinding[]): void {
-    const labels = uniqueAgentLabels(findings);
+  syncFromFindings(
+    findings: FlatFinding[],
+    agentSummaryLabels: string[] = [],
+  ): void {
+    const labels = uniqueAgentLabels(findings, agentSummaryLabels);
     const key = labels.join("\0");
     if (key === this.labelsKey) return;
     this.labelsKey = key;


### PR DESCRIPTION
## The Problem

The AI Review Arena's expert dropdown (the "Patterns" selector shown in the desktop UI) only lists experts that produced at least one finding. When an expert's review (`.er/experts/<id>.json`) had a summary but no findings, it silently disappeared from the dropdown — even though both files loaded fine and the Rust side correctly merged both summaries into `agent_summaries`.

## How we fix

`uniqueAgentLabels()` in `desktop-ui/src/lib/aiReviewAgents.ts` derived the label list purely from `ai.findings`. It now also unions in the keys of `ai.agent_summaries`, so a summary-only expert still gets a slot in the dropdown/pills. `showAgentDropdown` and the filter-coercion effect (`aiReviewFilter.svelte.ts`) were updated the same way, so selecting a summary-only expert doesn't get immediately reset back to another value.

## Design Choices and considerations

No Rust changes were needed — `crates/er-engine/src/ai/loader.rs` already loads and merges every expert file correctly; this was purely a frontend label-derivation bug.

## How to manually test

1. Run a review that produces at least two expert files under `.er/experts/`, where at least one expert has a summary but zero findings.
2. Open the AI Review card in the desktop app — confirm both experts appear in the reviewer dropdown, and selecting the summary-only one shows its summary and stays selected.

Also added `desktop-ui/src/lib/aiReviewAgents.test.ts` coverage: an expert with only a summary (no findings) must still appear in `uniqueAgentLabels()`'s output. `bun test` passes (20/20).