### PR TITLE
fix: stop Guide view freezing after reviewing a nested file

### DIFF
--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -230,11 +230,11 @@
   });
 
   // Reset collapse state only when the diff context changes (tab/branch/mode).
-  // clear() reads collapsed.size, so run it untracked — otherwise this effect
-  // takes a dependency on `collapsed` and wipes every collapse the user makes.
+  // diffFileCollapse's mutators are internally untracked, so this doesn't
+  // need its own untrack() wrapper (see diffFileCollapse.svelte.ts).
   $effect(() => {
     snapshotKey;
-    untrack(() => diffFileCollapse.clear());
+    diffFileCollapse.clear();
   });
 
   // Clear the reference highlight when the diff context changes (tab/branch/PR/
@@ -579,6 +579,9 @@
     for (const f of files) {
       if (!f.reviewed) continue;
       cur.add(f.path);
+      // diffFileCollapse's mutators are internally untracked, so calling
+      // collapse() here doesn't make this effect depend on the collapse
+      // store (see diffFileCollapse.svelte.ts).
       if (!_prevReviewedTour.has(f.path)) diffFileCollapse.collapse(f.path);
     }
     _prevReviewedTour = cur;

--- a/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
@@ -38,7 +38,9 @@
     void app.cmd("select_file", { idx: f.source_index });
   }
 
-  function toggleReviewed(f: FileSnapshot) {
+  function toggleReviewed(e: MouseEvent, f: FileSnapshot) {
+    e.stopPropagation();
+    e.preventDefault();
     // Guide mode auto-collapses a file on its reviewed false→true transition
     // (see FlatDiffView), so no explicit collapse is needed here.
     void app.cmd(f.reviewed ? "unmark_reviewed" : "mark_reviewed", { path: f.path });
@@ -109,7 +111,7 @@
       title={f.reviewed ? "Marked reviewed — click to unmark" : "Mark file reviewed"}
       aria-label={f.reviewed ? "Unmark as reviewed" : "Mark as reviewed"}
       aria-pressed={f.reviewed}
-      onclick={() => toggleReviewed(f)}
+      onclick={(e) => toggleReviewed(e, f)}
     >
       <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
         <polyline points="20 6 9 17 4 12" />

--- a/desktop-ui/src/lib/stores/diffFileCollapse.svelte.ts
+++ b/desktop-ui/src/lib/stores/diffFileCollapse.svelte.ts
@@ -1,3 +1,5 @@
+import { untrack } from "svelte";
+
 /** Per-file diff body collapse in the flat diff view (keyed by file path). */
 let collapsed = $state<ReadonlySet<string>>(new Set());
 /** Bumped on every mutation so derived models reliably re-run. */
@@ -12,42 +14,62 @@ function isCollapsed(filePath: string): boolean {
   return collapsed.has(filePath);
 }
 
+// Every mutator below reads `collapsed` (as a no-op guard, or to clone it)
+// before writing it. Called from inside a $derived/$effect without untrack,
+// that read-then-write makes the caller depend on the very state it's
+// mutating, which can reschedule the caller and wedge Svelte's reactive
+// flush (chevrons/checkboxes/sticky headers stop updating until a remount).
+// Guarding here — once — makes every mutator safe regardless of caller
+// context, instead of requiring each call site to remember to untrack it.
+
 function toggle(filePath: string) {
-  const next = new Set(collapsed);
-  if (next.has(filePath)) next.delete(filePath);
-  else next.add(filePath);
-  commit(next);
+  untrack(() => {
+    const next = new Set(collapsed);
+    if (next.has(filePath)) next.delete(filePath);
+    else next.add(filePath);
+    commit(next);
+  });
 }
 
 function collapse(filePath: string) {
-  if (collapsed.has(filePath)) return;
-  const next = new Set(collapsed);
-  next.add(filePath);
-  commit(next);
+  untrack(() => {
+    if (collapsed.has(filePath)) return;
+    const next = new Set(collapsed);
+    next.add(filePath);
+    commit(next);
+  });
 }
 
 function expand(filePath: string) {
-  if (!collapsed.has(filePath)) return;
-  const next = new Set(collapsed);
-  next.delete(filePath);
-  commit(next);
+  untrack(() => {
+    if (!collapsed.has(filePath)) return;
+    const next = new Set(collapsed);
+    next.delete(filePath);
+    commit(next);
+  });
 }
 
 function collapseAll(paths: readonly string[]) {
-  if (paths.length === 0) return;
-  const next = new Set(collapsed);
-  for (const p of paths) next.add(p);
-  commit(next);
+  untrack(() => {
+    if (paths.length === 0) return;
+    const next = new Set(collapsed);
+    for (const p of paths) next.add(p);
+    commit(next);
+  });
 }
 
 function expandAll() {
-  if (collapsed.size === 0) return;
-  commit(new Set());
+  untrack(() => {
+    if (collapsed.size === 0) return;
+    commit(new Set());
+  });
 }
 
 function clear() {
-  if (collapsed.size === 0) return;
-  commit(new Set());
+  untrack(() => {
+    if (collapsed.size === 0) return;
+    commit(new Set());
+  });
 }
 
 export const diffFileCollapse = {


### PR DESCRIPTION
## The Problem

In the desktop app's Guide (guided tour) view, clicking the reviewed checkbox on a nested/related file (a co-located test/style/story file shown indented under its primary file in the left pillar rail) froze the whole diff view: no other checkbox or collapse chevron responded, and scrolling stopped revealing previously-collapsed headers or keeping the sticky header pinned. Only a full app reload cleared it — a sign the Svelte reactive flush itself was wedged, not a data/backend issue.

## How we fix

The Guide view's auto-collapse-on-review `$effect` (`FlatDiffView.svelte`) called `diffFileCollapse.collapse()` without wrapping it in `untrack()`. `collapse()` reads `collapsed.has(...)` before writing it, so calling it un-untracked inside the effect made the effect depend on the very store it mutates — the same self-trigger hazard two sibling effects in the same file already guard against.

Rather than patching just that one call site, the fix moves the `untrack()` guard into the store itself (`diffFileCollapse.svelte.ts`): every mutator (`toggle`/`collapse`/`expand`/`collapseAll`/`expandAll`/`clear`) has the identical read-before-write shape internally, and other call sites elsewhere in the codebase were only safe by incidental calling convention (never yet called from inside an effect), not by any guarantee. Guarding inside the store makes every caller — present or future — safe regardless of context, and the two now-redundant call-site wrappers were removed.

Also brings `PillarRail`'s reviewed-checkbox click handler in line with `FileHeaderContent`'s existing `stopPropagation()`/`preventDefault()` pattern for consistency.

## How to manually test

1. Open the desktop app on a diff with a Guide/tour available, where at least one pillar has a file with related files (test/style/story) shown nested (indented, `↳`) under it in the left rail.
2. Click the reviewed checkbox on a nested file.
3. Confirm: other checkboxes and collapse chevrons stay responsive, the sticky header keeps pinning correctly, and scrolling still reveals previously-collapsed file headers.
4. Confirm normal Guide behavior still holds: reviewing a file still auto-collapses it, and manually re-expanding an already-reviewed file isn't re-collapsed by the effect.

Verified: `bun run check` (svelte-check) — 0 errors; `bun test src` — 570/570 passing.