### PR TITLE
Document desktop app installation and features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # easy-review (`er`)
 
-A git diff review tool built for developers who use AI coding assistants. Ships as a terminal TUI (`er`), with a Tauri desktop app in development.
+A git diff review tool built for developers who use AI coding assistants. Ships as a terminal TUI (`er`) and a desktop app (Tauri + Svelte) — both share the same review engine and data.
 
 AI writes code faster than you can review it. `er` makes review fast, navigable, and live-updating.
 
@@ -30,6 +30,23 @@ cargo install --path crates/er-tui
 ```
 
 Requires Rust 1.85+.
+
+## Desktop app
+
+A graphical front end for the same review engine — split diffs, an embedded terminal and browser, a multi-model review arena, and point-and-click settings. It reads and writes the same review data as the terminal, so you can use both side by side.
+
+As of **v0.4.0**, prebuilt Apple Silicon `.dmg` bundles are published on the [Releases page](https://github.com/VilfredSikker/easy-review/releases). Download it, open it, and drag **Easy Review** into Applications (right-click → **Open** the first time to bypass Gatekeeper, since the bundle isn't code-signed yet).
+
+Intel Macs, Linux, and Windows aren't packaged yet — build from source instead:
+
+```bash
+git clone https://github.com/VilfredSikker/easy-review.git
+cd easy-review
+./scripts/tauri-dev.sh     # dev shell with hot reload
+./scripts/tauri-build.sh   # release bundle
+```
+
+See [Installation](https://vilfredsikker.github.io/easy-review/guide/installation.html#desktop-app) for full details.
 
 ## Documentation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1498,6 +1498,11 @@
       <p class="reveal-up text-sm text-text-muted mt-6">
         Requires <span class="text-text-dim">git</span>; building from source needs <span class="text-text-dim">Rust 1.85+</span>. Single binary, no runtime dependencies.
       </p>
+      <p class="reveal-up text-sm text-text-muted mt-3">
+        Prefer a GUI? Grab the desktop app's prebuilt Apple Silicon <code class="text-text-dim">.dmg</code> from the
+        <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener" class="text-accent hover:underline">Releases page</a> —
+        see the <a href="guide/installation.html#desktop-app" class="text-accent hover:underline">Desktop install guide</a> for details (and building from source on other platforms).
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the desktop app (Tauri + Svelte) to the README and landing page, reflecting the project's evolution from terminal-only to a dual-platform tool.

## Changes

- **README.md**: 
  - Updated the opening description to clarify that the project now ships as both a terminal TUI and a desktop app, with shared review engine and data
  - Added a new "Desktop app" section documenting:
    - Feature overview (split diffs, embedded terminal/browser, multi-model review arena, point-and-click settings)
    - Prebuilt Apple Silicon `.dmg` bundles available on Releases page (v0.4.0+)
    - Installation instructions for Apple Silicon (drag-and-drop with Gatekeeper workaround)
    - Build-from-source instructions for Intel Macs, Linux, and Windows
    - Link to full installation guide

- **docs/index.html**:
  - Added a callout on the landing page directing users to the desktop app's prebuilt Apple Silicon `.dmg` on the Releases page
  - Linked to the Desktop install guide for full details and platform-specific build instructions

## Notes

These changes reflect the current state of the project: the desktop app is now a first-class citizen alongside the terminal TUI, sharing the same review engine and data storage. The documentation emphasizes the shared architecture and provides clear paths for both GUI-preferring users and those building from source on unsupported platforms.

https://claude.ai/code/session_01Pn4CQQWVFBPUKsYcgkvzAi