### PR TITLE
fix: don't drop entire review.json when a finding has a negative line anchor

### DIFF
--- a/crates/er-engine/src/ai/experts.rs
+++ b/crates/er-engine/src/ai/experts.rs
@@ -249,7 +249,7 @@ pub struct ExpertReview {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExpertFileReview {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::review::lenient_findings")]
     pub findings: Vec<Finding>,
 }
 

--- a/crates/er-engine/src/ai/loader.rs
+++ b/crates/er-engine/src/ai/loader.rs
@@ -431,6 +431,93 @@ mod tests {
     }
 
     #[test]
+    fn load_ai_state_keeps_review_with_negative_line_anchor() {
+        // Real-world failure: the annotated diff tags deleted lines as
+        // `[h<N> L-<old>]` and a model copied the negative number into
+        // `line_start`. The whole review used to fail deserialization and the
+        // Review section showed "No findings written" despite a completed run.
+        let dir = tempfile::tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let review = serde_json::json!({
+            "version": 1,
+            "diff_hash": "abc",
+            "files": {
+                "a.rs": {
+                    "risk": "medium",
+                    "findings": [{
+                        "id": "f-1",
+                        "title": "deleted-line finding",
+                        "description": "d",
+                        "severity": "medium",
+                        "category": "testing",
+                        "hunk_index": 3,
+                        "line_start": -494
+                    }]
+                }
+            }
+        });
+        std::fs::write(
+            dir.path().join("review.json"),
+            serde_json::to_string(&review).unwrap(),
+        )
+        .unwrap();
+
+        let state = load_ai_state(er_dir, "abc", None);
+        let review = state
+            .review
+            .expect("review must survive a negative line anchor");
+        let finding = &review.files["a.rs"].findings[0];
+        // Anchor degrades to hunk level instead of poisoning the parse.
+        assert_eq!(finding.line_start, None);
+        assert_eq!(finding.hunk_index, Some(3));
+        assert!(!state.is_stale);
+    }
+
+    #[test]
+    fn load_ai_state_skips_malformed_finding_keeps_rest() {
+        let dir = tempfile::tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let review = serde_json::json!({
+            "version": 1,
+            "diff_hash": "abc",
+            "files": {
+                "a.rs": {
+                    "risk": "low",
+                    "findings": [
+                        {
+                            "id": "f-bad",
+                            "title": "t",
+                            "severity": "catastrophic",
+                            "hunk_index": 0
+                        },
+                        {
+                            "id": "f-good",
+                            "title": "t",
+                            "description": "d",
+                            "severity": "low",
+                            "category": "logic",
+                            "hunk_index": 1,
+                            "line_start": 12
+                        }
+                    ]
+                }
+            }
+        });
+        std::fs::write(
+            dir.path().join("review.json"),
+            serde_json::to_string(&review).unwrap(),
+        )
+        .unwrap();
+
+        let state = load_ai_state(er_dir, "abc", None);
+        let review = state.review.expect("review must survive one bad finding");
+        let findings = &review.files["a.rs"].findings;
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].id, "f-good");
+        assert_eq!(findings[0].line_start, Some(12));
+    }
+
+    #[test]
     fn load_ai_state_keeps_review_with_placeholder_head_branch() {
         // An agent that copies the prompt template literally leaves
         // "<head branch if known>" — also not a real declaration.

--- a/crates/er-engine/src/ai/professor.rs
+++ b/crates/er-engine/src/ai/professor.rs
@@ -28,7 +28,7 @@ pub struct ProfessorReview {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProfessorFileReview {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::review::lenient_findings")]
     pub findings: Vec<Finding>,
 }
 

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -38,7 +38,11 @@ pub fn sanitize_for_shell(s: &str) -> String {
 ///
 /// The model reads the annotated file and copies these tags directly into `Finding.line_start`
 /// and `Finding.hunk_index`, eliminating the line-counting errors the prompt-side computation
-/// caused. The hash is still computed on the raw `input` so it matches what `er` itself sees.
+/// caused. Deleted-line tags (`L-<old>`) must not be copied into `line_start` — the prompt
+/// instructs the model to anchor those findings at hunk level (`line_start: null`), and
+/// `lenient_line_anchor` in `review.rs` degrades any negative value that slips through to
+/// `None` rather than failing the whole sidecar parse. The hash is still computed on the raw
+/// `input` so it matches what `er` itself sees.
 ///
 /// POSIX-compatible awk; works on macOS BSD awk and gawk alike. Paths are shell-quoted
 /// inside the helper, so callers pass raw paths.
@@ -109,6 +113,7 @@ pub fn review_rules_preamble(
 ### Annotate and anchor
 - Findings **only** on `+` or `-` lines in the annotated diff
 - Copy `hunk_index` from `[h<N>]` and `line_start` from `[h<N> L<M>]` — **never** count or infer line numbers
+- Deleted lines are tagged `[h<N> L-<M>]` (note the minus). For a finding on a deleted line, set `line_start: null` and anchor by `hunk_index` alone — **never** write a negative `line_start`
 - Set `outside_diff: false`; drop findings you cannot anchor to a tagged line
 
 ### Severity (P0 / P1 / P2)

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -60,8 +60,40 @@ pub struct ErFileReview {
     pub risk_reason: String,
     #[serde(default)]
     pub summary: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_findings")]
     pub findings: Vec<Finding>,
+}
+
+/// Deserialize an optional line anchor from model-authored JSON without
+/// failing the whole sidecar. The annotated diff tags deleted lines as
+/// `[h<N> L-<old>]`, and models sometimes copy the negative number into
+/// `line_start` verbatim — which `Option<usize>` would reject, silently
+/// discarding the entire review. Anything that isn't a non-negative integer
+/// degrades to `None` (hunk-level anchor).
+pub(crate) fn lenient_line_anchor<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value
+        .as_ref()
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|n| usize::try_from(n).ok()))
+}
+
+/// Deserialize a findings array, skipping individual entries that fail to
+/// parse instead of rejecting the whole sidecar. AI-authored files
+/// occasionally contain one malformed finding; losing that finding is far
+/// better than showing "no findings" for the entire review.
+pub(crate) fn lenient_findings<'de, D>(deserializer: D) -> Result<Vec<Finding>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value(v).ok())
+        .collect())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -104,9 +136,9 @@ pub enum Confidence {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvidenceItem {
     pub file: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_line_anchor")]
     pub line_start: Option<usize>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_line_anchor")]
     pub line_end: Option<usize>,
     /// What the agent learned from this file/range.
     pub note: String,
@@ -122,8 +154,11 @@ pub struct Finding {
     #[serde(default)]
     pub description: String,
     /// 0-based index into the file's hunks
+    #[serde(default, deserialize_with = "lenient_line_anchor")]
     pub hunk_index: Option<usize>,
+    #[serde(default, deserialize_with = "lenient_line_anchor")]
     pub line_start: Option<usize>,
+    #[serde(default, deserialize_with = "lenient_line_anchor")]
     pub line_end: Option<usize>,
     #[serde(default)]
     pub suggestion: String,

--- a/skills/REVIEW_RULES.md
+++ b/skills/REVIEW_RULES.md
@@ -16,7 +16,8 @@ See also: [`REVIEW_PHILOSOPHY.md`](REVIEW_PHILOSOPHY.md) for severity model and 
 1. Awk-annotate raw diff → `[h<N> L<M>]` tags on every content line
 2. Read the annotated diff — 20 lines of context per hunk
 3. **Findings only on `+` or `-` lines** — copy `hunk_index` / `line_start` from tags; never compute line numbers
-4. Set `outside_diff: false` on review pass; drop unanchored findings
+4. Deleted lines are tagged `[h<N> L-<M>]` (minus = old-side line). For findings on deleted lines set `line_start: null` and anchor by `hunk_index` alone — never write a negative `line_start`
+5. Set `outside_diff: false` on review pass; drop unanchored findings
 
 ## Philosophy (embedded)
 


### PR DESCRIPTION
## Problem

After a review run completes, the Review section can show **"No findings written"** with a **fresh** badge, even though the agent wrote a valid-looking `review.json` with findings (field report: PR 1351, `reshapebiotech-discovery`).

## Root cause

The diff annotator tags deleted lines as `[h<N> L-<old>]`, and the review rules say to copy `line_start` from the tag — so the model wrote `"line_start": -494` for a finding on deleted lines. `Finding.line_start` is `Option<usize>`, so the **entire** `review.json` failed serde deserialization, and `load_ai_state` treats an unparseable sidecar as an absent file. Meanwhile `checklist.json` parsed fine and its matching `diff_hash` rendered the "fresh" badge — a silently broken state that looks like the review never produced output.

## Fix

- **Lenient line anchors** — `hunk_index` / `line_start` / `line_end` on `Finding` and `EvidenceItem` now degrade negative or non-integer values to `None` (hunk-level anchor) instead of failing the whole parse.
- **Per-finding resilience** — a single malformed finding (e.g. unknown severity) is skipped instead of discarding the whole review; applied to `review.json`, `experts/*.json`, and `professor.json`.
- **Prompt fix** — `review_rules_preamble` and `skills/REVIEW_RULES.md` now explicitly instruct: deleted-line findings use `line_start: null` anchored by `hunk_index`; never write a negative `line_start`.

## Tests

- Regression test with the exact negative-anchor shape from the field report (finding survives, anchor degrades to hunk level, staleness unaffected).
- Test that one malformed finding is skipped while valid siblings load.
- Verified the user's actual 7.3 KB `review.json` from the agent log now parses: 10 files, both findings retained.
- `cargo test -p er-engine -p er-tui` (823 tests), clippy, and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ht19p5TBurpcnYwAzWeXgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht19p5TBurpcnYwAzWeXgd)_