### PR TITLE
feat: refresh AI Hub models and effort controls

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+## AI Hub model refresh
+
+- Added Claude Sonnet 5 and GPT-5.6 Sol, Terra, and Luna to the built-in AI Hub catalog.
+- Removed Opus 4.6 and Opus 4.7 from the built-in catalog; existing user-defined entries remain untouched.
+- Added model-aware reasoning-effort controls for GPT-5.6 Codex runs, including arena overrides.
+- Added a triage-model picker in Desktop Settings, with a reset to the fastest available model.
+
 # Easy Review v0.4.2
 
 ## In plain terms

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,7 +45,7 @@ args    = ["--print", "--output-format", "stream-json", "-p", "{prompt}"]
 # If omitted, AI Hub falls back to the single [agent] config above.
 [ai_hub]
 default_provider = "claude"
-default_model = "sonnet-4.6"
+default_model = "sonnet-5"
 
 [ai_hub.reviewer_models]
 triage = "haiku-4.5"
@@ -65,22 +65,13 @@ cost_per_1k_out = 0.015
 avg_latency_ms = 12000
 
 [[ai_hub.providers.claude.models]]
-id = "opus-4.6"
-label = "Opus 4.6"
-description = "Frontier reasoning · 1M context"
-args = ["--model", "claude-opus-4-6"]
-cost_per_1k_in = 0.005
-cost_per_1k_out = 0.025
-avg_latency_ms = 24000
-
-[[ai_hub.providers.claude.models]]
-id = "opus-4.7"
-label = "Opus 4.7"
-description = "Deepest reasoning · slowest"
-args = ["--model", "claude-opus-4-7"]
-cost_per_1k_in = 0.005
-cost_per_1k_out = 0.025
-avg_latency_ms = 24000
+id = "sonnet-5"
+label = "Sonnet 5"
+description = "Best speed + intelligence · 1M context"
+args = ["--model", "claude-sonnet-5"]
+cost_per_1k_in = 0.002
+cost_per_1k_out = 0.010
+avg_latency_ms = 12000
 
 [[ai_hub.providers.claude.models]]
 id = "opus-4.8"
@@ -131,6 +122,33 @@ args = ["--model", "gpt-5.5"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 18000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-sol"
+label = "GPT-5.6 Sol"
+description = "Flagship reasoning · detail + polish"
+args = ["--model", "gpt-5.6-sol"]
+cost_per_1k_in = 0.005
+cost_per_1k_out = 0.030
+avg_latency_ms = 20000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-terra"
+label = "GPT-5.6 Terra"
+description = "Strong everyday coding + tool use"
+args = ["--model", "gpt-5.6-terra"]
+cost_per_1k_in = 0.0025
+cost_per_1k_out = 0.015
+avg_latency_ms = 14000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-luna"
+label = "GPT-5.6 Luna"
+description = "Fast, efficient repeatable work"
+args = ["--model", "gpt-5.6-luna"]
+cost_per_1k_in = 0.001
+cost_per_1k_out = 0.005
+avg_latency_ms = 8000
 
 [ai_hub.providers.cursor]
 label = "Cursor"

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -21,6 +21,7 @@ pub struct ConfigPatch {
 pub struct GetConfigHubResponse {
     pub settings: DesktopSettingsSnapshot,
     pub providers: Vec<AiProviderInfo>,
+    pub triage_model_id: Option<String>,
 }
 
 fn feature_allows_mode(features: &FeatureFlags, mode: DiffMode) -> bool {
@@ -105,6 +106,7 @@ pub fn get_config_hub(state: State<AppState>) -> Result<GetConfigHubResponse, St
     Ok(GetConfigHubResponse {
         settings,
         providers,
+        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
     })
 }
 
@@ -126,6 +128,7 @@ pub fn apply_config_patch(
     Ok(GetConfigHubResponse {
         settings,
         providers,
+        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
     })
 }
 
@@ -174,5 +177,6 @@ pub fn set_ai_hub_defaults(
     Ok(GetConfigHubResponse {
         settings,
         providers,
+        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
     })
 }

--- a/crates/er-engine/src/agent_runtime.rs
+++ b/crates/er-engine/src/agent_runtime.rs
@@ -4,7 +4,7 @@ use crate::ai::{
     ErChecklist, ErGitHubComments, ErOrder, ErQuestions, ErReview, ErTour, ExpertReview,
     ProfessorReview, TriageReview,
 };
-use crate::config::{inject_claude_effort, resolve_effort, ErConfig};
+use crate::config::{inject_provider_effort, resolve_effort, ErConfig};
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
@@ -282,18 +282,20 @@ pub fn resolve_invocation(
     let family = CliFamily::detect(&command);
     if family == CliFamily::Claude {
         inject_allowed_tools(&mut args, request.access.claude_tools());
+    }
+    if family == CliFamily::Codex {
+        if let Some(output_dir) = request.access.output_dir() {
+            inject_codex_writable_dir(&mut args, output_dir);
+        }
+    }
+    if matches!(family, CliFamily::Claude | CliFamily::Codex) {
         let effort = resolve_effort(
             &config.ai_hub,
             &config.agent,
             request.effort,
             request.effort_override,
         );
-        inject_claude_effort(&mut args, effort.as_deref());
-    }
-    if family == CliFamily::Codex {
-        if let Some(output_dir) = request.access.output_dir() {
-            inject_codex_writable_dir(&mut args, output_dir);
-        }
+        inject_provider_effort(&command, &mut args, effort.as_deref());
     }
     if request.live_logs && family.supports_claude_stream_json() {
         inject_stream_json(&mut args, family);
@@ -757,6 +759,35 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn codex_invocation_injects_reasoning_effort() {
+        let config = codex_config();
+        let task = AgentTaskKind::Review;
+        let invocation = resolve_invocation(
+            &config,
+            AgentInvocationRequest {
+                selection: AgentSelection::Runtime {
+                    provider_id: Some("codex"),
+                    model_id: Some("gpt-5.6-sol"),
+                    task_aware: true,
+                },
+                task: &task,
+                effort: Some("high"),
+                effort_override: None,
+                work_dir: "/repo".into(),
+                access: AgentAccessProfile::ReadOnly,
+                live_logs: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(invocation.family, CliFamily::Codex);
+        assert!(has_option_value(
+            &invocation.args,
+            "-c",
+            "model_reasoning_effort=high"
+        ));
     }
 
     #[test]

--- a/crates/er-engine/src/agent_runtime.rs
+++ b/crates/er-engine/src/agent_runtime.rs
@@ -227,7 +227,7 @@ pub fn resolve_invocation(
     config: &ErConfig,
     request: AgentInvocationRequest<'_>,
 ) -> Result<AgentInvocation> {
-    let (command, mut args) = match request.selection {
+    let (command, mut args, resolved_model_id) = match request.selection {
         AgentSelection::Runtime {
             provider_id,
             model_id,
@@ -249,14 +249,18 @@ pub fn resolve_invocation(
                 } else {
                     config.ai_hub.resolve_model_id(&pid, model_id)
                 };
-                if let Some(model_id) = resolved_model {
-                    if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
+                if let Some(model_id) = &resolved_model {
+                    if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
                         args.extend(model.args.clone());
                     }
                 }
-                (provider.command.clone(), args)
+                (provider.command.clone(), args, resolved_model)
             } else {
-                (config.agent.command.clone(), config.agent.args.clone())
+                (
+                    config.agent.command.clone(),
+                    config.agent.args.clone(),
+                    (!config.agent.model.is_empty()).then(|| config.agent.model.clone()),
+                )
             }
         }
         AgentSelection::Exact {
@@ -275,7 +279,7 @@ pub fn resolve_invocation(
                 .with_context(|| format!("unknown model {model_id} for provider {provider_id}"))?;
             let mut args = provider.args.clone();
             args.extend(model.args.clone());
-            (provider.command.clone(), args)
+            (provider.command.clone(), args, Some(model_id.to_string()))
         }
     };
 
@@ -295,7 +299,12 @@ pub fn resolve_invocation(
             request.effort,
             request.effort_override,
         );
-        inject_provider_effort(&command, &mut args, effort.as_deref());
+        inject_provider_effort(
+            &command,
+            &mut args,
+            resolved_model_id.as_deref(),
+            effort.as_deref(),
+        );
     }
     if request.live_logs && family.supports_claude_stream_json() {
         inject_stream_json(&mut args, family);
@@ -788,6 +797,33 @@ mod tests {
             "-c",
             "model_reasoning_effort=high"
         ));
+    }
+
+    #[test]
+    fn codex_invocation_skips_effort_for_unsupported_model() {
+        let config = codex_config();
+        let task = AgentTaskKind::Review;
+        let invocation = resolve_invocation(
+            &config,
+            AgentInvocationRequest {
+                selection: AgentSelection::Runtime {
+                    provider_id: Some("codex"),
+                    model_id: Some("gpt-5.4"),
+                    task_aware: true,
+                },
+                task: &task,
+                effort: Some("high"),
+                effort_override: None,
+                work_dir: "/repo".into(),
+                access: AgentAccessProfile::ReadOnly,
+                live_logs: false,
+            },
+        )
+        .unwrap();
+        assert!(!invocation
+            .args
+            .iter()
+            .any(|arg| arg.starts_with("model_reasoning_effort=")));
     }
 
     #[test]

--- a/crates/er-engine/src/ai_hub_catalog.toml
+++ b/crates/er-engine/src/ai_hub_catalog.toml
@@ -1,7 +1,7 @@
 # Canonical [ai_hub] presets merged into user config at load time (missing models only).
 [ai_hub]
 default_provider = "claude"
-default_model = "sonnet-4.6"
+default_model = "sonnet-5"
 
 [ai_hub.reviewer_models]
 triage = "haiku-4.5"
@@ -21,22 +21,13 @@ cost_per_1k_out = 0.015
 avg_latency_ms = 12000
 
 [[ai_hub.providers.claude.models]]
-id = "opus-4.6"
-label = "Opus 4.6"
-description = "Frontier reasoning · 1M context"
-args = ["--model", "claude-opus-4-6"]
-cost_per_1k_in = 0.005
-cost_per_1k_out = 0.025
-avg_latency_ms = 24000
-
-[[ai_hub.providers.claude.models]]
-id = "opus-4.7"
-label = "Opus 4.7"
-description = "Deepest reasoning · slowest"
-args = ["--model", "claude-opus-4-7"]
-cost_per_1k_in = 0.005
-cost_per_1k_out = 0.025
-avg_latency_ms = 24000
+id = "sonnet-5"
+label = "Sonnet 5"
+description = "Best speed + intelligence · 1M context"
+args = ["--model", "claude-sonnet-5"]
+cost_per_1k_in = 0.002
+cost_per_1k_out = 0.010
+avg_latency_ms = 12000
 
 [[ai_hub.providers.claude.models]]
 id = "opus-4.8"
@@ -87,6 +78,33 @@ args = ["--model", "gpt-5.5"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 18000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-sol"
+label = "GPT-5.6 Sol"
+description = "Flagship reasoning · detail + polish"
+args = ["--model", "gpt-5.6-sol"]
+cost_per_1k_in = 0.005
+cost_per_1k_out = 0.030
+avg_latency_ms = 20000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-terra"
+label = "GPT-5.6 Terra"
+description = "Strong everyday coding + tool use"
+args = ["--model", "gpt-5.6-terra"]
+cost_per_1k_in = 0.0025
+cost_per_1k_out = 0.015
+avg_latency_ms = 14000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-luna"
+label = "GPT-5.6 Luna"
+description = "Fast, efficient repeatable work"
+args = ["--model", "gpt-5.6-luna"]
+cost_per_1k_in = 0.001
+cost_per_1k_out = 0.005
+avg_latency_ms = 8000
 
 [ai_hub.providers.cursor]
 label = "Cursor"

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -22,18 +22,19 @@ pub fn plan_card_ai_invocation(
     runtime_effort: Option<&str>,
     work_dir: String,
 ) -> CardAiInvocation {
-    let (command, mut args, is_claude) = if let Some(pid) =
+    let (command, mut args, is_claude, resolved_model_id) = if let Some(pid) =
         config.ai_hub.resolve_provider_id(provider_id)
     {
         if let Some(provider) = config.ai_hub.providers.get(&pid) {
             let mut args = provider.args.clone();
-            if let Some(mid) = config.ai_hub.resolve_model_id(&pid, model_id) {
-                if let Some(model) = provider.models.iter().find(|m| m.id == mid) {
+            let resolved_model_id = config.ai_hub.resolve_model_id(&pid, model_id);
+            if let Some(mid) = &resolved_model_id {
+                if let Some(model) = provider.models.iter().find(|m| m.id == *mid) {
                     args.extend(model.args.clone());
                 }
             }
             let is_claude = provider.command.ends_with("claude") || provider.command == "claude";
-            (provider.command.clone(), args, is_claude)
+            (provider.command.clone(), args, is_claude, resolved_model_id)
         } else {
             fallback_agent(config)
         }
@@ -48,7 +49,12 @@ pub fn plan_card_ai_invocation(
         inject_read_only_tools(&mut args);
     }
     let effort = resolve_effort(&config.ai_hub, &config.agent, runtime_effort, None);
-    inject_provider_effort(&command, &mut args, effort.as_deref());
+    inject_provider_effort(
+        &command,
+        &mut args,
+        resolved_model_id.as_deref(),
+        effort.as_deref(),
+    );
 
     CardAiInvocation {
         command,
@@ -59,10 +65,15 @@ pub fn plan_card_ai_invocation(
     }
 }
 
-fn fallback_agent(config: &ErConfig) -> (String, Vec<String>, bool) {
+fn fallback_agent(config: &ErConfig) -> (String, Vec<String>, bool, Option<String>) {
     let cmd = config.agent.command.clone();
     let is_claude = cmd.ends_with("claude") || cmd == "claude";
-    (cmd, config.agent.args.clone(), is_claude)
+    (
+        cmd,
+        config.agent.args.clone(),
+        is_claude,
+        (!config.agent.model.is_empty()).then(|| config.agent.model.clone()),
+    )
 }
 
 fn inject_read_only_tools(args: &mut Vec<String>) {

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -1,7 +1,7 @@
 //! Subprocess invocation for desktop card-level AI (Ask AI / Validate with AI).
 
 use crate::config::{
-    agent_command_uses_stream_json, inject_claude_effort, resolve_effort, ErConfig,
+    agent_command_uses_stream_json, inject_provider_effort, resolve_effort, ErConfig,
 };
 use std::process::Command;
 
@@ -46,9 +46,9 @@ pub fn plan_card_ai_invocation(
 
     if is_claude {
         inject_read_only_tools(&mut args);
-        let effort = resolve_effort(&config.ai_hub, &config.agent, runtime_effort, None);
-        inject_claude_effort(&mut args, effort.as_deref());
     }
+    let effort = resolve_effort(&config.ai_hub, &config.agent, runtime_effort, None);
+    inject_provider_effort(&command, &mut args, effort.as_deref());
 
     CardAiInvocation {
         command,
@@ -253,5 +253,35 @@ mod tests {
         let inv = plan_card_ai_invocation(&config, None, None, None, "/repo".into());
         assert!(inv.args.iter().any(|a| a == "Read"));
         assert!(inv.args.iter().any(|a| a.contains("grep")));
+    }
+
+    #[test]
+    fn plan_injects_reasoning_effort_for_codex() {
+        let mut config = ErConfig::default();
+        config.ai_hub.default_effort = Some("high".into());
+        config.ai_hub.providers.insert(
+            "codex".into(),
+            crate::config::AiProviderConfig {
+                command: "codex".into(),
+                models: vec![crate::config::AiModelConfig {
+                    id: "gpt-5.6-sol".into(),
+                    args: vec!["--model".into(), "gpt-5.6-sol".into()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+
+        let inv = plan_card_ai_invocation(
+            &config,
+            Some("codex"),
+            Some("gpt-5.6-sol"),
+            None,
+            "/repo".into(),
+        );
+        assert!(inv
+            .args
+            .windows(2)
+            .any(|pair| { pair[0] == "-c" && pair[1] == "model_reasoning_effort=high" }));
     }
 }

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2263,16 +2263,14 @@ impl App {
                     crate::config::agent_command_uses_stream_json(&cmd),
                 )
             };
-        if is_claude_compatible {
-            let effort_override = if name == "triage" { Some("low") } else { None };
-            let effort = crate::config::resolve_effort(
-                &self.config.ai_hub,
-                &self.config.agent,
-                self.current_ai_effort.as_deref(),
-                effort_override,
-            );
-            crate::config::inject_claude_effort(&mut config_args, effort.as_deref());
-        }
+        let effort_override = if name == "triage" { Some("low") } else { None };
+        let effort = crate::config::resolve_effort(
+            &self.config.ai_hub,
+            &self.config.agent,
+            self.current_ai_effort.as_deref(),
+            effort_override,
+        );
+        crate::config::inject_provider_effort(&agent_cmd, &mut config_args, effort.as_deref());
 
         // Ensure .er/ directory exists
         std::fs::create_dir_all(&er_dir_path)?;
@@ -2654,16 +2652,14 @@ impl App {
                     crate::config::agent_command_uses_stream_json(&cmd),
                 )
             };
-        if is_claude_compatible {
-            let effort_override = if kind == "triage" { Some("low") } else { None };
-            let effort = crate::config::resolve_effort(
-                &self.config.ai_hub,
-                &self.config.agent,
-                self.current_ai_effort.as_deref(),
-                effort_override,
-            );
-            crate::config::inject_claude_effort(&mut config_args, effort.as_deref());
-        }
+        let effort_override = if kind == "triage" { Some("low") } else { None };
+        let effort = crate::config::resolve_effort(
+            &self.config.ai_hub,
+            &self.config.agent,
+            self.current_ai_effort.as_deref(),
+            effort_override,
+        );
+        crate::config::inject_provider_effort(&agent_cmd, &mut config_args, effort.as_deref());
 
         std::fs::create_dir_all(&target.er_dir)?;
 

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2223,50 +2223,58 @@ impl App {
         let is_remote = self.tab().is_remote();
         self.sync_ai_selection();
 
-        let (agent_cmd, mut config_args, is_claude_compatible, is_codex, is_stream_json) =
-            if let Some(provider_id) = self
+        let (
+            agent_cmd,
+            mut config_args,
+            is_claude_compatible,
+            is_codex,
+            is_stream_json,
+            resolved_model_id,
+        ) = if let Some(provider_id) = self
+            .config
+            .ai_hub
+            .resolve_provider_id(self.current_ai_provider.as_deref())
+        {
+            let provider = self
                 .config
                 .ai_hub
-                .resolve_provider_id(self.current_ai_provider.as_deref())
-            {
-                let provider = self
-                    .config
-                    .ai_hub
-                    .providers
-                    .get(&provider_id)
-                    .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
-                let mut args = provider.args.clone();
-                if let Some(model_id) = self.config.ai_hub.resolve_spawn_model_id(
-                    &provider_id,
-                    self.current_ai_model.as_deref(),
-                    name,
-                ) {
-                    if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
-                        args.extend(model.args.clone());
-                    }
+                .providers
+                .get(&provider_id)
+                .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
+            let mut args = provider.args.clone();
+            let resolved_model_id = self.config.ai_hub.resolve_spawn_model_id(
+                &provider_id,
+                self.current_ai_model.as_deref(),
+                name,
+            );
+            if let Some(model_id) = &resolved_model_id {
+                if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
+                    args.extend(model.args.clone());
                 }
-                let is_claude =
-                    provider.command.ends_with("claude") || provider.command == "claude";
-                let is_codex = crate::config::agent_command_is_codex(&provider.command);
-                (
-                    provider.command.clone(),
-                    args,
-                    is_claude,
-                    is_codex,
-                    provider.uses_stream_json_log(),
-                )
-            } else {
-                let cmd = self.config.agent.command.clone();
-                let is_claude = cmd.ends_with("claude") || cmd == "claude";
-                let is_codex = crate::config::agent_command_is_codex(&cmd);
-                (
-                    cmd.clone(),
-                    self.config.agent.args.clone(),
-                    is_claude,
-                    is_codex,
-                    crate::config::agent_command_uses_stream_json(&cmd),
-                )
-            };
+            }
+            let is_claude = provider.command.ends_with("claude") || provider.command == "claude";
+            let is_codex = crate::config::agent_command_is_codex(&provider.command);
+            (
+                provider.command.clone(),
+                args,
+                is_claude,
+                is_codex,
+                provider.uses_stream_json_log(),
+                resolved_model_id,
+            )
+        } else {
+            let cmd = self.config.agent.command.clone();
+            let is_claude = cmd.ends_with("claude") || cmd == "claude";
+            let is_codex = crate::config::agent_command_is_codex(&cmd);
+            (
+                cmd.clone(),
+                self.config.agent.args.clone(),
+                is_claude,
+                is_codex,
+                crate::config::agent_command_uses_stream_json(&cmd),
+                (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
+            )
+        };
         let effort_override = if name == "triage" { Some("low") } else { None };
         let effort = crate::config::resolve_effort(
             &self.config.ai_hub,
@@ -2274,7 +2282,12 @@ impl App {
             self.current_ai_effort.as_deref(),
             effort_override,
         );
-        crate::config::inject_provider_effort(&agent_cmd, &mut config_args, effort.as_deref());
+        crate::config::inject_provider_effort(
+            &agent_cmd,
+            &mut config_args,
+            resolved_model_id.as_deref(),
+            effort.as_deref(),
+        );
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }
@@ -2619,50 +2632,58 @@ impl App {
 
         self.sync_ai_selection();
 
-        let (agent_cmd, mut config_args, is_claude_compatible, is_codex, is_stream_json) =
-            if let Some(provider_id) = self
+        let (
+            agent_cmd,
+            mut config_args,
+            is_claude_compatible,
+            is_codex,
+            is_stream_json,
+            resolved_model_id,
+        ) = if let Some(provider_id) = self
+            .config
+            .ai_hub
+            .resolve_provider_id(self.current_ai_provider.as_deref())
+        {
+            let provider = self
                 .config
                 .ai_hub
-                .resolve_provider_id(self.current_ai_provider.as_deref())
-            {
-                let provider = self
-                    .config
-                    .ai_hub
-                    .providers
-                    .get(&provider_id)
-                    .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
-                let mut args = provider.args.clone();
-                if let Some(model_id) = self.config.ai_hub.resolve_spawn_model_id(
-                    &provider_id,
-                    self.current_ai_model.as_deref(),
-                    &kind,
-                ) {
-                    if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
-                        args.extend(model.args.clone());
-                    }
+                .providers
+                .get(&provider_id)
+                .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
+            let mut args = provider.args.clone();
+            let resolved_model_id = self.config.ai_hub.resolve_spawn_model_id(
+                &provider_id,
+                self.current_ai_model.as_deref(),
+                &kind,
+            );
+            if let Some(model_id) = &resolved_model_id {
+                if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
+                    args.extend(model.args.clone());
                 }
-                let is_claude =
-                    provider.command.ends_with("claude") || provider.command == "claude";
-                let is_codex = crate::config::agent_command_is_codex(&provider.command);
-                (
-                    provider.command.clone(),
-                    args,
-                    is_claude,
-                    is_codex,
-                    provider.uses_stream_json_log(),
-                )
-            } else {
-                let cmd = self.config.agent.command.clone();
-                let is_claude = cmd.ends_with("claude") || cmd == "claude";
-                let is_codex = crate::config::agent_command_is_codex(&cmd);
-                (
-                    cmd.clone(),
-                    self.config.agent.args.clone(),
-                    is_claude,
-                    is_codex,
-                    crate::config::agent_command_uses_stream_json(&cmd),
-                )
-            };
+            }
+            let is_claude = provider.command.ends_with("claude") || provider.command == "claude";
+            let is_codex = crate::config::agent_command_is_codex(&provider.command);
+            (
+                provider.command.clone(),
+                args,
+                is_claude,
+                is_codex,
+                provider.uses_stream_json_log(),
+                resolved_model_id,
+            )
+        } else {
+            let cmd = self.config.agent.command.clone();
+            let is_claude = cmd.ends_with("claude") || cmd == "claude";
+            let is_codex = crate::config::agent_command_is_codex(&cmd);
+            (
+                cmd.clone(),
+                self.config.agent.args.clone(),
+                is_claude,
+                is_codex,
+                crate::config::agent_command_uses_stream_json(&cmd),
+                (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
+            )
+        };
         let effort_override = if kind == "triage" { Some("low") } else { None };
         let effort = crate::config::resolve_effort(
             &self.config.ai_hub,
@@ -2670,7 +2691,12 @@ impl App {
             self.current_ai_effort.as_deref(),
             effort_override,
         );
-        crate::config::inject_provider_effort(&agent_cmd, &mut config_args, effort.as_deref());
+        crate::config::inject_provider_effort(
+            &agent_cmd,
+            &mut config_args,
+            resolved_model_id.as_deref(),
+            effort.as_deref(),
+        );
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }

--- a/crates/er-engine/src/arena/adapter.rs
+++ b/crates/er-engine/src/arena/adapter.rs
@@ -38,7 +38,7 @@ pub fn resolve_provider_command(
     if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
         args.extend(model.args.clone());
     }
-    inject_provider_effort(&provider.command, &mut args, effort);
+    inject_provider_effort(&provider.command, &mut args, Some(model_id), effort);
     if agent_command_is_codex(&provider.command) {
         inject_codex_ignore_user_config(&mut args);
     }

--- a/crates/er-engine/src/arena/adapter.rs
+++ b/crates/er-engine/src/arena/adapter.rs
@@ -1,4 +1,4 @@
-use crate::config::{agent_command_is_claude, inject_claude_effort, AiHubConfig};
+use crate::config::{inject_provider_effort, AiHubConfig};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Read};
@@ -36,9 +36,7 @@ pub fn resolve_provider_command(
     if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
         args.extend(model.args.clone());
     }
-    if agent_command_is_claude(&provider.command) {
-        inject_claude_effort(&mut args, effort);
-    }
+    inject_provider_effort(&provider.command, &mut args, effort);
     Ok(ProviderCommand {
         command: provider.command.clone(),
         args,

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -608,10 +608,19 @@ pub fn inject_codex_effort(args: &mut Vec<String>, effort: Option<&str>) {
 }
 
 /// Inject the configured effort using the target provider CLI's argument format.
-pub fn inject_provider_effort(command: &str, args: &mut Vec<String>, effort: Option<&str>) {
+///
+/// Codex only supports this override for models with advertised effort levels.
+pub fn inject_provider_effort(
+    command: &str,
+    args: &mut Vec<String>,
+    model_id: Option<&str>,
+    effort: Option<&str>,
+) {
     if agent_command_is_claude(command) {
         inject_claude_effort(args, effort);
-    } else if agent_command_is_codex(command) {
+    } else if agent_command_is_codex(command)
+        && model_id.is_some_and(|id| !effort_levels_for_hub_model(id).is_empty())
+    {
         inject_codex_effort(args, effort);
     }
 }
@@ -1627,6 +1636,31 @@ mod tests {
         let len = args.len();
         inject_codex_effort(&mut args, Some("low"));
         assert_eq!(args.len(), len);
+    }
+
+    #[test]
+    fn provider_effort_only_injects_for_effort_capable_codex_models() {
+        let mut unsupported_args = vec!["exec".into()];
+        inject_provider_effort(
+            "codex",
+            &mut unsupported_args,
+            Some("gpt-5.4"),
+            Some("high"),
+        );
+        assert!(!unsupported_args
+            .iter()
+            .any(|arg| arg.starts_with("model_reasoning_effort=")));
+
+        let mut supported_args = vec!["exec".into()];
+        inject_provider_effort(
+            "codex",
+            &mut supported_args,
+            Some("gpt-5.6-sol"),
+            Some("high"),
+        );
+        assert!(supported_args
+            .iter()
+            .any(|arg| arg == "model_reasoning_effort=high"));
     }
 
     #[test]

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -388,6 +388,18 @@ impl AiHubConfig {
             .or_else(|| provider.models.first().map(|m| m.id.clone()))
     }
 
+    /// Whether any configured provider exposes this model id.
+    pub fn hub_model_exists(&self, model_id: &str) -> bool {
+        self.providers
+            .values()
+            .any(|provider| provider.models.iter().any(|model| model.id == model_id))
+    }
+
+    /// Explicit triage model override, if configured.
+    pub fn triage_model_id(&self) -> Option<&str> {
+        self.reviewer_models.get("triage").map(String::as_str)
+    }
+
     /// Model id for a reviewer kind when spawning (e.g. triage → haiku).
     pub fn resolve_reviewer_model(&self, reviewer_kind: &str, provider_id: &str) -> Option<String> {
         let provider = self.providers.get(provider_id)?;
@@ -500,13 +512,22 @@ pub fn agent_command_is_claude(command: &str) -> bool {
     command == "claude" || command.ends_with("/claude")
 }
 
+/// True when the provider command is the Codex CLI (supports `-c model_reasoning_effort=...`).
+pub fn agent_command_is_codex(command: &str) -> bool {
+    command == "codex" || command.ends_with("/codex")
+}
+
 pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "xhigh", "max"];
 
 const EFFORT_LEVELS_OPUS_46_SONNET: &[&str] = &["low", "medium", "high", "max"];
 
 /// Effort levels supported for an ai_hub model id (empty when effort does not apply).
 pub fn effort_levels_for_hub_model(model_id: &str) -> &'static [&'static str] {
-    if model_id.starts_with("opus-4.7")
+    if model_id.starts_with("sonnet-5")
+        || model_id.contains("sonnet-5")
+        || model_id.starts_with("gpt-5.6-")
+        || model_id.contains("gpt-5-6-")
+        || model_id.starts_with("opus-4.7")
         || model_id.starts_with("opus-4.8")
         || model_id.contains("opus-4-7")
         || model_id.contains("opus-4-8")
@@ -550,6 +571,30 @@ pub fn inject_claude_effort(args: &mut Vec<String>, effort: Option<&str>) {
     }
     args.push("--effort".into());
     args.push(level.to_string());
+}
+
+/// Append Codex's per-invocation reasoning override when not already present.
+pub fn inject_codex_effort(args: &mut Vec<String>, effort: Option<&str>) {
+    let Some(level) = effort.map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    if args
+        .iter()
+        .any(|arg| arg == "model_reasoning_effort" || arg.starts_with("model_reasoning_effort="))
+    {
+        return;
+    }
+    args.push("-c".into());
+    args.push(format!("model_reasoning_effort={level}"));
+}
+
+/// Inject the configured effort using the target provider CLI's argument format.
+pub fn inject_provider_effort(command: &str, args: &mut Vec<String>, effort: Option<&str>) {
+    if agent_command_is_claude(command) {
+        inject_claude_effort(args, effort);
+    } else if agent_command_is_codex(command) {
+        inject_codex_effort(args, effort);
+    }
 }
 
 impl AiModelConfig {
@@ -1049,6 +1094,9 @@ mod tests {
         assert_eq!(codex.models[0].id, "gpt-5.4");
         // The catalog supplements the remaining codex models in-memory.
         assert!(codex.models.iter().any(|m| m.id == "gpt-5.3-codex"));
+        assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-sol"));
+        assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-terra"));
+        assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-luna"));
     }
 
     // ── Default values ──
@@ -1457,6 +1505,8 @@ mod tests {
 
     #[test]
     fn hub_model_effort_levels() {
+        assert!(effort_levels_for_hub_model("sonnet-5").contains(&"xhigh"));
+        assert!(effort_levels_for_hub_model("gpt-5.6-sol").contains(&"max"));
         assert!(effort_levels_for_hub_model("opus-4.8").contains(&"xhigh"));
         assert!(!effort_levels_for_hub_model("opus-4.6").contains(&"xhigh"));
         assert!(effort_levels_for_hub_model("sonnet-4.6").contains(&"max"));
@@ -1469,23 +1519,11 @@ mod tests {
             providers: BTreeMap::from([(
                 "claude".into(),
                 AiProviderConfig {
-                    models: vec![
-                        AiModelConfig {
-                            id: "sonnet-4.6".into(),
-                            label: Some("Sonnet 4.6".into()),
-                            ..Default::default()
-                        },
-                        AiModelConfig {
-                            id: "opus-4.6".into(),
-                            label: Some("Opus 4.6".into()),
-                            ..Default::default()
-                        },
-                        AiModelConfig {
-                            id: "opus-4.7".into(),
-                            label: Some("Opus 4.7".into()),
-                            ..Default::default()
-                        },
-                    ],
+                    models: vec![AiModelConfig {
+                        id: "sonnet-4.6".into(),
+                        label: Some("Sonnet 4.6".into()),
+                        ..Default::default()
+                    }],
                     ..Default::default()
                 },
             )]),
@@ -1496,6 +1534,7 @@ mod tests {
 
         let claude = hub.providers.get("claude").expect("claude provider");
         let ids: Vec<&str> = claude.models.iter().map(|m| m.id.as_str()).collect();
+        assert!(ids.contains(&"sonnet-5"), "missing sonnet-5: {ids:?}");
         assert!(ids.contains(&"opus-4.8"), "missing opus-4.8: {ids:?}");
         assert!(ids.contains(&"haiku-4.5"), "missing haiku-4.5: {ids:?}");
 
@@ -1512,8 +1551,6 @@ mod tests {
 
         // User-defined models and order are preserved.
         assert_eq!(claude.models[0].id, "sonnet-4.6");
-        assert_eq!(claude.models[1].id, "opus-4.6");
-        assert_eq!(claude.models[2].id, "opus-4.7");
     }
 
     #[test]
@@ -1539,6 +1576,39 @@ mod tests {
         let len = args.len();
         inject_claude_effort(&mut args, Some("low"));
         assert_eq!(args.len(), len);
+    }
+
+    #[test]
+    fn inject_codex_effort_idempotent() {
+        let mut args = vec!["exec".into()];
+        inject_codex_effort(&mut args, Some("high"));
+        assert!(args
+            .windows(2)
+            .any(|pair| { pair[0] == "-c" && pair[1] == "model_reasoning_effort=high" }));
+        let len = args.len();
+        inject_codex_effort(&mut args, Some("low"));
+        assert_eq!(args.len(), len);
+    }
+
+    #[test]
+    fn triage_model_override_must_exist_in_hub() {
+        let mut hub = AiHubConfig::default();
+        hub.providers.insert(
+            "claude".into(),
+            AiProviderConfig {
+                models: vec![AiModelConfig {
+                    id: "haiku-4.5".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+        assert!(hub.hub_model_exists("haiku-4.5"));
+        assert!(!hub.hub_model_exists("missing-model"));
+        assert_eq!(hub.triage_model_id(), None);
+        hub.reviewer_models
+            .insert("triage".into(), "haiku-4.5".into());
+        assert_eq!(hub.triage_model_id(), Some("haiku-4.5"));
     }
 
     #[test]

--- a/crates/er-engine/src/config_desktop_settings.rs
+++ b/crates/er-engine/src/config_desktop_settings.rs
@@ -233,6 +233,19 @@ pub fn apply_config_field(config: &mut ErConfig, key: &str, value: ConfigFieldVa
                 config.ai_hub.max_concurrent_reviews = n;
             }
         }
+        "ai_hub.reviewer_models.triage" => {
+            if let ConfigFieldValue::String(v) = value {
+                let model_id = v.trim();
+                if model_id.is_empty() {
+                    config.ai_hub.reviewer_models.remove("triage");
+                } else if config.ai_hub.hub_model_exists(model_id) {
+                    config
+                        .ai_hub
+                        .reviewer_models
+                        .insert("triage".into(), model_id.to_string());
+                }
+            }
+        }
         "watched.diff_mode" => {
             if let ConfigFieldValue::String(v) = value {
                 if v == "content" || v == "snapshot" {
@@ -318,6 +331,56 @@ mod tests {
             ConfigFieldValue::String("high".into()),
         );
         assert_eq!(config.agent.effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn apply_config_field_updates_triage_model_only_when_known() {
+        let mut config = ErConfig::default();
+        config.ai_hub.providers.insert(
+            "claude".into(),
+            crate::config::AiProviderConfig {
+                models: vec![crate::config::AiModelConfig {
+                    id: "haiku-4.5".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+
+        apply_config_field(
+            &mut config,
+            "ai_hub.reviewer_models.triage",
+            ConfigFieldValue::String("haiku-4.5".into()),
+        );
+        assert_eq!(
+            config
+                .ai_hub
+                .reviewer_models
+                .get("triage")
+                .map(String::as_str),
+            Some("haiku-4.5")
+        );
+
+        apply_config_field(
+            &mut config,
+            "ai_hub.reviewer_models.triage",
+            ConfigFieldValue::String("unknown".into()),
+        );
+        assert_eq!(
+            config
+                .ai_hub
+                .reviewer_models
+                .get("triage")
+                .map(String::as_str),
+            Some("haiku-4.5")
+        );
+
+        apply_config_field(
+            &mut config,
+            "ai_hub.reviewer_models.triage",
+            ConfigFieldValue::String(String::new()),
+        );
+        assert!(!config.ai_hub.reviewer_models.contains_key("triage"));
     }
 
     #[test]

--- a/desktop-ui/src/lib/arena/effort.ts
+++ b/desktop-ui/src/lib/arena/effort.ts
@@ -1,4 +1,4 @@
-/** Claude Code effort levels (mirrors er-engine `config::EFFORT_LEVELS`). */
+/** Reasoning effort levels (mirrors er-engine `config::EFFORT_LEVELS`). */
 export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];
@@ -7,6 +7,15 @@ const OPUS_46_SONNET = ["low", "medium", "high", "max"] as const;
 
 /** Effort levels supported for an ai_hub model id (empty when effort does not apply). */
 export function effortLevelsForModel(modelId: string): readonly string[] {
+  if (
+    modelId.startsWith("sonnet-5") ||
+    modelId.includes("sonnet-5") ||
+    modelId.startsWith("gpt-5.6-sol") ||
+    modelId.startsWith("gpt-5.6-terra") ||
+    modelId.startsWith("gpt-5.6-luna")
+  ) {
+    return EFFORT_LEVELS;
+  }
   if (
     modelId.startsWith("opus-4.7") ||
     modelId.startsWith("opus-4.8") ||

--- a/desktop-ui/src/lib/arena/effort.ts
+++ b/desktop-ui/src/lib/arena/effort.ts
@@ -10,9 +10,8 @@ export function effortLevelsForModel(modelId: string): readonly string[] {
   if (
     modelId.startsWith("sonnet-5") ||
     modelId.includes("sonnet-5") ||
-    modelId.startsWith("gpt-5.6-sol") ||
-    modelId.startsWith("gpt-5.6-terra") ||
-    modelId.startsWith("gpt-5.6-luna")
+    modelId.startsWith("gpt-5.6-") ||
+    modelId.includes("gpt-5-6-")
   ) {
     return EFFORT_LEVELS;
   }

--- a/desktop-ui/src/lib/components/AiActionPalette.svelte
+++ b/desktop-ui/src/lib/components/AiActionPalette.svelte
@@ -28,6 +28,7 @@
   let subView = $state<SubView>("main");
   let providers = $state<AiProviderInfo[]>([]);
   let selectedProvider = $state<AiProviderInfo | null>(null);
+  let selectedModelId = $state("");
   let selectedReviewers = $state<Set<string>>(new Set());
   let reviewerHighlight = $state(0);
   let reviewerPickerRef = $state<{ moveHighlight: (d: number) => void; toggleHighlighted: () => void } | null>(null);
@@ -47,6 +48,7 @@
     subView = "main";
     providers = [];
     selectedProvider = null;
+    selectedModelId = "";
     selectedReviewers = new Set();
     reviewerHighlight = 0;
   }
@@ -61,6 +63,7 @@
     subView = "main";
     providers = [];
     selectedProvider = null;
+    selectedModelId = "";
     selectedReviewers = new Set();
     open = true;
   }
@@ -124,6 +127,8 @@
       close();
     } else {
       selectedProvider = provider;
+      selectedModelId =
+        provider.models.find((m) => m.is_selected)?.id ?? provider.models[0]?.id ?? "";
       subView = "models";
       selectedIdx = Math.max(0, provider.models.findIndex((m) => m.is_selected));
     }
@@ -131,8 +136,9 @@
 
   function selectModel(modelId: string) {
     if (!selectedProvider) return;
+    selectedModelId = modelId;
     app.cmd("set_ai_selection", { providerId: selectedProvider.id, modelId: modelId });
-    if (selectedProvider.id !== "claude" || !modelSupportsEffort(modelId)) {
+    if (!modelSupportsEffort(modelId)) {
       close();
     }
   }
@@ -143,16 +149,7 @@
 
   const activeAiLabel = $derived(app.snapshot?.active_ai_label ?? "");
   const activeEffort = $derived(app.snapshot?.active_ai_effort ?? null);
-  const selectedModelId = $derived(
-    selectedProvider?.models.find((m) => m.is_selected)?.id ??
-      selectedProvider?.models[0]?.id ??
-      "",
-  );
-  const effortLevels = $derived(
-    selectedProvider?.id === "claude" && selectedModelId
-      ? effortLevelsForModel(selectedModelId)
-      : [],
-  );
+  const effortLevels = $derived(selectedModelId ? effortLevelsForModel(selectedModelId) : []);
   const showEffortPicker = $derived(subView === "models" && effortLevels.length > 0);
   const reviewerCount = $derived(selectedReviewers.size);
 
@@ -454,11 +451,11 @@
             </button>
           {/each}
         </div>
-        <p class="mt-1.5 text-[10px] text-ink-400">Applies to Claude reviews and arena runs.</p>
+        <p class="mt-1.5 text-[10px] text-ink-400">Applies to Claude and Codex reviews and arena runs.</p>
       </div>
     {/if}
     <div class="py-1">
-      {#each currentItems as item, i}
+      {#each currentItems as item, i (item.label)}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div

--- a/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
+++ b/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
@@ -15,7 +15,7 @@
     modelLabel,
     pickMostExpensiveModel,
   } from "$lib/arena/estimate";
-  import { effortLabel, effortLevelsForModel } from "$lib/arena/effort";
+  import { effortLabel, effortLevelsForModel, modelSupportsEffort } from "$lib/arena/effort";
   import { arenaError, arenaLog, arenaWarn } from "$lib/arena/log";
 
   interface Props {
@@ -123,25 +123,27 @@
   const minReviewers = $derived(isSingleMode ? 1 : 2);
   const maxReviewers = $derived(isSingleMode ? 1 : 6);
 
-  const claudeModelIds = $derived.by(() => {
+  const effortCapableModelIds = $derived.by(() => {
     if (isAgentsMode) {
       const ids: string[] = [];
       for (const g of agentGroups) {
         for (const m of g.models) {
-          if (m.provider_id === "claude") ids.push(m.model_id);
+          if (modelSupportsEffort(m.model_id)) ids.push(m.model_id);
         }
       }
       return ids;
     }
-    return picked.filter((p) => p.provider_id === "claude").map((p) => p.model_id);
+    return picked
+      .map((p) => p.model_id)
+      .filter((modelId) => modelSupportsEffort(modelId));
   });
 
-  const usesClaude = $derived(claudeModelIds.length > 0);
+  const usesEffortCapableModels = $derived(effortCapableModelIds.length > 0);
 
   const effortLevelsForRun = $derived.by(() => {
-    if (claudeModelIds.length === 0) return [] as readonly string[];
-    let levels = [...effortLevelsForModel(claudeModelIds[0]!)];
-    for (const id of claudeModelIds.slice(1)) {
+    if (effortCapableModelIds.length === 0) return [] as readonly string[];
+    let levels = [...effortLevelsForModel(effortCapableModelIds[0]!)];
+    for (const id of effortCapableModelIds.slice(1)) {
       const next = effortLevelsForModel(id);
       levels = levels.filter((l) => next.includes(l));
     }
@@ -155,7 +157,7 @@
   );
 
   function arenaRunEffort(): string | undefined {
-    if (!usesClaude || effortUseGlobal) return undefined;
+    if (!usesEffortCapableModels || effortUseGlobal) return undefined;
     return effortOverride;
   }
   const exceedsCostLimit = $derived(
@@ -590,7 +592,7 @@
         {#each [
           { id: "models" as const, label: "General models", desc: "Same prompt across frontier LLMs" },
           { id: "agents" as const, label: "Specialized agents", desc: "A different agent for each lens" },
-        ] as opt}
+        ] as opt (opt.id)}
           <button
             type="button"
             onclick={() => {
@@ -805,14 +807,14 @@
           {/if}
         {/if}
 
-        {#if usesClaude && effortLevelsForRun.length > 0}
+        {#if usesEffortCapableModels && effortLevelsForRun.length > 0}
           <div
             class="rounded-lg border border-[var(--arena-border)] bg-[var(--arena-bg-0)] px-3 py-2.5 space-y-2"
           >
             <div class="min-w-0">
               <p class="text-[11px] font-medium text-[var(--arena-fg)]">Effort</p>
               <p class="text-[10px] leading-snug text-[var(--arena-fg-subtle)]">
-                Claude reasoning depth for this run
+                Claude and Codex reasoning depth for this run
               </p>
             </div>
             <label class="flex items-center gap-2 text-[11px] text-[var(--arena-fg-muted)]">

--- a/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
+++ b/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
@@ -128,14 +128,23 @@
       const ids: string[] = [];
       for (const g of agentGroups) {
         for (const m of g.models) {
-          if (modelSupportsEffort(m.model_id)) ids.push(m.model_id);
+          if (
+            (m.provider_id === "claude" || m.provider_id === "codex") &&
+            modelSupportsEffort(m.model_id)
+          ) {
+            ids.push(m.model_id);
+          }
         }
       }
       return ids;
     }
     return picked
-      .map((p) => p.model_id)
-      .filter((modelId) => modelSupportsEffort(modelId));
+      .filter(
+        (reviewer) =>
+          (reviewer.provider_id === "claude" || reviewer.provider_id === "codex") &&
+          modelSupportsEffort(reviewer.model_id),
+      )
+      .map((reviewer) => reviewer.model_id);
   });
 
   const usesEffortCapableModels = $derived(effortCapableModelIds.length > 0);

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -84,7 +84,7 @@
     generalFields = res.settings.general;
     terminalFields = res.settings.terminal;
     providers = res.providers;
-    triageModelId = res.triage_model_id ?? "";
+    triageModelId = res.triageModelId ?? "";
     repoRoot = res.settings.repoRoot;
   }
 

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -49,6 +49,9 @@
 
   const selectedProvider = $derived(providers.find((p) => p.is_selected) ?? null);
   const selectedModels = $derived(selectedProvider?.models ?? []);
+  const hasInactiveTriageModel = $derived(
+    triageModelId !== "" && !selectedModels.some((model) => model.id === triageModelId),
+  );
   const triageProviderGroups = $derived(
     selectedProvider && selectedProvider.models.length > 0 ? [selectedProvider] : [],
   );
@@ -389,6 +392,17 @@
                   Override the model used for fast triage reviews on the active provider.
                 </p>
               </div>
+              {#if hasInactiveTriageModel}
+                <div
+                  class="mb-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning"
+                  role="status"
+                >
+                  Saved triage model <code class="font-mono">{triageModelId}</code> is unavailable on
+                  {selectedProvider?.label ?? "the active provider"}. Triage will use the fastest
+                  available model. Choose a model below to replace this inactive override, or “Use fastest
+                  available” to clear it.
+                </div>
+              {/if}
               <button
                 type="button"
                 class="px-2.5 py-1 text-xs rounded-md border transition-colors {triageModelId === ''

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -36,6 +36,7 @@
   let generalFields = $state<ConfigHubField[]>([]);
   let terminalFields = $state<ConfigHubField[]>([]);
   let providers = $state<AiProviderInfo[]>([]);
+  let triageModelId = $state("");
   let repoRoot = $state("");
   let addPattern = $state("");
   let textWarnings = $state<Record<string, string | null>>({});
@@ -48,6 +49,9 @@
 
   const selectedProvider = $derived(providers.find((p) => p.is_selected) ?? null);
   const selectedModels = $derived(selectedProvider?.models ?? []);
+  const triageProviderGroups = $derived(
+    providers.filter((provider) => provider.models.length > 0),
+  );
 
   interface FieldSection {
     title: string | null;
@@ -80,6 +84,7 @@
     generalFields = res.settings.general;
     terminalFields = res.settings.terminal;
     providers = res.providers;
+    triageModelId = res.triage_model_id;
     repoRoot = res.settings.repoRoot;
   }
 
@@ -124,6 +129,10 @@
     if (!p) return;
     await invoke("set_ai_selection", { providerId: p.id, modelId });
     await reload();
+  }
+
+  function selectTriageModel(modelId: string) {
+    void patch("ai_hub.reviewer_models.triage", modelId);
   }
 
   async function saveDefaults() {
@@ -372,6 +381,43 @@
               <div class="mt-2 pt-2 border-t border-hairline/60">
                 <Button onclick={() => void saveDefaults()}>Save as default</Button>
               </div>
+            </div>
+            <div class="bg-card border border-hairline rounded-xl px-4 py-3 mt-3">
+              <div class="mb-3">
+                <p class="text-sm text-fg">Triage model</p>
+                <p class="text-xs text-muted mt-0.5">
+                  Override the model used for fast triage reviews.
+                </p>
+              </div>
+              <button
+                type="button"
+                class="px-2.5 py-1 text-xs rounded-md border transition-colors {triageModelId === ''
+                  ? 'bg-accent-soft text-accent border-accent-border font-medium'
+                  : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
+                onclick={() => selectTriageModel("")}
+              >
+                Use fastest available
+              </button>
+              {#each triageProviderGroups as provider (provider.id)}
+                <div class="mt-3">
+                  <p class="text-[10px] uppercase tracking-wider text-muted font-semibold mb-1.5">
+                    {provider.label}
+                  </p>
+                  <div class="flex flex-wrap gap-1.5">
+                    {#each provider.models as model (model.id)}
+                      <button
+                        type="button"
+                        class="px-2.5 py-1 text-xs rounded-md border transition-colors {triageModelId === model.id
+                          ? 'bg-accent-soft text-accent border-accent-border font-medium'
+                          : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
+                        onclick={() => selectTriageModel(model.id)}
+                      >
+                        {model.label}
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              {/each}
             </div>
           {:else}
             <div class="border border-dashed border-border rounded-xl px-6 py-8 text-center">

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -50,7 +50,7 @@
   const selectedProvider = $derived(providers.find((p) => p.is_selected) ?? null);
   const selectedModels = $derived(selectedProvider?.models ?? []);
   const triageProviderGroups = $derived(
-    providers.filter((provider) => provider.models.length > 0),
+    selectedProvider && selectedProvider.models.length > 0 ? [selectedProvider] : [],
   );
 
   interface FieldSection {
@@ -386,7 +386,7 @@
               <div class="mb-3">
                 <p class="text-sm text-fg">Triage model</p>
                 <p class="text-xs text-muted mt-0.5">
-                  Override the model used for fast triage reviews.
+                  Override the model used for fast triage reviews on the active provider.
                 </p>
               </div>
               <button

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -84,7 +84,7 @@
     generalFields = res.settings.general;
     terminalFields = res.settings.terminal;
     providers = res.providers;
-    triageModelId = res.triage_model_id;
+    triageModelId = res.triage_model_id ?? "";
     repoRoot = res.settings.repoRoot;
   }
 

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -662,6 +662,7 @@ export interface DesktopSettingsSnapshot {
 export interface GetConfigHubResponse {
   settings: DesktopSettingsSnapshot;
   providers: AiProviderInfo[];
+  triage_model_id: string;
 }
 
 export interface FeatureFlagsSnapshot {

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -662,7 +662,7 @@ export interface DesktopSettingsSnapshot {
 export interface GetConfigHubResponse {
   settings: DesktopSettingsSnapshot;
   providers: AiProviderInfo[];
-  triage_model_id: string | null;
+  triageModelId: string | null;
 }
 
 export interface FeatureFlagsSnapshot {

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -662,7 +662,7 @@ export interface DesktopSettingsSnapshot {
 export interface GetConfigHubResponse {
   settings: DesktopSettingsSnapshot;
   providers: AiProviderInfo[];
-  triage_model_id: string;
+  triage_model_id: string | null;
 }
 
 export interface FeatureFlagsSnapshot {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -65,7 +65,7 @@ Optional runtime provider/model presets for the AI Hub. When present, AI Hub act
 ```toml
 [ai_hub]
 default_provider = "claude"
-default_model = "sonnet-4.6"
+default_model = "sonnet-5"
 
 [ai_hub.reviewer_models]
 triage = "haiku-4.5"
@@ -81,14 +81,9 @@ label = "Sonnet 4.6"
 args = ["--model", "claude-sonnet-4-6"]
 
 [[ai_hub.providers.claude.models]]
-id = "opus-4.6"
-label = "Opus 4.6"
-args = ["--model", "claude-opus-4-6"]
-
-[[ai_hub.providers.claude.models]]
-id = "opus-4.7"
-label = "Opus 4.7"
-args = ["--model", "claude-opus-4-7"]
+id = "sonnet-5"
+label = "Sonnet 5"
+args = ["--model", "claude-sonnet-5"]
 
 [[ai_hub.providers.claude.models]]
 id = "opus-4.8"
@@ -110,6 +105,21 @@ id = "gpt-5.4"
 label = "GPT-5.4"
 args = ["--model", "gpt-5.4"]
 
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-sol"
+label = "GPT-5.6 Sol"
+args = ["--model", "gpt-5.6-sol"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-terra"
+label = "GPT-5.6 Terra"
+args = ["--model", "gpt-5.6-terra"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.6-luna"
+label = "GPT-5.6 Luna"
+args = ["--model", "gpt-5.6-luna"]
+
 [ai_hub.providers.cursor]
 label = "Cursor"
 command = "agent"
@@ -128,6 +138,7 @@ Rules:
 - On load, `er` merges any missing built-in catalog models (e.g. new Opus releases) into your config in memory without rewriting your TOML file.
 - The selected provider/model applies to AI Hub actions such as review, triage, experts, professor, questions, and summary.
 - `[ai_hub.reviewer_models]` overrides the hub model for specific reviewer kinds. Triage uses `triage = "haiku-4.5"` by default in the example config; when unset, triage falls back to the fastest model in the active provider list.
+- Claude and GPT-5.6 models support `default_effort`; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>`.
 
 ### `[watched]`
 

--- a/docs/guide/configuration.html
+++ b/docs/guide/configuration.html
@@ -96,7 +96,7 @@ args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"--outp
     </p>
     <pre><code>[ai_hub]
 default_provider = <span class="tok-str">"claude"</span>
-default_model    = <span class="tok-str">"sonnet-4.6"</span>
+default_model    = <span class="tok-str">"sonnet-5"</span>
 default_effort   = <span class="tok-str">"medium"</span>  <span class="cmt"># reasoning effort passed to providers that support it</span>
 max_concurrent_reviews = <span class="tok-key">3</span>  <span class="cmt"># queue further reviews beyond this many at once (1–16)</span>
 
@@ -109,9 +109,9 @@ command = <span class="tok-str">"claude"</span>
 args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"-p"</span>, <span class="tok-str">"{prompt}"</span>]
 
 [[ai_hub.providers.claude.models]]
-id    = <span class="tok-str">"sonnet-4.6"</span>
-label = <span class="tok-str">"Sonnet 4.6"</span>
-args  = [<span class="tok-str">"--model"</span>, <span class="tok-str">"claude-sonnet-4-6"</span>]
+id    = <span class="tok-str">"sonnet-5"</span>
+label = <span class="tok-str">"Sonnet 5"</span>
+args  = [<span class="tok-str">"--model"</span>, <span class="tok-str">"claude-sonnet-5"</span>]
 <span class="cmt"># optional metadata: description, cost_per_1k_in, cost_per_1k_out, avg_latency_ms</span></code></pre>
     <ul>
       <li>If <code>[ai_hub]</code> is absent, <code>er</code> falls back to the single <code>[agent]</code> config.</li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Claude Sonnet 5 and GPT-5.6 Sol, Terra, and Luna to the AI Hub catalog.
- Add Codex reasoning-effort injection and desktop effort selection for supported Claude and Codex models.
- Add Desktop Settings triage-model selection and refresh examples, docs, and release notes.

## Validation
- Pending engine and frontend checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8627f45c-a073-488c-ba9e-045699fad90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8627f45c-a073-488c-ba9e-045699fad90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

