### PR TITLE
fix(desktop): copy linked worktree path in branch context bar

### DIFF
--- a/desktop-ui/src/App.svelte
+++ b/desktop-ui/src/App.svelte
@@ -31,6 +31,7 @@
   import ExportReviewView from "$lib/components/ExportReviewView.svelte";
   import SettingsPage from "$lib/components/settings/SettingsPage.svelte";
   import { browser } from "$lib/stores/browser.svelte";
+  import { resolveTabRoot } from "$lib/resolveTabRoot";
   import { browserHide } from "$lib/stores/browserHost";
   import { installExternalLinkGuard } from "$lib/openExternalUrl";
   import { startWindowDrag } from "$lib/windowDrag";
@@ -209,11 +210,7 @@
 
   const activeTabIdx = $derived(app.snapshot?.active_tab ?? 0);
   const activeTab = $derived(app.snapshot?.tabs?.[activeTabIdx]);
-  const activeTabRoot = $derived(
-    app.snapshot?.worktrees?.find((w) => w.branch === activeTab?.branch)?.path ??
-      activeTab?.repo_root ??
-      "",
-  );
+  const activeTabRoot = $derived(resolveTabRoot(app.snapshot, activeTab));
 
   $effect(() => {
     app.snapshot;

--- a/desktop-ui/src/lib/components/BranchContextBar.svelte
+++ b/desktop-ui/src/lib/components/BranchContextBar.svelte
@@ -5,6 +5,7 @@
   import { terminal } from "$lib/stores/terminal.svelte";
   import { copyToClipboard } from "$lib/clipboard";
   import { resolveActivePrUrl } from "$lib/prUrl";
+  import { resolveTabRoot } from "$lib/resolveTabRoot";
   import { openExternalUrl } from "$lib/openExternalUrl";
 
   const snapshot = $derived(app.snapshot);
@@ -82,8 +83,8 @@
   }
 
   /** Resolved local worktree path for the active tab. Remote-only PR tabs
-   *  have no local checkout, so `repo_root` is empty and the button hides. */
-  const worktreePath = $derived(activeTab?.repo_root?.trim() || null);
+   *  have no local checkout, so the resolved path is empty and the button hides. */
+  const worktreePath = $derived(resolveTabRoot(snapshot, activeTab) || null);
 
   async function handleWorktreeClick(e: MouseEvent) {
     const path = worktreePath;

--- a/desktop-ui/src/lib/resolveTabRoot.test.ts
+++ b/desktop-ui/src/lib/resolveTabRoot.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { resolveTabRoot } from "./resolveTabRoot";
+import type { AppSnapshot, TabSummary } from "./types";
+
+const tab = (overrides: Partial<TabSummary> = {}): TabSummary => ({
+  idx: 0,
+  label: "feat",
+  kind: "local_branch",
+  branch: "feat",
+  pr_number: null,
+  repo_root: "/Users/me/Projects/discovery",
+  is_active: true,
+  change_token: "",
+  ...overrides,
+});
+
+function minimalSnapshot(overrides: Partial<AppSnapshot>): AppSnapshot {
+  return {
+    mode: "branch",
+    branch: "feat",
+    base: "main",
+    input_mode: "normal",
+    files: [],
+    selected_file: 0,
+    current_hunk: null,
+    filter: null,
+    reviewed_count: 0,
+    total_count: 0,
+    ai: {
+      fresh: true,
+      stale_reason: null,
+      summary_markdown: null,
+      agent_summaries: {},
+      high: 0,
+      med: 0,
+      low: 0,
+      local_comment_count: 0,
+      github_comment_count: 0,
+      comments: 0,
+      questions: 0,
+      unpushed: 0,
+      threads: [],
+      findings: [],
+      has_review_json: false,
+      eligible_comment_count: 0,
+      triage: null,
+    },
+    pr: null,
+    panels: { left: true, tree: true, right: true },
+    theme: "dark",
+    watch_active: false,
+    watch_status: { active: false, branch: null, root_path: null },
+    worktrees: [],
+    projects: [],
+    local_branch: null,
+    notification: null,
+    tabs: [],
+    active_tab: 0,
+    bg_loading: { pr_list: false, gh_status: false, gh_comments: false },
+    ...overrides,
+  };
+}
+
+describe("resolveTabRoot", () => {
+  it("prefers the linked worktree path for the viewed branch", () => {
+    const snapshot = minimalSnapshot({
+      branch: "vilfred+dev-6490-1-frontend-and-backend-mock",
+      worktrees: [
+        {
+          path: "/Users/me/Projects/discovery",
+          branch: "main",
+          is_current: true,
+          is_pr: false,
+          pr_number: null,
+          is_merged: false,
+        },
+        {
+          path: "/Users/me/Projects/discovery/.claude/worktrees/vilfred+dev-6490-1-frontend-and-backend-mock",
+          branch: "vilfred+dev-6490-1-frontend-and-backend-mock",
+          is_current: false,
+          is_pr: true,
+          pr_number: 6490,
+          is_merged: false,
+        },
+      ],
+    });
+    const active = tab({
+      branch: "vilfred+dev-6490-1-frontend-and-backend-mock",
+      repo_root: "/Users/me/Projects/discovery",
+    });
+
+    expect(resolveTabRoot(snapshot, active)).toBe(
+      "/Users/me/Projects/discovery/.claude/worktrees/vilfred+dev-6490-1-frontend-and-backend-mock",
+    );
+  });
+
+  it("falls back to repo_root when no worktree matches", () => {
+    const snapshot = minimalSnapshot({ branch: "feat", worktrees: [] });
+    expect(resolveTabRoot(snapshot, tab())).toBe("/Users/me/Projects/discovery");
+  });
+
+  it("returns empty string for remote-only tabs", () => {
+    const snapshot = minimalSnapshot({ branch: "dependabot/foo", worktrees: [] });
+    const active = tab({
+      kind: "remote_pr",
+      branch: null,
+      repo_root: "",
+    });
+    expect(resolveTabRoot(snapshot, active)).toBe("");
+  });
+});

--- a/desktop-ui/src/lib/resolveTabRoot.ts
+++ b/desktop-ui/src/lib/resolveTabRoot.ts
@@ -1,0 +1,15 @@
+import type { AppSnapshot, TabSummary } from "./types";
+
+/** Resolved filesystem root for the active tab: the linked worktree path when
+ *  the viewed branch is checked out in one, otherwise the tab's `repo_root`. */
+export function resolveTabRoot(
+  snapshot: AppSnapshot | null | undefined,
+  activeTab: TabSummary | undefined,
+): string {
+  const branch = snapshot?.branch ?? activeTab?.branch ?? null;
+  const fromWorktree =
+    branch != null
+      ? snapshot?.worktrees?.find((w) => w.branch === branch)?.path
+      : undefined;
+  return fromWorktree?.trim() || activeTab?.repo_root?.trim() || "";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking the copy-worktree button in the branch context bar copied the project root (`repo_root`) instead of the linked worktree where the viewed branch is checked out.

Example:
- **Received:** `/Users/.../discovery`
- **Expected:** `/Users/.../discovery/.claude/worktrees/vilfred+dev-6490-1-frontend-and-backend-mock`

## Fix

Introduce `resolveTabRoot()` to look up the viewed branch in `snapshot.worktrees` and return its filesystem path, falling back to `repo_root` when no linked worktree exists.

Use this helper in:
- `BranchContextBar.svelte` (copy/reveal worktree button)
- `App.svelte` (terminal cwd — refactored to share the same logic)

## Tests

- Added `resolveTabRoot.test.ts` covering linked worktree resolution, repo_root fallback, and remote-only tabs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0895b42a-f3e5-424e-b680-5d10fc6783c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0895b42a-f3e5-424e-b680-5d10fc6783c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

