### PR TITLE
docs: mark desktop .dmg direct download as coming soon

### DIFF
--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -62,27 +62,28 @@ er</code></pre>
     <h2 id="desktop-app">Desktop app <span class="pill desktop">desktop</span></h2>
     <div class="callout note">
       <span class="ico">◆</span>
-      <div><p>A prebuilt macOS bundle now ships with releases. As of <strong>v0.4.0</strong>, the
-      <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener">Releases page</a>
-      includes an <strong>Apple&nbsp;Silicon</strong> <code>.dmg</code> (e.g. <code>Easy.Review_0.4.0_aarch64.dmg</code>).
-      Intel Macs, Linux, and Windows are not packaged yet — build those from source (below). The install script and
-      <code>cargo install</code> only cover the <code>er</code> terminal binary.</p></div>
+      <div><p>The desktop app is installed by <a href="#install-from-source">building from source</a> (below). A signed
+      direct-download <code>.dmg</code> is <strong>coming soon</strong> — distributing one requires an Apple Developer
+      Program membership for code signing and notarization. The install script and <code>cargo install</code> only cover
+      the <code>er</code> terminal binary.</p></div>
     </div>
 
-    <h3>Install the macOS bundle <span class="pill desktop">Apple Silicon</span></h3>
-    <p>Download the <code>.dmg</code> from the
-    <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener">latest release</a>,
-    open it, and drag <strong>Easy Review</strong> into Applications. The bundle is not yet code-signed, so the first
-    time you launch it macOS may block it as being from an unidentified developer — right-click the app and choose
-    <strong>Open</strong> to bypass Gatekeeper once.</p>
+    <h3>Direct download <span class="pill desktop">Coming soon</span></h3>
+    <p>A prebuilt, code-signed <code>.dmg</code> for <strong>Apple&nbsp;Silicon</strong> Macs will be offered on the
+    <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener">Releases page</a>
+    once signing is set up. Until then, clone the repository and build locally (next section). Intel Macs, Linux, and
+    Windows are not planned as prebuilt downloads — build those from source as well.</p>
 
-    <h3>Run in development</h3>
+    <h3 id="install-from-source">Install from source</h3>
+    <p>Clone the repo and run the desktop app in development, or build a release bundle for your machine:</p>
+
+    <h4>Run in development</h4>
     <pre><code>git clone https://github.com/VilfredSikker/easy-review.git
 cd easy-review
 ./scripts/tauri-dev.sh</code></pre>
     <p>This launches the Tauri dev shell with the Svelte frontend and hot reload.</p>
 
-    <h3>Build a release bundle</h3>
+    <h4>Build a release bundle</h4>
     <pre><code>./scripts/tauri-build.sh</code></pre>
     <p>On macOS this produces an <code>Easy Review.app</code> under the desktop build target (set
     <code>ER_SKIP_DMG=0</code> to also produce a <code>.dmg</code>). Building requires <code>cargo-tauri</code> and

--- a/docs/guide/troubleshooting.html
+++ b/docs/guide/troubleshooting.html
@@ -121,9 +121,11 @@
 
     <h3>Is the desktop app released?</h3>
     <p>
-      Yes, for Apple Silicon Macs — releases include a prebuilt <code>.dmg</code> alongside the <code>er</code>
-      terminal binaries. Other platforms build from source with <code>./scripts/tauri-dev.sh</code> or
-      <code>./scripts/tauri-build.sh</code>. See <a href="installation.html#desktop-app">Installation → Desktop app</a>.
+      The desktop app is available by building from source with <code>./scripts/tauri-dev.sh</code> or
+      <code>./scripts/tauri-build.sh</code>. A signed direct-download <code>.dmg</code> is coming soon; until then,
+      see <a href="installation.html#install-from-source">Installation → Install from source</a>. The
+      <code>er</code> terminal binary ships as a prebuilt release on the
+      <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener">Releases page</a>.
     </p>
 
     <h3>How do I report a bug or request a feature?</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1499,9 +1499,10 @@
         Requires <span class="text-text-dim">git</span>; building from source needs <span class="text-text-dim">Rust 1.85+</span>. Single binary, no runtime dependencies.
       </p>
       <p class="reveal-up text-sm text-text-muted mt-3">
-        Prefer a GUI? Grab the desktop app's prebuilt Apple Silicon <code class="text-text-dim">.dmg</code> from the
-        <a href="https://github.com/VilfredSikker/easy-review/releases" target="_blank" rel="noopener" class="text-accent hover:underline">Releases page</a> —
-        see the <a href="guide/installation.html#desktop-app" class="text-accent hover:underline">Desktop install guide</a> for details (and building from source on other platforms).
+        Prefer a GUI? Install the desktop app from source — a signed direct-download <code class="text-text-dim">.dmg</code> is
+        <strong>coming soon</strong>. See the
+        <a href="guide/installation.html#install-from-source" class="text-accent hover:underline">Desktop install guide</a>
+        for clone-and-build steps.
       </p>
     </div>
   </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the installation guide (and related docs) to reflect that a signed macOS `.dmg` direct download is not available yet.

## Changes

- **Installation guide** (`docs/guide/installation.html`): Replaces the "download the .dmg" instructions with a **Coming soon** section explaining that Apple Developer signing/notarization is required. Promotes **Install from source** as the current path (`git clone` + `./scripts/tauri-dev.sh` or `./scripts/tauri-build.sh`).
- **Troubleshooting** and **landing page**: Align copy so they no longer claim a prebuilt `.dmg` ships with releases.

The terminal `er` binary install path is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74fa0af4-cc5d-42c3-ac4a-cbfe9b979946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74fa0af4-cc5d-42c3-ac4a-cbfe9b979946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

