### PR TITLE
feat: refresh AI model catalog and effort settings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## AI Hub model refresh
 
-- Added Claude Sonnet 5 and GPT-5.6 Sol, Terra, and Luna to the built-in AI Hub catalog.
-- Removed Opus 4.6 and Opus 4.7 from the built-in catalog; existing user-defined entries remain untouched.
-- Added model-aware reasoning-effort controls for GPT-5.6 Codex runs, including arena overrides.
+- Refreshed the built-in catalog with Claude Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, the GPT-5.6 Sol/Terra/Luna family, GPT-5.5, GPT-5.4, GPT-5.4 Mini, and GPT-5.3 Codex Spark.
+- Deprecated built-in entries are no longer advertised; existing user-defined or persisted legacy entries remain untouched.
+- Added model metadata-driven effort/reasoning controls across Desktop, TUI, the action palette, and Arena. `Auto` omits provider overrides.
+- Added atomic global persistence for provider, model, and effort selections, plus validation before Claude/Codex invocation.
 - Added a triage-model picker in Desktop Settings, with a reset to the fastest available model.
 
 # Easy Review v0.4.2

--- a/config.toml.example
+++ b/config.toml.example
@@ -46,6 +46,8 @@ args    = ["--print", "--output-format", "stream-json", "-p", "{prompt}"]
 [ai_hub]
 default_provider = "claude"
 default_model = "sonnet-5"
+# Optional global effort/reasoning override; omit or use Auto in the UI for provider default.
+# default_effort = "high"
 
 [ai_hub.reviewer_models]
 triage = "haiku-4.5"
@@ -56,10 +58,11 @@ command = "claude"
 args = ["--print", "-p", "{prompt}"]
 
 [[ai_hub.providers.claude.models]]
-id = "sonnet-4.6"
-label = "Sonnet 4.6"
-description = "Balanced quality + speed"
-args = ["--model", "claude-sonnet-4-6"]
+id = "fable-5"
+label = "Fable 5"
+description = "Frontier reasoning · maximum depth"
+args = ["--model", "claude-fable-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.003
 cost_per_1k_out = 0.015
 avg_latency_ms = 12000
@@ -69,6 +72,7 @@ id = "sonnet-5"
 label = "Sonnet 5"
 description = "Best speed + intelligence · 1M context"
 args = ["--model", "claude-sonnet-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.002
 cost_per_1k_out = 0.010
 avg_latency_ms = 12000
@@ -78,6 +82,7 @@ id = "opus-4.8"
 label = "Opus 4.8"
 description = "Latest frontier · 1M context"
 args = ["--model", "claude-opus-4-8"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.025
 avg_latency_ms = 24000
@@ -87,6 +92,7 @@ id = "haiku-4.5"
 label = "Haiku 4.5"
 description = "Fast & cheap · good for noise"
 args = ["--model", "claude-haiku-4-5-20251001"]
+effort_levels = []
 cost_per_1k_in = 0.001
 cost_per_1k_out = 0.005
 avg_latency_ms = 5000
@@ -101,17 +107,9 @@ id = "gpt-5.4"
 label = "GPT-5.4"
 description = "Strong general · lower cost"
 args = ["--model", "gpt-5.4"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 cost_per_1k_in = 0.0025
 cost_per_1k_out = 0.015
-avg_latency_ms = 14000
-
-[[ai_hub.providers.codex.models]]
-id = "gpt-5.3-codex"
-label = "GPT-5.3 Codex"
-description = "Agentic coding specialist"
-args = ["--model", "gpt-5.3-codex"]
-cost_per_1k_in = 0.00175
-cost_per_1k_out = 0.014
 avg_latency_ms = 14000
 
 [[ai_hub.providers.codex.models]]
@@ -119,6 +117,7 @@ id = "gpt-5.5"
 label = "GPT-5.5"
 description = "Best-in-class general"
 args = ["--model", "gpt-5.5"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 18000
@@ -128,6 +127,7 @@ id = "gpt-5.6-sol"
 label = "GPT-5.6 Sol"
 description = "Flagship reasoning · detail + polish"
 args = ["--model", "gpt-5.6-sol"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 20000
@@ -137,6 +137,7 @@ id = "gpt-5.6-terra"
 label = "GPT-5.6 Terra"
 description = "Strong everyday coding + tool use"
 args = ["--model", "gpt-5.6-terra"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.0025
 cost_per_1k_out = 0.015
 avg_latency_ms = 14000
@@ -146,9 +147,24 @@ id = "gpt-5.6-luna"
 label = "GPT-5.6 Luna"
 description = "Fast, efficient repeatable work"
 args = ["--model", "gpt-5.6-luna"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.001
 cost_per_1k_out = 0.005
 avg_latency_ms = 8000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.4-mini"
+label = "GPT-5.4 Mini"
+description = "Fast, efficient coding"
+args = ["--model", "gpt-5.4-mini"]
+effort_levels = ["low", "medium", "high", "xhigh"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.3-codex-spark"
+label = "GPT-5.3 Codex Spark"
+description = "Fast coding specialist"
+args = ["--model", "gpt-5.3-codex-spark"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 
 [ai_hub.providers.cursor]
 label = "Cursor"

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3580,6 +3580,7 @@ pub struct AiModelInfo {
     pub cost_per_1k_out: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avg_latency_ms: Option<u32>,
+    pub effort_levels: Vec<String>,
 }
 
 #[tauri::command]
@@ -3611,6 +3612,7 @@ pub fn list_ai_providers(state: State<AppState>) -> Result<Vec<AiProviderInfo>, 
                         cost_per_1k_in: m.cost_per_1k_in,
                         cost_per_1k_out: m.cost_per_1k_out,
                         avg_latency_ms: m.avg_latency_ms,
+                        effort_levels: m.effort_levels.clone(),
                     })
                     .collect(),
             }
@@ -3641,8 +3643,15 @@ pub fn set_ai_selection(
         }
     }
 
+    let normalized_effort = er_engine::config::normalize_effort(
+        &app.config.ai_hub,
+        Some(&provider_id),
+        model_id.as_deref(),
+        app.current_ai_effort.as_deref(),
+    );
     app.current_ai_provider = Some(provider_id);
     app.current_ai_model = model_id;
+    app.current_ai_effort = normalized_effort;
 
     state
         .desktop_revision
@@ -3656,9 +3665,24 @@ pub fn set_ai_effort(
     state: State<AppState>,
 ) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
-    let normalized = effort
-        .map(|e| e.trim().to_string())
-        .filter(|e| !e.is_empty());
+    let provider_id = app
+        .config
+        .ai_hub
+        .resolve_provider_id(app.current_ai_provider.as_deref());
+    let model_id = provider_id.as_deref().and_then(|provider| {
+        app.config
+            .ai_hub
+            .resolve_model_id(provider, app.current_ai_model.as_deref())
+    });
+    let normalized = er_engine::config::normalize_effort(
+        &app.config.ai_hub,
+        provider_id.as_deref(),
+        model_id.as_deref(),
+        effort.as_deref(),
+    );
+    if effort.is_some() && normalized.is_none() {
+        return Err("Effort is unsupported for the selected model".into());
+    }
     app.current_ai_effort = normalized.clone();
     app.config.ai_hub.default_effort = normalized;
     er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -22,6 +22,8 @@ pub struct GetConfigHubResponse {
     pub settings: DesktopSettingsSnapshot,
     pub providers: Vec<AiProviderInfo>,
     pub triage_model_id: Option<String>,
+    pub active_effort: Option<String>,
+    pub default_effort: Option<String>,
 }
 
 fn feature_allows_mode(features: &FeatureFlags, mode: DiffMode) -> bool {
@@ -90,11 +92,30 @@ fn list_providers_inner(app: &er_engine::app::App) -> Vec<AiProviderInfo> {
                         cost_per_1k_in: m.cost_per_1k_in,
                         cost_per_1k_out: m.cost_per_1k_out,
                         avg_latency_ms: m.avg_latency_ms,
+                        effort_levels: m.effort_levels.clone(),
                     })
                     .collect(),
             }
         })
         .collect()
+}
+
+fn normalized_default_effort(app: &er_engine::app::App) -> Option<String> {
+    let provider = app
+        .config
+        .ai_hub
+        .resolve_provider_id(app.config.ai_hub.default_provider.as_deref());
+    let model = provider.as_deref().and_then(|id| {
+        app.config
+            .ai_hub
+            .resolve_model_id(id, app.config.ai_hub.default_model.as_deref())
+    });
+    er_engine::config::normalize_effort(
+        &app.config.ai_hub,
+        provider.as_deref(),
+        model.as_deref(),
+        app.config.ai_hub.default_effort.as_deref(),
+    )
 }
 
 #[tauri::command]
@@ -107,6 +128,8 @@ pub fn get_config_hub(state: State<AppState>) -> Result<GetConfigHubResponse, St
         settings,
         providers,
         triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
+        active_effort: app.current_ai_effort.clone(),
+        default_effort: normalized_default_effort(&app),
     })
 }
 
@@ -129,6 +152,8 @@ pub fn apply_config_patch(
         settings,
         providers,
         triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
+        active_effort: app.current_ai_effort.clone(),
+        default_effort: normalized_default_effort(&app),
     })
 }
 
@@ -149,6 +174,7 @@ pub fn save_config_global_cmd(state: State<AppState>) -> Result<AppSnapshot, Str
 pub fn set_ai_hub_defaults(
     provider_id: String,
     model_id: Option<String>,
+    effort: Option<String>,
     state: State<AppState>,
 ) -> Result<GetConfigHubResponse, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
@@ -163,10 +189,21 @@ pub fn set_ai_hub_defaults(
             ));
         }
     }
+    let normalized_effort = er_engine::config::normalize_effort(
+        &app.config.ai_hub,
+        Some(&provider_id),
+        model_id.as_deref(),
+        effort.as_deref(),
+    );
+    if effort.is_some() && normalized_effort.is_none() {
+        return Err("Effort is unsupported for the selected model".into());
+    }
     app.config.ai_hub.default_provider = Some(provider_id.clone());
     app.config.ai_hub.default_model = model_id.clone();
+    app.config.ai_hub.default_effort = normalized_effort.clone();
     app.current_ai_provider = Some(provider_id);
     app.current_ai_model = model_id;
+    app.current_ai_effort = normalized_effort;
     save_config(&app.config).map_err(|e| e.to_string())?;
     let repo_root = app.tab().repo_root.clone();
     state
@@ -178,5 +215,7 @@ pub fn set_ai_hub_defaults(
         settings,
         providers,
         triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
+        active_effort: app.current_ai_effort.clone(),
+        default_effort: normalized_default_effort(&app),
     })
 }

--- a/crates/er-engine/src/agent_runtime.rs
+++ b/crates/er-engine/src/agent_runtime.rs
@@ -4,7 +4,7 @@ use crate::ai::{
     ErChecklist, ErGitHubComments, ErOrder, ErQuestions, ErReview, ErTour, ExpertReview,
     ProfessorReview, TriageReview,
 };
-use crate::config::{inject_provider_effort, resolve_effort, ErConfig};
+use crate::config::{inject_provider_effort, ErConfig};
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
@@ -227,7 +227,7 @@ pub fn resolve_invocation(
     config: &ErConfig,
     request: AgentInvocationRequest<'_>,
 ) -> Result<AgentInvocation> {
-    let (command, mut args, resolved_model_id) = match request.selection {
+    let (command, mut args, resolved_provider_id, resolved_model_id) = match request.selection {
         AgentSelection::Runtime {
             provider_id,
             model_id,
@@ -254,11 +254,12 @@ pub fn resolve_invocation(
                         args.extend(model.args.clone());
                     }
                 }
-                (provider.command.clone(), args, resolved_model)
+                (provider.command.clone(), args, Some(pid), resolved_model)
             } else {
                 (
                     config.agent.command.clone(),
                     config.agent.args.clone(),
+                    None,
                     (!config.agent.model.is_empty()).then(|| config.agent.model.clone()),
                 )
             }
@@ -279,7 +280,7 @@ pub fn resolve_invocation(
                 .with_context(|| format!("unknown model {model_id} for provider {provider_id}"))?;
             let mut args = provider.args.clone();
             args.extend(model.args.clone());
-            (provider.command.clone(), args, Some(model_id.to_string()))
+            (provider.command.clone(), args, Some(provider_id.to_string()), Some(model_id.to_string()))
         }
     };
 
@@ -293,9 +294,11 @@ pub fn resolve_invocation(
         }
     }
     if matches!(family, CliFamily::Claude | CliFamily::Codex) {
-        let effort = resolve_effort(
+        let effort = crate::config::resolve_effort_for_model(
             &config.ai_hub,
             &config.agent,
+            resolved_provider_id.as_deref(),
+            resolved_model_id.as_deref(),
             request.effort,
             request.effort_override,
         );
@@ -870,7 +873,7 @@ mod tests {
             AgentInvocationRequest {
                 selection: AgentSelection::Runtime {
                     provider_id: Some("claude"),
-                    model_id: Some("sonnet-4.6"),
+                    model_id: Some("sonnet-5"),
                     task_aware: true,
                 },
                 task: &task,
@@ -909,7 +912,7 @@ mod tests {
             AgentInvocationRequest {
                 selection: AgentSelection::Exact {
                     provider_id: "codex",
-                    model_id: "gpt-5.3-codex",
+                    model_id: "gpt-5.4",
                 },
                 task: &task,
                 effort: None,
@@ -923,7 +926,7 @@ mod tests {
         assert!(has_option_value(
             &invocation.args,
             "--model",
-            "gpt-5.3-codex"
+            "gpt-5.4"
         ));
         assert!(!invocation.args.iter().any(|arg| arg == "--add-dir"));
     }

--- a/crates/er-engine/src/ai_hub_catalog.toml
+++ b/crates/er-engine/src/ai_hub_catalog.toml
@@ -12,19 +12,21 @@ command = "claude"
 args = ["--print", "-p", "{prompt}"]
 
 [[ai_hub.providers.claude.models]]
-id = "sonnet-4.6"
-label = "Sonnet 4.6"
-description = "Balanced quality + speed"
-args = ["--model", "claude-sonnet-4-6"]
-cost_per_1k_in = 0.003
-cost_per_1k_out = 0.015
-avg_latency_ms = 12000
+id = "fable-5"
+label = "Fable 5"
+description = "Frontier reasoning · maximum depth"
+args = ["--model", "claude-fable-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
+cost_per_1k_in = 0.005
+cost_per_1k_out = 0.025
+avg_latency_ms = 24000
 
 [[ai_hub.providers.claude.models]]
 id = "sonnet-5"
 label = "Sonnet 5"
 description = "Best speed + intelligence · 1M context"
 args = ["--model", "claude-sonnet-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.002
 cost_per_1k_out = 0.010
 avg_latency_ms = 12000
@@ -34,6 +36,7 @@ id = "opus-4.8"
 label = "Opus 4.8"
 description = "Latest frontier · 1M context"
 args = ["--model", "claude-opus-4-8"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.025
 avg_latency_ms = 24000
@@ -43,6 +46,7 @@ id = "haiku-4.5"
 label = "Haiku 4.5"
 description = "Fast & cheap · good for noise"
 args = ["--model", "claude-haiku-4-5-20251001"]
+effort_levels = []
 cost_per_1k_in = 0.001
 cost_per_1k_out = 0.005
 avg_latency_ms = 5000
@@ -57,17 +61,9 @@ id = "gpt-5.4"
 label = "GPT-5.4"
 description = "Strong general · lower cost"
 args = ["--model", "gpt-5.4"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 cost_per_1k_in = 0.0025
 cost_per_1k_out = 0.015
-avg_latency_ms = 14000
-
-[[ai_hub.providers.codex.models]]
-id = "gpt-5.3-codex"
-label = "GPT-5.3 Codex"
-description = "Agentic coding specialist"
-args = ["--model", "gpt-5.3-codex"]
-cost_per_1k_in = 0.00175
-cost_per_1k_out = 0.014
 avg_latency_ms = 14000
 
 [[ai_hub.providers.codex.models]]
@@ -75,6 +71,7 @@ id = "gpt-5.5"
 label = "GPT-5.5"
 description = "Best-in-class general"
 args = ["--model", "gpt-5.5"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 18000
@@ -84,6 +81,7 @@ id = "gpt-5.6-sol"
 label = "GPT-5.6 Sol"
 description = "Flagship reasoning · detail + polish"
 args = ["--model", "gpt-5.6-sol"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.005
 cost_per_1k_out = 0.030
 avg_latency_ms = 20000
@@ -93,6 +91,7 @@ id = "gpt-5.6-terra"
 label = "GPT-5.6 Terra"
 description = "Strong everyday coding + tool use"
 args = ["--model", "gpt-5.6-terra"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.0025
 cost_per_1k_out = 0.015
 avg_latency_ms = 14000
@@ -102,9 +101,30 @@ id = "gpt-5.6-luna"
 label = "GPT-5.6 Luna"
 description = "Fast, efficient repeatable work"
 args = ["--model", "gpt-5.6-luna"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 cost_per_1k_in = 0.001
 cost_per_1k_out = 0.005
 avg_latency_ms = 8000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.4-mini"
+label = "GPT-5.4 Mini"
+description = "Fast, efficient coding"
+args = ["--model", "gpt-5.4-mini"]
+effort_levels = ["low", "medium", "high", "xhigh"]
+cost_per_1k_in = 0.001
+cost_per_1k_out = 0.005
+avg_latency_ms = 8000
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.3-codex-spark"
+label = "GPT-5.3 Codex Spark"
+description = "Fast coding specialist"
+args = ["--model", "gpt-5.3-codex-spark"]
+effort_levels = ["low", "medium", "high", "xhigh"]
+cost_per_1k_in = 0.001
+cost_per_1k_out = 0.005
+avg_latency_ms = 7000
 
 [ai_hub.providers.cursor]
 label = "Cursor"

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -1,8 +1,6 @@
 //! Subprocess invocation for desktop card-level AI (Ask AI / Validate with AI).
 
-use crate::config::{
-    agent_command_uses_stream_json, inject_provider_effort, resolve_effort, ErConfig,
-};
+use crate::config::{agent_command_uses_stream_json, inject_provider_effort, ErConfig};
 use std::process::Command;
 
 /// Resolved agent command + args for a card AI subprocess.
@@ -22,7 +20,7 @@ pub fn plan_card_ai_invocation(
     runtime_effort: Option<&str>,
     work_dir: String,
 ) -> CardAiInvocation {
-    let (command, mut args, is_claude, resolved_model_id) = if let Some(pid) =
+    let (command, mut args, is_claude, resolved_provider_id, resolved_model_id) = if let Some(pid) =
         config.ai_hub.resolve_provider_id(provider_id)
     {
         if let Some(provider) = config.ai_hub.providers.get(&pid) {
@@ -34,7 +32,13 @@ pub fn plan_card_ai_invocation(
                 }
             }
             let is_claude = provider.command.ends_with("claude") || provider.command == "claude";
-            (provider.command.clone(), args, is_claude, resolved_model_id)
+            (
+                provider.command.clone(),
+                args,
+                is_claude,
+                Some(pid.to_string()),
+                resolved_model_id,
+            )
         } else {
             fallback_agent(config)
         }
@@ -48,7 +52,14 @@ pub fn plan_card_ai_invocation(
     if is_claude {
         inject_read_only_tools(&mut args);
     }
-    let effort = resolve_effort(&config.ai_hub, &config.agent, runtime_effort, None);
+    let effort = crate::config::resolve_effort_for_model(
+        &config.ai_hub,
+        &config.agent,
+        resolved_provider_id.as_deref(),
+        resolved_model_id.as_deref(),
+        runtime_effort,
+        None,
+    );
     inject_provider_effort(
         &command,
         &mut args,
@@ -65,13 +76,16 @@ pub fn plan_card_ai_invocation(
     }
 }
 
-fn fallback_agent(config: &ErConfig) -> (String, Vec<String>, bool, Option<String>) {
+fn fallback_agent(
+    config: &ErConfig,
+) -> (String, Vec<String>, bool, Option<String>, Option<String>) {
     let cmd = config.agent.command.clone();
     let is_claude = cmd.ends_with("claude") || cmd == "claude";
     (
         cmd,
         config.agent.args.clone(),
         is_claude,
+        None,
         (!config.agent.model.is_empty()).then(|| config.agent.model.clone()),
     )
 }
@@ -277,6 +291,10 @@ mod tests {
                 models: vec![crate::config::AiModelConfig {
                     id: "gpt-5.6-sol".into(),
                     args: vec!["--model".into(), "gpt-5.6-sol".into()],
+                    effort_levels: vec!["low", "medium", "high", "xhigh", "max"]
+                        .into_iter()
+                        .map(String::from)
+                        .collect(),
                     ..Default::default()
                 }],
                 ..Default::default()

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2229,6 +2229,7 @@ impl App {
             is_claude_compatible,
             is_codex,
             is_stream_json,
+            resolved_provider_id,
             resolved_model_id,
         ) = if let Some(provider_id) = self
             .config
@@ -2260,6 +2261,7 @@ impl App {
                 is_claude,
                 is_codex,
                 provider.uses_stream_json_log(),
+                Some(provider_id),
                 resolved_model_id,
             )
         } else {
@@ -2272,13 +2274,16 @@ impl App {
                 is_claude,
                 is_codex,
                 crate::config::agent_command_uses_stream_json(&cmd),
+                None,
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
         let effort_override = if name == "triage" { Some("low") } else { None };
-        let effort = crate::config::resolve_effort(
+        let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
+            resolved_provider_id.as_deref(),
+            resolved_model_id.as_deref(),
             self.current_ai_effort.as_deref(),
             effort_override,
         );
@@ -2638,6 +2643,7 @@ impl App {
             is_claude_compatible,
             is_codex,
             is_stream_json,
+            resolved_provider_id,
             resolved_model_id,
         ) = if let Some(provider_id) = self
             .config
@@ -2669,6 +2675,7 @@ impl App {
                 is_claude,
                 is_codex,
                 provider.uses_stream_json_log(),
+                Some(provider_id),
                 resolved_model_id,
             )
         } else {
@@ -2681,13 +2688,16 @@ impl App {
                 is_claude,
                 is_codex,
                 crate::config::agent_command_uses_stream_json(&cmd),
+                None,
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
         let effort_override = if kind == "triage" { Some("low") } else { None };
-        let effort = crate::config::resolve_effort(
+        let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
+            resolved_provider_id.as_deref(),
+            resolved_model_id.as_deref(),
             self.current_ai_effort.as_deref(),
             effort_override,
         );

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -4486,7 +4486,18 @@ impl App {
     }
 
     fn initial_ai_effort(config: &ErConfig) -> Option<String> {
-        crate::config::resolve_effort(&config.ai_hub, &config.agent, None, None)
+        let provider = config.ai_hub.resolve_provider_id(None);
+        let model = provider
+            .as_deref()
+            .and_then(|provider_id| config.ai_hub.resolve_model_id(provider_id, None));
+        crate::config::resolve_effort_for_model(
+            &config.ai_hub,
+            &config.agent,
+            provider.as_deref(),
+            model.as_deref(),
+            None,
+            None,
+        )
     }
 
     /// Create the app from CLI path arguments.
@@ -4691,6 +4702,23 @@ impl App {
         });
         self.current_ai_provider = provider;
         self.current_ai_model = model;
+        self.current_ai_effort = crate::config::resolve_effort_for_model(
+            &self.config.ai_hub,
+            &self.config.agent,
+            self.current_ai_provider.as_deref(),
+            self.current_ai_model.as_deref(),
+            self.current_ai_effort.as_deref(),
+            None,
+        );
+    }
+
+    /// Make the session follow the persisted global hub defaults after a
+    /// settings change.
+    pub fn sync_ai_selection_from_defaults(&mut self) {
+        self.current_ai_provider = self.config.ai_hub.default_provider.clone();
+        self.current_ai_model = self.config.ai_hub.default_model.clone();
+        self.current_ai_effort = self.config.ai_hub.default_effort.clone();
+        self.sync_ai_selection();
     }
 
     pub fn active_ai_selection_label(&self) -> String {
@@ -6312,6 +6340,22 @@ impl App {
                 }
                 self.config_hub_rebuild_items();
             }
+            config::ConfigItem::DynamicStringCycle {
+                options, get, set, ..
+            } => {
+                let options = options(&self.config);
+                if options.is_empty() {
+                    return;
+                }
+                let current = get(&self.config);
+                let pos = options
+                    .iter()
+                    .position(|value| value == &current)
+                    .unwrap_or(0);
+                set(&mut self.config, options[(pos + 1) % options.len()].clone());
+                self.sync_ai_selection_from_defaults();
+                self.config_hub_rebuild_items();
+            }
             config::ConfigItem::NumberEdit {
                 get, set, min, max, ..
             } => {
@@ -6399,6 +6443,23 @@ impl App {
                 }
                 self.config_hub_rebuild_items();
             }
+            config::ConfigItem::DynamicStringCycle {
+                options, get, set, ..
+            } => {
+                let options = options(&self.config);
+                if options.is_empty() {
+                    return;
+                }
+                let current = get(&self.config);
+                let pos = options
+                    .iter()
+                    .position(|value| value == &current)
+                    .unwrap_or(0);
+                let prev = (pos + options.len() - 1) % options.len();
+                set(&mut self.config, options[prev].clone());
+                self.sync_ai_selection_from_defaults();
+                self.config_hub_rebuild_items();
+            }
             config::ConfigItem::NumberEdit {
                 get, set, min, max, ..
             } => {
@@ -6472,6 +6533,7 @@ impl App {
             self.tab_mut().watched_config = self.config.watched.clone();
             self.tab_mut().refresh_watched_files();
             self.notify("Config saved globally");
+            self.sync_ai_selection_from_defaults();
             self.overlay = None;
         }
     }
@@ -6480,6 +6542,7 @@ impl App {
     pub fn config_hub_cancel(&mut self) {
         if let Some(OverlayData::ConfigHub { saved_config, .. }) = self.overlay.take() {
             self.config = *saved_config;
+            self.sync_ai_selection_from_defaults();
         }
     }
 

--- a/crates/er-engine/src/arena/adapter.rs
+++ b/crates/er-engine/src/arena/adapter.rs
@@ -38,7 +38,13 @@ pub fn resolve_provider_command(
     if let Some(model) = provider.models.iter().find(|m| m.id == model_id) {
         args.extend(model.args.clone());
     }
-    inject_provider_effort(&provider.command, &mut args, Some(model_id), effort);
+    let effort = crate::config::normalize_effort(hub, Some(provider_id), Some(model_id), effort);
+    inject_provider_effort(
+        &provider.command,
+        &mut args,
+        Some(model_id),
+        effort.as_deref(),
+    );
     if agent_command_is_codex(&provider.command) {
         inject_codex_ignore_user_config(&mut args);
     }

--- a/crates/er-engine/src/arena/orchestrator.rs
+++ b/crates/er-engine/src/arena/orchestrator.rs
@@ -1186,6 +1186,7 @@ mod tests {
                         cost_per_1k_in: None,
                         cost_per_1k_out: None,
                         avg_latency_ms: Some(5_000),
+                        effort_levels: vec![],
                     },
                     AiModelConfig {
                         id: "slow".into(),
@@ -1195,6 +1196,7 @@ mod tests {
                         cost_per_1k_in: None,
                         cost_per_1k_out: None,
                         avg_latency_ms: Some(20_000),
+                        effort_levels: vec![],
                     },
                 ],
                 ..Default::default()
@@ -1232,6 +1234,7 @@ mod tests {
                     cost_per_1k_in: Some(0.001),
                     cost_per_1k_out: Some(0.001),
                     avg_latency_ms: None,
+                    effort_levels: vec![],
                 }],
                 ..Default::default()
             },
@@ -1249,6 +1252,7 @@ mod tests {
                     cost_per_1k_in: Some(0.1),
                     cost_per_1k_out: Some(0.1),
                     avg_latency_ms: None,
+                    effort_levels: vec![],
                 }],
                 ..Default::default()
             },
@@ -1285,6 +1289,7 @@ mod tests {
                         cost_per_1k_in: Some(0.001),
                         cost_per_1k_out: Some(0.001),
                         avg_latency_ms: None,
+                        effort_levels: vec![],
                     },
                     AiModelConfig {
                         id: "dear".into(),
@@ -1294,6 +1299,7 @@ mod tests {
                         cost_per_1k_in: Some(0.2),
                         cost_per_1k_out: Some(0.2),
                         avg_latency_ms: None,
+                        effort_levels: vec![],
                     },
                 ],
                 ..Default::default()

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -213,6 +213,11 @@ pub struct AiModelConfig {
     pub cost_per_1k_out: Option<f32>,
     #[serde(default)]
     pub avg_latency_ms: Option<u32>,
+    /// Explicit reasoning/effort levels supported by this model. An empty
+    /// list means the provider default (Auto); support is never inferred from
+    /// a model ID.
+    #[serde(default)]
+    pub effort_levels: Vec<String>,
 }
 
 /// [summary] section — configuration for diff summary / changelog generation
@@ -537,30 +542,39 @@ pub fn inject_codex_ignore_user_config(args: &mut Vec<String>) {
 }
 
 pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "xhigh", "max"];
+pub const AUTO_EFFORT: &str = "Auto";
 
-const EFFORT_LEVELS_OPUS_46_SONNET: &[&str] = &["low", "medium", "high", "max"];
+/// Return the effort metadata advertised by the selected hub model.
+pub fn effort_levels_for_hub_model<'a>(
+    hub: &'a AiHubConfig,
+    provider_id: Option<&str>,
+    model_id: Option<&str>,
+) -> &'a [String] {
+    provider_id
+        .and_then(|provider| hub.providers.get(provider))
+        .and_then(|provider| {
+            model_id.and_then(|model| provider.models.iter().find(|m| m.id == model))
+        })
+        .map(|model| model.effort_levels.as_slice())
+        .unwrap_or(&[])
+}
 
-/// Effort levels supported for an ai_hub model id (empty when effort does not apply).
-pub fn effort_levels_for_hub_model(model_id: &str) -> &'static [&'static str] {
-    if model_id.starts_with("sonnet-5")
-        || model_id.contains("sonnet-5")
-        || model_id.starts_with("gpt-5.6-")
-        || model_id.contains("gpt-5-6-")
-        || model_id.starts_with("opus-4.7")
-        || model_id.starts_with("opus-4.8")
-        || model_id.contains("opus-4-7")
-        || model_id.contains("opus-4-8")
-    {
-        return EFFORT_LEVELS;
+/// Normalize an effort selection. Auto and invalid/unsupported values are
+/// represented as `None`, so command construction cannot leak them to a CLI.
+pub fn normalize_effort(
+    hub: &AiHubConfig,
+    provider_id: Option<&str>,
+    model_id: Option<&str>,
+    effort: Option<&str>,
+) -> Option<String> {
+    let value = effort?.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("auto") {
+        return None;
     }
-    if model_id.starts_with("opus-4.6")
-        || model_id.starts_with("sonnet-4.6")
-        || model_id.contains("opus-4-6")
-        || model_id.contains("sonnet-4-6")
-    {
-        return EFFORT_LEVELS_OPUS_46_SONNET;
-    }
-    &[]
+    effort_levels_for_hub_model(hub, provider_id, model_id)
+        .iter()
+        .any(|level| level == value)
+        .then(|| value.to_string())
 }
 
 /// Precedence: run override → runtime → hub default → agent fallback.
@@ -578,6 +592,20 @@ pub fn resolve_effort(
         .or_else(|| pick(runtime))
         .or_else(|| pick(hub.default_effort.as_deref()))
         .or_else(|| pick(agent.effort.as_deref()))
+}
+
+/// Resolve the configured effort and discard values unsupported by the
+/// selected model. Invocation code should use this resolver.
+pub fn resolve_effort_for_model(
+    hub: &AiHubConfig,
+    agent: &AgentConfig,
+    provider_id: Option<&str>,
+    model_id: Option<&str>,
+    runtime: Option<&str>,
+    run_override: Option<&str>,
+) -> Option<String> {
+    let candidate = resolve_effort(hub, agent, runtime, run_override);
+    normalize_effort(hub, provider_id, model_id, candidate.as_deref())
 }
 
 /// Append `--effort <level>` when not already present.
@@ -618,9 +646,7 @@ pub fn inject_provider_effort(
 ) {
     if agent_command_is_claude(command) {
         inject_claude_effort(args, effort);
-    } else if agent_command_is_codex(command)
-        && model_id.is_some_and(|id| !effort_levels_for_hub_model(id).is_empty())
-    {
+    } else if agent_command_is_codex(command) && model_id.is_some() {
         inject_codex_effort(args, effort);
     }
 }
@@ -795,6 +821,13 @@ pub enum ConfigItem {
         get: fn(&ErConfig) -> String,
         set: fn(&mut ErConfig, String),
     },
+    DynamicStringCycle {
+        label: String,
+        description: String,
+        options: fn(&ErConfig) -> Vec<String>,
+        get: fn(&ErConfig) -> String,
+        set: fn(&mut ErConfig, String),
+    },
     StringEdit {
         label: String,
         description: String,
@@ -831,6 +864,9 @@ impl std::fmt::Debug for ConfigItem {
             ConfigItem::SectionHeader(s) => write!(f, "SectionHeader({:?})", s),
             ConfigItem::BoolToggle { label, .. } => write!(f, "BoolToggle({:?})", label),
             ConfigItem::StringCycle { label, .. } => write!(f, "StringCycle({:?})", label),
+            ConfigItem::DynamicStringCycle { label, .. } => {
+                write!(f, "DynamicStringCycle({:?})", label)
+            }
             ConfigItem::StringEdit { label, .. } => write!(f, "StringEdit({:?})", label),
             ConfigItem::NumberEdit { label, .. } => write!(f, "NumberEdit({:?})", label),
             ConfigItem::ListEntry { label, index } => {
@@ -937,6 +973,28 @@ fn general_config_hub_items(config: &ErConfig) -> Vec<ConfigItem> {
                 c.agent.effort = if v.is_empty() { None } else { Some(v) };
             },
         },
+        ConfigItem::SectionHeader("AI Hub".into()),
+        ConfigItem::DynamicStringCycle {
+            label: "Provider".into(),
+            description: "Global AI Hub provider".into(),
+            options: hub_provider_options,
+            get: hub_provider_value,
+            set: set_hub_provider,
+        },
+        ConfigItem::DynamicStringCycle {
+            label: "Model".into(),
+            description: "Model for the selected provider".into(),
+            options: hub_model_options,
+            get: hub_model_value,
+            set: set_hub_model,
+        },
+        ConfigItem::DynamicStringCycle {
+            label: "Effort / reasoning".into(),
+            description: "Auto uses the provider default".into(),
+            options: hub_effort_options,
+            get: hub_effort_value,
+            set: set_hub_effort,
+        },
         ConfigItem::SectionHeader("Watched Paths".into()),
         ConfigItem::StringCycle {
             label: "Diff mode".into(),
@@ -960,6 +1018,126 @@ fn general_config_hub_items(config: &ErConfig) -> Vec<ConfigItem> {
     });
 
     items
+}
+
+fn hub_provider_options(config: &ErConfig) -> Vec<String> {
+    config.ai_hub.provider_ids()
+}
+
+fn hub_provider_value(config: &ErConfig) -> String {
+    config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+        .unwrap_or_else(|| "Auto".into())
+}
+
+fn hub_model_options(config: &ErConfig) -> Vec<String> {
+    let Some(provider) = config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+        .and_then(|id| config.ai_hub.providers.get(&id))
+    else {
+        return vec!["Auto".into()];
+    };
+    provider
+        .models
+        .iter()
+        .map(|model| model.id.clone())
+        .collect()
+}
+
+fn hub_model_value(config: &ErConfig) -> String {
+    config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+        .and_then(|provider| {
+            config
+                .ai_hub
+                .resolve_model_id(&provider, config.ai_hub.default_model.as_deref())
+        })
+        .unwrap_or_else(|| "Auto".into())
+}
+
+fn hub_effort_options(config: &ErConfig) -> Vec<String> {
+    let provider = config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref());
+    let model = provider.as_deref().and_then(|id| {
+        config
+            .ai_hub
+            .resolve_model_id(id, config.ai_hub.default_model.as_deref())
+    });
+    let mut options = vec![AUTO_EFFORT.into()];
+    options.extend(
+        effort_levels_for_hub_model(&config.ai_hub, provider.as_deref(), model.as_deref())
+            .iter()
+            .cloned(),
+    );
+    options
+}
+
+fn hub_effort_value(config: &ErConfig) -> String {
+    config
+        .ai_hub
+        .default_effort
+        .clone()
+        .unwrap_or_else(|| AUTO_EFFORT.into())
+}
+
+fn set_hub_provider(config: &mut ErConfig, provider: String) {
+    if !config.ai_hub.providers.contains_key(&provider) {
+        return;
+    }
+    config.ai_hub.default_provider = Some(provider.clone());
+    config.ai_hub.default_model = config.ai_hub.resolve_model_id(&provider, None);
+    config.ai_hub.default_effort = normalize_effort(
+        &config.ai_hub,
+        Some(&provider),
+        config.ai_hub.default_model.as_deref(),
+        config.ai_hub.default_effort.as_deref(),
+    );
+}
+
+fn set_hub_model(config: &mut ErConfig, model: String) {
+    let Some(provider) = config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+    else {
+        return;
+    };
+    if !config
+        .ai_hub
+        .providers
+        .get(&provider)
+        .is_some_and(|p| p.models.iter().any(|m| m.id == model))
+    {
+        return;
+    }
+    config.ai_hub.default_provider = Some(provider.clone());
+    config.ai_hub.default_model = Some(model.clone());
+    config.ai_hub.default_effort = normalize_effort(
+        &config.ai_hub,
+        Some(&provider),
+        Some(&model),
+        config.ai_hub.default_effort.as_deref(),
+    );
+}
+
+fn set_hub_effort(config: &mut ErConfig, effort: String) {
+    let provider = config
+        .ai_hub
+        .resolve_provider_id(config.ai_hub.default_provider.as_deref());
+    let model = provider.as_deref().and_then(|id| {
+        config
+            .ai_hub
+            .resolve_model_id(id, config.ai_hub.default_model.as_deref())
+    });
+    config.ai_hub.default_effort = normalize_effort(
+        &config.ai_hub,
+        provider.as_deref(),
+        model.as_deref(),
+        Some(&effort),
+    );
 }
 
 fn terminal_config_hub_items(_config: &ErConfig) -> Vec<ConfigItem> {
@@ -1121,10 +1299,12 @@ mod tests {
         // The user's model is preserved and stays first.
         assert_eq!(codex.models[0].id, "gpt-5.4");
         // The catalog supplements the remaining codex models in-memory.
-        assert!(codex.models.iter().any(|m| m.id == "gpt-5.3-codex"));
+        assert!(!codex.models.iter().any(|m| m.id == "gpt-5.3-codex"));
         assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-sol"));
         assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-terra"));
         assert!(codex.models.iter().any(|m| m.id == "gpt-5.6-luna"));
+        assert!(codex.models.iter().any(|m| m.id == "gpt-5.4-mini"));
+        assert!(codex.models.iter().any(|m| m.id == "gpt-5.3-codex-spark"));
     }
 
     // ── Default values ──
@@ -1173,6 +1353,7 @@ mod tests {
                         cost_per_1k_in: None,
                         cost_per_1k_out: None,
                         avg_latency_ms: None,
+                        effort_levels: vec![],
                     },
                     AiModelConfig {
                         id: "gpt-5.3-codex".into(),
@@ -1182,6 +1363,7 @@ mod tests {
                         cost_per_1k_in: None,
                         cost_per_1k_out: None,
                         avg_latency_ms: None,
+                        effort_levels: vec![],
                     },
                 ],
             },
@@ -1335,6 +1517,65 @@ mod tests {
             "Expected at least 22 total items (with headers), got {}",
             items.len()
         );
+    }
+
+    #[test]
+    fn config_hub_dynamic_ai_cycles_follow_catalog_metadata_and_auto() {
+        let mut config = ErConfig::default();
+        supplement_ai_hub(&mut config.ai_hub);
+        let items = config_hub_items_for_scope(&config, SettingsScope::General);
+        let (provider_options, provider_get, provider_set) = items
+            .iter()
+            .find_map(|item| match item {
+                ConfigItem::DynamicStringCycle {
+                    label,
+                    options,
+                    get,
+                    set,
+                    ..
+                } if label == "Provider" => Some((*options, *get, *set)),
+                _ => None,
+            })
+            .expect("provider cycle");
+        assert!(provider_options(&config).contains(&"codex".into()));
+        provider_set(&mut config, "codex".into());
+        assert_eq!(provider_get(&config), "codex");
+
+        let (model_options, _, model_set) = items
+            .iter()
+            .find_map(|item| match item {
+                ConfigItem::DynamicStringCycle {
+                    label,
+                    options,
+                    get,
+                    set,
+                    ..
+                } if label == "Model" => Some((*options, *get, *set)),
+                _ => None,
+            })
+            .expect("model cycle");
+        assert!(model_options(&config).contains(&"gpt-5.4-mini".into()));
+        model_set(&mut config, "gpt-5.4-mini".into());
+
+        let (effort_options, effort_get, effort_set) = items
+            .iter()
+            .find_map(|item| match item {
+                ConfigItem::DynamicStringCycle {
+                    label,
+                    options,
+                    get,
+                    set,
+                    ..
+                } if label == "Effort / reasoning" => Some((*options, *get, *set)),
+                _ => None,
+            })
+            .expect("effort cycle");
+        assert_eq!(effort_options(&config)[0], AUTO_EFFORT);
+        assert!(effort_options(&config).contains(&"xhigh".into()));
+        effort_set(&mut config, "xhigh".into());
+        assert_eq!(effort_get(&config), "xhigh");
+        effort_set(&mut config, AUTO_EFFORT.into());
+        assert_eq!(effort_get(&config), AUTO_EFFORT);
     }
 
     #[test]
@@ -1533,12 +1774,32 @@ mod tests {
 
     #[test]
     fn hub_model_effort_levels() {
-        assert!(effort_levels_for_hub_model("sonnet-5").contains(&"xhigh"));
-        assert!(effort_levels_for_hub_model("gpt-5.6-sol").contains(&"max"));
-        assert!(effort_levels_for_hub_model("opus-4.8").contains(&"xhigh"));
-        assert!(!effort_levels_for_hub_model("opus-4.6").contains(&"xhigh"));
-        assert!(effort_levels_for_hub_model("sonnet-4.6").contains(&"max"));
-        assert!(effort_levels_for_hub_model("haiku-4.5").is_empty());
+        let mut hub = AiHubConfig::default();
+        hub.providers.insert(
+            "claude".into(),
+            AiProviderConfig {
+                models: vec![
+                    AiModelConfig {
+                        id: "sonnet-5".into(),
+                        effort_levels: EFFORT_LEVELS.iter().map(|s| s.to_string()).collect(),
+                        ..Default::default()
+                    },
+                    AiModelConfig {
+                        id: "haiku-4.5".into(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        assert!(
+            effort_levels_for_hub_model(&hub, Some("claude"), Some("sonnet-5"))
+                .iter()
+                .any(|level| level == "xhigh")
+        );
+        assert!(effort_levels_for_hub_model(&hub, Some("claude"), Some("haiku-4.5")).is_empty());
+        assert!(normalize_effort(&hub, Some("claude"), Some("sonnet-5"), Some("Auto")).is_none());
+        assert!(normalize_effort(&hub, Some("claude"), Some("haiku-4.5"), Some("high")).is_none());
     }
 
     #[test]
@@ -1640,12 +1901,16 @@ mod tests {
 
     #[test]
     fn provider_effort_only_injects_for_effort_capable_codex_models() {
+        let mut hub = AiHubConfig::default();
+        supplement_ai_hub(&mut hub);
+        let unsupported_effort =
+            normalize_effort(&hub, Some("codex"), Some("legacy-model"), Some("high"));
         let mut unsupported_args = vec!["exec".into()];
         inject_provider_effort(
             "codex",
             &mut unsupported_args,
-            Some("gpt-5.4"),
-            Some("high"),
+            Some("legacy-model"),
+            unsupported_effort.as_deref(),
         );
         assert!(!unsupported_args
             .iter()
@@ -1656,7 +1921,7 @@ mod tests {
             "codex",
             &mut supported_args,
             Some("gpt-5.6-sol"),
-            Some("high"),
+            normalize_effort(&hub, Some("codex"), Some("gpt-5.6-sol"), Some("high")).as_deref(),
         );
         assert!(supported_args
             .iter()

--- a/crates/er-tui/src/ui/settings.rs
+++ b/crates/er-tui/src/ui/settings.rs
@@ -147,6 +147,42 @@ pub fn render_config_hub(
                 list_items.push(ListItem::new(line).style(style));
             }
 
+            ConfigItem::DynamicStringCycle {
+                label,
+                description,
+                options: _,
+                get,
+                ..
+            } => {
+                let value = get(&app.config);
+                let marker = if is_sel { "▸ " } else { "  " };
+                let mut spans = vec![
+                    Span::styled(marker, ratatui::style::Style::default().fg(styles::CYAN())),
+                    Span::styled(
+                        format!("{}: ", label),
+                        if is_sel {
+                            ratatui::style::Style::default().fg(styles::BRIGHT())
+                        } else {
+                            ratatui::style::Style::default().fg(styles::TEXT())
+                        },
+                    ),
+                    Span::styled(value, ratatui::style::Style::default().fg(styles::YELLOW())),
+                    Span::styled("  ◀▶", ratatui::style::Style::default().fg(styles::DIM())),
+                ];
+                if is_sel && !description.is_empty() {
+                    spans.push(Span::styled(
+                        format!("  {}", description),
+                        ratatui::style::Style::default().fg(styles::MUTED()),
+                    ));
+                }
+                let style = if is_sel {
+                    styles::selected_style()
+                } else {
+                    ratatui::style::Style::default().bg(styles::PANEL())
+                };
+                list_items.push(ListItem::new(Line::from(spans)).style(style));
+            }
+
             ConfigItem::StringEdit {
                 label,
                 description,

--- a/desktop-ui/src/lib/arena/effort.ts
+++ b/desktop-ui/src/lib/arena/effort.ts
@@ -1,41 +1,19 @@
-/** Reasoning effort levels (mirrors er-engine `config::EFFORT_LEVELS`). */
+/** Canonical labels used by catalog metadata and arena controls. */
 export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 
-const OPUS_46_SONNET = ["low", "medium", "high", "max"] as const;
-
-/** Effort levels supported for an ai_hub model id (empty when effort does not apply). */
-export function effortLevelsForModel(modelId: string): readonly string[] {
-  if (
-    modelId.startsWith("sonnet-5") ||
-    modelId.includes("sonnet-5") ||
-    modelId.startsWith("gpt-5.6-") ||
-    modelId.includes("gpt-5-6-")
-  ) {
-    return EFFORT_LEVELS;
-  }
-  if (
-    modelId.startsWith("opus-4.7") ||
-    modelId.startsWith("opus-4.8") ||
-    modelId.includes("opus-4-7") ||
-    modelId.includes("opus-4-8")
-  ) {
-    return EFFORT_LEVELS;
-  }
-  if (
-    modelId.startsWith("opus-4.6") ||
-    modelId.startsWith("sonnet-4.6") ||
-    modelId.includes("opus-4-6") ||
-    modelId.includes("sonnet-4-6")
-  ) {
-    return OPUS_46_SONNET;
-  }
-  return [];
+/** Effort levels are supplied by the shared Rust catalog metadata. */
+export function effortLevelsForModel(
+  model: { effort_levels: string[] } | null | undefined,
+): readonly string[] {
+  return model?.effort_levels ?? [];
 }
 
-export function modelSupportsEffort(modelId: string): boolean {
-  return effortLevelsForModel(modelId).length > 0;
+export function modelSupportsEffort(
+  model: { effort_levels: string[] } | null | undefined,
+): boolean {
+  return effortLevelsForModel(model).length > 0;
 }
 
 export function effortLabel(level: string): string {

--- a/desktop-ui/src/lib/components/AiActionPalette.svelte
+++ b/desktop-ui/src/lib/components/AiActionPalette.svelte
@@ -138,18 +138,22 @@
     if (!selectedProvider) return;
     selectedModelId = modelId;
     app.cmd("set_ai_selection", { providerId: selectedProvider.id, modelId: modelId });
-    if (!modelSupportsEffort(modelId)) {
+    const model = selectedProvider.models.find((item) => item.id === modelId);
+    if (!modelSupportsEffort(model)) {
       close();
     }
   }
 
   function setEffort(level: string) {
-    void app.cmd("set_ai_effort", { effort: level });
+    void app.cmd("set_ai_effort", { effort: level === "Auto" ? null : level });
   }
 
   const activeAiLabel = $derived(app.snapshot?.active_ai_label ?? "");
   const activeEffort = $derived(app.snapshot?.active_ai_effort ?? null);
-  const effortLevels = $derived(selectedModelId ? effortLevelsForModel(selectedModelId) : []);
+  const selectedModel = $derived(
+    selectedProvider?.models.find((model) => model.id === selectedModelId) ?? null,
+  );
+  const effortLevels = $derived(["Auto", ...effortLevelsForModel(selectedModel)]);
   const showEffortPicker = $derived(subView === "models" && effortLevels.length > 0);
   const reviewerCount = $derived(selectedReviewers.size);
 
@@ -443,7 +447,7 @@
               type="button"
               onclick={() => setEffort(level)}
               class="rounded px-2 py-1 text-[11px] font-medium transition-colors
-                {activeEffort === level
+                {(level === "Auto" ? activeEffort == null : activeEffort === level)
                 ? 'bg-accent text-on-accent'
                 : 'bg-ink-700 text-ink-200 hover:bg-ink-650'}"
             >

--- a/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
+++ b/desktop-ui/src/lib/components/arena/ArenaLauncher.svelte
@@ -114,6 +114,13 @@
   const agentArenaCount = $derived(agentGroups.filter((g) => g.models.length >= 2).length);
   const agentSingleCount = $derived(agentGroups.filter((g) => g.models.length === 1).length);
 
+  function modelInfo(modelId: string, providerId?: string) {
+    return providers
+      .filter((provider) => !providerId || provider.id === providerId)
+      .flatMap((provider) => provider.models)
+      .find((model) => model.id === modelId) ?? null;
+  }
+
   const isAgentsMode = $derived(reviewerMode === "agents");
   const isArena = $derived(
     isAgentsMode
@@ -130,7 +137,7 @@
         for (const m of g.models) {
           if (
             (m.provider_id === "claude" || m.provider_id === "codex") &&
-            modelSupportsEffort(m.model_id)
+            modelSupportsEffort(modelInfo(m.model_id, m.provider_id))
           ) {
             ids.push(m.model_id);
           }
@@ -142,7 +149,7 @@
       .filter(
         (reviewer) =>
           (reviewer.provider_id === "claude" || reviewer.provider_id === "codex") &&
-          modelSupportsEffort(reviewer.model_id),
+          modelSupportsEffort(modelInfo(reviewer.model_id, reviewer.provider_id)),
       )
       .map((reviewer) => reviewer.model_id);
   });
@@ -151,9 +158,9 @@
 
   const effortLevelsForRun = $derived.by(() => {
     if (effortCapableModelIds.length === 0) return [] as readonly string[];
-    let levels = [...effortLevelsForModel(effortCapableModelIds[0]!)];
+    let levels = [...effortLevelsForModel(modelInfo(effortCapableModelIds[0]!))];
     for (const id of effortCapableModelIds.slice(1)) {
-      const next = effortLevelsForModel(id);
+      const next = effortLevelsForModel(modelInfo(id));
       levels = levels.filter((l) => next.includes(l));
     }
     return levels;

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -37,6 +37,7 @@
   let terminalFields = $state<ConfigHubField[]>([]);
   let providers = $state<AiProviderInfo[]>([]);
   let triageModelId = $state("");
+  let selectedEffort = $state("Auto");
   let repoRoot = $state("");
   let addPattern = $state("");
   let textWarnings = $state<Record<string, string | null>>({});
@@ -49,6 +50,8 @@
 
   const selectedProvider = $derived(providers.find((p) => p.is_selected) ?? null);
   const selectedModels = $derived(selectedProvider?.models ?? []);
+  const selectedModel = $derived(selectedModels.find((model) => model.is_selected) ?? null);
+  const effortOptions = $derived(["Auto", ...(selectedModel?.effort_levels ?? [])]);
   const hasInactiveTriageModel = $derived(
     triageModelId !== "" && !selectedModels.some((model) => model.id === triageModelId),
   );
@@ -88,6 +91,8 @@
     terminalFields = res.settings.terminal;
     providers = res.providers;
     triageModelId = res.triageModelId ?? "";
+    selectedEffort = res.activeEffort ?? "Auto";
+    if (!effortOptions.includes(selectedEffort)) selectedEffort = "Auto";
     repoRoot = res.settings.repoRoot;
   }
 
@@ -131,6 +136,8 @@
     const p = selectedProvider;
     if (!p) return;
     await invoke("set_ai_selection", { providerId: p.id, modelId });
+    const model = p.models.find((item) => item.id === modelId);
+    if (!model?.effort_levels.includes(selectedEffort)) selectedEffort = "Auto";
     await reload();
   }
 
@@ -146,6 +153,7 @@
       const res = await invoke<GetConfigHubResponse>("set_ai_hub_defaults", {
         providerId: p.id,
         modelId: model?.id ?? null,
+        effort: selectedEffort === "Auto" ? null : selectedEffort,
       });
       applySettings(res);
       app.showToast("success", "Saved AI defaults to config");
@@ -381,6 +389,23 @@
                   </div>
                 </div>
               {/if}
+              <div class="py-2 mt-1">
+                <div class="text-sm text-fg mb-1.5">Effort / reasoning</div>
+                <div class="flex flex-wrap gap-1.5">
+                  {#each effortOptions as level (level)}
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-xs rounded-md border transition-colors {selectedEffort === level
+                        ? 'bg-accent-soft text-accent border-accent-border font-medium'
+                        : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
+                      onclick={() => (selectedEffort = level)}
+                    >
+                      {level === 'xhigh' ? 'XHigh' : level}
+                    </button>
+                  {/each}
+                </div>
+                <p class="text-[11px] text-muted mt-1.5">Auto uses the provider default.</p>
+              </div>
               <div class="mt-2 pt-2 border-t border-hairline/60">
                 <Button onclick={() => void saveDefaults()}>Save as default</Button>
               </div>

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -532,6 +532,8 @@ export interface AiModelInfo {
   cost_per_1k_in?: number | null;
   cost_per_1k_out?: number | null;
   avg_latency_ms?: number | null;
+  /** Explicit levels from the shared catalog; empty means provider default. */
+  effort_levels: string[];
 }
 
 export interface AiProviderInfo {
@@ -663,6 +665,8 @@ export interface GetConfigHubResponse {
   settings: DesktopSettingsSnapshot;
   providers: AiProviderInfo[];
   triageModelId: string | null;
+  activeEffort: string | null;
+  defaultEffort: string | null;
 }
 
 export interface FeatureFlagsSnapshot {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -60,12 +60,14 @@ args = ["--print", "-p", "{prompt}"]    # Arguments ({prompt} is replaced)
 
 ### `[ai_hub]`
 
-Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor without editing config mid-session. Selection is session-local; presets still come from TOML.
+Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor. The selected provider, model, and effort can be saved globally from Desktop Settings or the TUI General settings.
 
 ```toml
 [ai_hub]
 default_provider = "claude"
 default_model = "sonnet-5"
+# Optional; omit or use Auto in the UI for the provider default.
+# default_effort = "high"
 
 [ai_hub.reviewer_models]
 triage = "haiku-4.5"
@@ -76,24 +78,28 @@ command = "claude"
 args = ["--print", "-p", "{prompt}"]
 
 [[ai_hub.providers.claude.models]]
-id = "sonnet-4.6"
-label = "Sonnet 4.6"
-args = ["--model", "claude-sonnet-4-6"]
+id = "fable-5"
+label = "Fable 5"
+args = ["--model", "claude-fable-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [[ai_hub.providers.claude.models]]
 id = "sonnet-5"
 label = "Sonnet 5"
 args = ["--model", "claude-sonnet-5"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [[ai_hub.providers.claude.models]]
 id = "opus-4.8"
 label = "Opus 4.8"
 args = ["--model", "claude-opus-4-8"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [[ai_hub.providers.claude.models]]
 id = "haiku-4.5"
 label = "Haiku 4.5"
 args = ["--model", "claude-haiku-4-5-20251001"]
+effort_levels = []
 
 [ai_hub.providers.codex]
 label = "Codex"
@@ -104,21 +110,43 @@ args = ["exec", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "w
 id = "gpt-5.4"
 label = "GPT-5.4"
 args = ["--model", "gpt-5.4"]
+effort_levels = ["low", "medium", "high", "xhigh"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.5"
+label = "GPT-5.5"
+args = ["--model", "gpt-5.5"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 
 [[ai_hub.providers.codex.models]]
 id = "gpt-5.6-sol"
 label = "GPT-5.6 Sol"
 args = ["--model", "gpt-5.6-sol"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [[ai_hub.providers.codex.models]]
 id = "gpt-5.6-terra"
 label = "GPT-5.6 Terra"
 args = ["--model", "gpt-5.6-terra"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [[ai_hub.providers.codex.models]]
 id = "gpt-5.6-luna"
 label = "GPT-5.6 Luna"
 args = ["--model", "gpt-5.6-luna"]
+effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.4-mini"
+label = "GPT-5.4 Mini"
+args = ["--model", "gpt-5.4-mini"]
+effort_levels = ["low", "medium", "high", "xhigh"]
+
+[[ai_hub.providers.codex.models]]
+id = "gpt-5.3-codex-spark"
+label = "GPT-5.3 Codex Spark"
+args = ["--model", "gpt-5.3-codex-spark"]
+effort_levels = ["low", "medium", "high", "xhigh"]
 
 [ai_hub.providers.cursor]
 label = "Cursor"
@@ -135,10 +163,10 @@ Rules:
 - Provider `args` are the shared base arguments for that CLI.
 - Model `args` are appended after provider args.
 - If `[ai_hub]` is absent, `er` falls back to the single `[agent]` configuration.
-- On load, `er` merges any missing built-in catalog models (e.g. new Opus releases) into your config in memory without rewriting your TOML file.
+- On load, `er` merges missing current built-in catalog models into your config in memory without rewriting your TOML file; user-defined legacy entries are preserved.
 - The selected provider/model applies to AI Hub actions such as review, triage, experts, professor, questions, and summary.
 - `[ai_hub.reviewer_models]` overrides the hub model for specific reviewer kinds. Triage uses `triage = "haiku-4.5"` by default in the example config; when unset, triage falls back to the fastest model in the active provider list.
-- Claude and GPT-5.6 models support `default_effort`; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>`.
+- Each model's `effort_levels` metadata is authoritative. `Auto` (the default) omits the override; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>` only for supported levels.
 
 ### `[watched]`
 

--- a/docs/guide/configuration.html
+++ b/docs/guide/configuration.html
@@ -112,13 +112,14 @@ args    = [<span class="tok-str">"--print"</span>, <span class="tok-str">"-p"</s
 id    = <span class="tok-str">"sonnet-5"</span>
 label = <span class="tok-str">"Sonnet 5"</span>
 args  = [<span class="tok-str">"--model"</span>, <span class="tok-str">"claude-sonnet-5"</span>]
-<span class="cmt"># optional metadata: description, cost_per_1k_in, cost_per_1k_out, avg_latency_ms</span></code></pre>
+effort_levels = [<span class="tok-str">"low"</span>, <span class="tok-str">"medium"</span>, <span class="tok-str">"high"</span>, <span class="tok-str">"xhigh"</span>, <span class="tok-str">"max"</span>]
+<span class="cmt"># empty effort_levels means Auto only; support comes from metadata, not model IDs</span></code></pre>
     <ul>
       <li>If <code>[ai_hub]</code> is absent, <code>er</code> falls back to the single <code>[agent]</code> config.</li>
-      <li>Selection is session-local; the presets themselves come from TOML.</li>
+      <li>Selection can be changed at runtime and saved globally from Desktop Settings or the TUI General settings.</li>
       <li>On load, <code>er</code> merges any missing built-in catalog models into your config <em>in memory</em> — it does
       not rewrite your file.</li>
-      <li>Providers in the example config include Claude, Codex, and Cursor.</li>
+      <li>The current built-in catalog includes Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, the GPT-5.6 Sol/Terra/Luna family, GPT-5.5, GPT-5.4, GPT-5.4 Mini, and GPT-5.3 Codex Spark.</li>
       <li>The selected provider/model applies to AI Hub actions: review, triage, experts, professor, questions, and summary.</li>
     </ul>
 


### PR DESCRIPTION
## Summary

- Refresh the built-in AI Hub catalog with current Claude and Codex models while preserving persisted custom/legacy entries.
- Make per-model effort metadata authoritative and expose provider, model, and effort/reasoning controls in Desktop and TUI settings.
- Persist global defaults atomically, treat Auto as no override, validate selections, and emit provider-specific Claude/Codex CLI flags only for supported levels.
- Reuse catalog metadata in the action palette and Arena launcher; update examples, docs, and release notes.

## Verification

- `cargo test -p er-engine` — passed (758 unit tests plus 2 integration tests).
- `./scripts/er-tui.sh test -p er-engine -p er-tui` — passed.
- `cargo test -p er-desktop --no-run` — passed.
- `cd desktop-ui && bun run check` — passed with 0 errors and 13 pre-existing warnings.
- `cd desktop-ui && bun test src` — passed (587 tests).
- `cargo test -p er-desktop` — 104 passed; 2 unrelated existing temp-repository tests failed while determining the current branch, and a third environment-sensitive test hung and was interrupted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all AI invocation paths (reviews, card AI, arena) and global config persistence; incorrect effort injection could change model behavior, but validation and Auto-as-none reduce CLI leakage risk.
> 
> **Overview**
> Refreshes the **built-in AI Hub catalog** (Claude Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, GPT-5.4 Mini, GPT-5.3 Codex Spark) and stops advertising deprecated built-ins while leaving user/legacy entries intact.
> 
> **Effort/reasoning** moves from hard-coded model-ID heuristics to per-model `effort_levels` in catalog/config. `normalize_effort` and `resolve_effort_for_model` validate selections; **Auto** means no CLI override. Desktop (Settings, action palette, Arena), TUI config hub, and agent invocation paths share this metadata.
> 
> Adds **global persistence** for default provider, model, and effort (`set_ai_hub_defaults`, `set_ai_effort` with errors for unsupported effort), exposes `effort_levels` and active/default effort in config hub APIs, and syncs session selection when hub defaults change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a063d2c49e158283e7bf51d77b018ae8ba93bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->