### PR TITLE
fix: AI agent managed storage access and Codex card AI prompts

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -49,9 +49,6 @@ default_model = "sonnet-5"
 # Optional global effort/reasoning override; omit or use Auto in the UI for provider default.
 # default_effort = "high"
 
-[ai_hub.reviewer_models]
-triage = "haiku-4.5"
-
 [ai_hub.providers.claude]
 label = "Claude"
 command = "claude"

--- a/crates/er-desktop/permissions/app-commands.toml
+++ b/crates/er-desktop/permissions/app-commands.toml
@@ -68,7 +68,6 @@ commands.allow = [
   "get_config_hub",
   "apply_config_patch",
   "save_config_global_cmd",
-  "set_ai_hub_defaults",
   "set_ai_effort",
   "promote_to_comment",
   "promote_to_note",

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3690,9 +3690,7 @@ pub fn set_ai_effort(
             app.current_ai_provider
                 .clone()
                 .or(default_selection.provider_id),
-            app.current_ai_model
-                .clone()
-                .or(default_selection.model_id),
+            app.current_ai_model.clone().or(default_selection.model_id),
         )
     };
 

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3627,20 +3627,31 @@ pub fn list_ai_providers(state: State<AppState>) -> Result<Vec<AiProviderInfo>, 
 pub fn set_ai_selection(
     provider_id: String,
     model_id: Option<String>,
+    persist: Option<bool>,
     state: State<AppState>,
 ) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
-
+    let persist = persist.unwrap_or(false);
     let agent = app.config.agent.clone();
-    let selection = app
-        .config
-        .ai_hub
-        .set_default_selection(&provider_id, model_id.as_deref(), &agent)
-        .map_err(|e| e.to_string())?;
+
+    let selection = if persist {
+        let selection = app
+            .config
+            .ai_hub
+            .set_default_selection(&provider_id, model_id.as_deref(), &agent)
+            .map_err(|e| e.to_string())?;
+        er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
+        selection
+    } else {
+        // Session-only (AI action palette): validate against a clone so global
+        // defaults in config.toml are not rewritten by a mid-session pick.
+        let mut hub = app.config.ai_hub.clone();
+        hub.set_default_selection(&provider_id, model_id.as_deref(), &agent)
+            .map_err(|e| e.to_string())?
+    };
     app.current_ai_provider = selection.provider_id;
     app.current_ai_model = selection.model_id;
     app.current_ai_effort = selection.effort;
-    er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
 
     state
         .desktop_revision
@@ -3651,17 +3662,23 @@ pub fn set_ai_selection(
 #[tauri::command]
 pub fn set_ai_effort(
     effort: Option<String>,
+    persist: Option<bool>,
     state: State<AppState>,
 ) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
+    let persist = persist.unwrap_or(false);
     let default_selection = app
         .config
         .ai_hub
         .resolve_default_selection(&app.config.agent);
-    let provider_id = default_selection.provider_id;
-    let model_id = default_selection.model_id;
-    app.current_ai_provider = provider_id.clone();
-    app.current_ai_model = model_id.clone();
+    let provider_id = app
+        .current_ai_provider
+        .clone()
+        .or(default_selection.provider_id);
+    let model_id = app
+        .current_ai_model
+        .clone()
+        .or(default_selection.model_id);
     let normalized = er_engine::config::normalize_effort(
         &app.config.ai_hub,
         provider_id.as_deref(),
@@ -3671,9 +3688,13 @@ pub fn set_ai_effort(
     if effort.is_some() && normalized.is_none() {
         return Err("Effort is unsupported for the selected model".into());
     }
+    app.current_ai_provider = provider_id;
+    app.current_ai_model = model_id;
     app.current_ai_effort = normalized.clone();
-    app.config.ai_hub.default_effort = normalized;
-    er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
+    if persist {
+        app.config.ai_hub.default_effort = normalized;
+        er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
+    }
 
     state
         .desktop_revision

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3588,20 +3588,24 @@ pub fn list_ai_providers(state: State<AppState>) -> Result<Vec<AiProviderInfo>, 
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
     app.sync_config_from_active_tab();
     let hub = &app.config.ai_hub;
-    let selection = hub.resolve_default_selection(&app.config.agent);
-    let resolved_provider = selection.provider_id.as_deref();
+    // Palette / session highlight: use live current_* (not persisted defaults).
+    let current_provider = app.current_ai_provider.as_deref();
+    let current_model = app.current_ai_model.as_deref();
+    let resolved_provider = hub.resolve_provider_id(current_provider);
 
     let providers = hub
         .providers
         .iter()
         .map(|(id, cfg)| {
-            let resolved_model = (selection.provider_id.as_deref() == Some(id.as_str()))
-                .then(|| selection.model_id.as_deref())
-                .flatten();
+            let resolved_model = if resolved_provider.as_deref() == Some(id.as_str()) {
+                hub.resolve_model_id(id, current_model)
+            } else {
+                None
+            };
             AiProviderInfo {
                 id: id.clone(),
                 label: cfg.display_name(id),
-                is_selected: resolved_provider == Some(id.as_str()),
+                is_selected: resolved_provider.as_deref() == Some(id.as_str()),
                 models: cfg
                     .models
                     .iter()
@@ -3643,10 +3647,16 @@ pub fn set_ai_selection(
         er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
         selection
     } else {
-        // Session-only (AI action palette): validate against a clone so global
-        // defaults in config.toml are not rewritten by a mid-session pick.
-        let mut hub = app.config.ai_hub.clone();
-        hub.set_default_selection(&provider_id, model_id.as_deref(), &agent)
+        // Session-only: keep current effort when the new model still supports it.
+        let runtime_effort = app.current_ai_effort.clone();
+        app.config
+            .ai_hub
+            .resolve_selection(
+                &provider_id,
+                model_id.as_deref(),
+                &agent,
+                runtime_effort.as_deref(),
+            )
             .map_err(|e| e.to_string())?
     };
     app.current_ai_provider = selection.provider_id;
@@ -3671,14 +3681,21 @@ pub fn set_ai_effort(
         .config
         .ai_hub
         .resolve_default_selection(&app.config.agent);
-    let provider_id = app
-        .current_ai_provider
-        .clone()
-        .or(default_selection.provider_id);
-    let model_id = app
-        .current_ai_model
-        .clone()
-        .or(default_selection.model_id);
+
+    let (provider_id, model_id) = if persist {
+        // Settings: normalize against persisted defaults, not a session palette pick.
+        (default_selection.provider_id, default_selection.model_id)
+    } else {
+        (
+            app.current_ai_provider
+                .clone()
+                .or(default_selection.provider_id),
+            app.current_ai_model
+                .clone()
+                .or(default_selection.model_id),
+        )
+    };
+
     let normalized = er_engine::config::normalize_effort(
         &app.config.ai_hub,
         provider_id.as_deref(),
@@ -3688,12 +3705,16 @@ pub fn set_ai_effort(
     if effort.is_some() && normalized.is_none() {
         return Err("Effort is unsupported for the selected model".into());
     }
-    app.current_ai_provider = provider_id;
-    app.current_ai_model = model_id;
-    app.current_ai_effort = normalized.clone();
+
     if persist {
-        app.config.ai_hub.default_effort = normalized;
+        app.config.ai_hub.default_effort = normalized.clone();
+        // Keep session aligned with the defaults being edited in Settings.
+        app.current_ai_provider = provider_id;
+        app.current_ai_model = model_id;
+        app.current_ai_effort = normalized;
         er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
+    } else {
+        app.current_ai_effort = normalized;
     }
 
     state

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3588,19 +3588,20 @@ pub fn list_ai_providers(state: State<AppState>) -> Result<Vec<AiProviderInfo>, 
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
     app.sync_config_from_active_tab();
     let hub = &app.config.ai_hub;
-    let current_provider = app.current_ai_provider.as_deref();
-    let current_model = app.current_ai_model.as_deref();
-    let resolved_provider = hub.resolve_provider_id(current_provider);
+    let selection = hub.resolve_default_selection(&app.config.agent);
+    let resolved_provider = selection.provider_id.as_deref();
 
     let providers = hub
         .providers
         .iter()
         .map(|(id, cfg)| {
-            let resolved_model = hub.resolve_model_id(id, current_model);
+            let resolved_model = (selection.provider_id.as_deref() == Some(id.as_str()))
+                .then(|| selection.model_id.as_deref())
+                .flatten();
             AiProviderInfo {
                 id: id.clone(),
                 label: cfg.display_name(id),
-                is_selected: resolved_provider.as_deref() == Some(id.as_str()),
+                is_selected: resolved_provider == Some(id.as_str()),
                 models: cfg
                     .models
                     .iter()
@@ -3630,28 +3631,16 @@ pub fn set_ai_selection(
 ) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
 
-    let hub = &app.config.ai_hub;
-    if !hub.providers.contains_key(&provider_id) {
-        return Err(format!("Unknown provider: {provider_id}"));
-    }
-    if let Some(ref mid) = model_id {
-        let provider = hub.providers.get(&provider_id).unwrap();
-        if !provider.models.is_empty() && !provider.models.iter().any(|m| &m.id == mid) {
-            return Err(format!(
-                "Unknown model '{mid}' for provider '{provider_id}'"
-            ));
-        }
-    }
-
-    let normalized_effort = er_engine::config::normalize_effort(
-        &app.config.ai_hub,
-        Some(&provider_id),
-        model_id.as_deref(),
-        app.current_ai_effort.as_deref(),
-    );
-    app.current_ai_provider = Some(provider_id);
-    app.current_ai_model = model_id;
-    app.current_ai_effort = normalized_effort;
+    let agent = app.config.agent.clone();
+    let selection = app
+        .config
+        .ai_hub
+        .set_default_selection(&provider_id, model_id.as_deref(), &agent)
+        .map_err(|e| e.to_string())?;
+    app.current_ai_provider = selection.provider_id;
+    app.current_ai_model = selection.model_id;
+    app.current_ai_effort = selection.effort;
+    er_engine::config::save_config(&app.config).map_err(|e| e.to_string())?;
 
     state
         .desktop_revision
@@ -3665,15 +3654,14 @@ pub fn set_ai_effort(
     state: State<AppState>,
 ) -> Result<AppSnapshot, String> {
     let mut app = state.app.lock().map_err(|e| e.to_string())?;
-    let provider_id = app
+    let default_selection = app
         .config
         .ai_hub
-        .resolve_provider_id(app.current_ai_provider.as_deref());
-    let model_id = provider_id.as_deref().and_then(|provider| {
-        app.config
-            .ai_hub
-            .resolve_model_id(provider, app.current_ai_model.as_deref())
-    });
+        .resolve_default_selection(&app.config.agent);
+    let provider_id = default_selection.provider_id;
+    let model_id = default_selection.model_id;
+    app.current_ai_provider = provider_id.clone();
+    app.current_ai_model = model_id.clone();
     let normalized = er_engine::config::normalize_effort(
         &app.config.ai_hub,
         provider_id.as_deref(),

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -21,9 +21,7 @@ pub struct ConfigPatch {
 pub struct GetConfigHubResponse {
     pub settings: DesktopSettingsSnapshot,
     pub providers: Vec<AiProviderInfo>,
-    pub triage_model_id: Option<String>,
     pub active_effort: Option<String>,
-    pub default_effort: Option<String>,
 }
 
 fn feature_allows_mode(features: &FeatureFlags, mode: DiffMode) -> bool {
@@ -69,18 +67,19 @@ fn apply_config_side_effects(app: &mut er_engine::app::App, watched_changed: boo
 
 fn list_providers_inner(app: &er_engine::app::App) -> Vec<AiProviderInfo> {
     let hub = &app.config.ai_hub;
-    let current_provider = app.current_ai_provider.as_deref();
-    let current_model = app.current_ai_model.as_deref();
-    let resolved_provider = hub.resolve_provider_id(current_provider);
+    let selection = hub.resolve_default_selection(&app.config.agent);
+    let resolved_provider = selection.provider_id.as_deref();
 
     hub.providers
         .iter()
         .map(|(id, cfg)| {
-            let resolved_model = hub.resolve_model_id(id, current_model);
+            let resolved_model = (selection.provider_id.as_deref() == Some(id.as_str()))
+                .then(|| selection.model_id.as_deref())
+                .flatten();
             AiProviderInfo {
                 id: id.clone(),
                 label: cfg.display_name(id),
-                is_selected: resolved_provider.as_deref() == Some(id.as_str()),
+                is_selected: resolved_provider == Some(id.as_str()),
                 models: cfg
                     .models
                     .iter()
@@ -100,24 +99,6 @@ fn list_providers_inner(app: &er_engine::app::App) -> Vec<AiProviderInfo> {
         .collect()
 }
 
-fn normalized_default_effort(app: &er_engine::app::App) -> Option<String> {
-    let provider = app
-        .config
-        .ai_hub
-        .resolve_provider_id(app.config.ai_hub.default_provider.as_deref());
-    let model = provider.as_deref().and_then(|id| {
-        app.config
-            .ai_hub
-            .resolve_model_id(id, app.config.ai_hub.default_model.as_deref())
-    });
-    er_engine::config::normalize_effort(
-        &app.config.ai_hub,
-        provider.as_deref(),
-        model.as_deref(),
-        app.config.ai_hub.default_effort.as_deref(),
-    )
-}
-
 #[tauri::command]
 pub fn get_config_hub(state: State<AppState>) -> Result<GetConfigHubResponse, String> {
     let app = state.app.lock().map_err(|e| e.to_string())?;
@@ -127,9 +108,7 @@ pub fn get_config_hub(state: State<AppState>) -> Result<GetConfigHubResponse, St
     Ok(GetConfigHubResponse {
         settings,
         providers,
-        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
         active_effort: app.current_ai_effort.clone(),
-        default_effort: normalized_default_effort(&app),
     })
 }
 
@@ -143,6 +122,7 @@ pub fn apply_config_patch(
     let watched_changed = apply_config_field(&mut app.config, &patch.key, patch.value);
     save_config(&app.config).map_err(|e| e.to_string())?;
     apply_config_side_effects(&mut app, watched_changed);
+    app.sync_ai_selection_from_defaults();
     state
         .desktop_revision
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -151,9 +131,7 @@ pub fn apply_config_patch(
     Ok(GetConfigHubResponse {
         settings,
         providers,
-        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
         active_effort: app.current_ai_effort.clone(),
-        default_effort: normalized_default_effort(&app),
     })
 }
 
@@ -168,54 +146,4 @@ pub fn save_config_global_cmd(state: State<AppState>) -> Result<AppSnapshot, Str
         .desktop_revision
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     Ok(snap_from(&app, &state))
-}
-
-#[tauri::command]
-pub fn set_ai_hub_defaults(
-    provider_id: String,
-    model_id: Option<String>,
-    effort: Option<String>,
-    state: State<AppState>,
-) -> Result<GetConfigHubResponse, String> {
-    let mut app = state.app.lock().map_err(|e| e.to_string())?;
-    if !app.config.ai_hub.providers.contains_key(&provider_id) {
-        return Err(format!("Unknown provider: {provider_id}"));
-    }
-    if let Some(ref mid) = model_id {
-        let provider = app.config.ai_hub.providers.get(&provider_id).unwrap();
-        if !provider.models.is_empty() && !provider.models.iter().any(|m| &m.id == mid) {
-            return Err(format!(
-                "Unknown model '{mid}' for provider '{provider_id}'"
-            ));
-        }
-    }
-    let normalized_effort = er_engine::config::normalize_effort(
-        &app.config.ai_hub,
-        Some(&provider_id),
-        model_id.as_deref(),
-        effort.as_deref(),
-    );
-    if effort.is_some() && normalized_effort.is_none() {
-        return Err("Effort is unsupported for the selected model".into());
-    }
-    app.config.ai_hub.default_provider = Some(provider_id.clone());
-    app.config.ai_hub.default_model = model_id.clone();
-    app.config.ai_hub.default_effort = normalized_effort.clone();
-    app.current_ai_provider = Some(provider_id);
-    app.current_ai_model = model_id;
-    app.current_ai_effort = normalized_effort;
-    save_config(&app.config).map_err(|e| e.to_string())?;
-    let repo_root = app.tab().repo_root.clone();
-    state
-        .desktop_revision
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let settings = desktop_settings_snapshot(&app.config, &repo_root);
-    let providers = list_providers_inner(&app);
-    Ok(GetConfigHubResponse {
-        settings,
-        providers,
-        triage_model_id: app.config.ai_hub.triage_model_id().map(str::to_string),
-        active_effort: app.current_ai_effort.clone(),
-        default_effort: normalized_default_effort(&app),
-    })
 }

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -105,10 +105,14 @@ pub fn get_config_hub(state: State<AppState>) -> Result<GetConfigHubResponse, St
     let repo_root = app.tab().repo_root.clone();
     let settings = desktop_settings_snapshot(&app.config, &repo_root);
     let providers = list_providers_inner(&app);
+    let default_selection = app
+        .config
+        .ai_hub
+        .resolve_default_selection(&app.config.agent);
     Ok(GetConfigHubResponse {
         settings,
         providers,
-        active_effort: app.current_ai_effort.clone(),
+        active_effort: default_selection.effort,
     })
 }
 
@@ -122,16 +126,24 @@ pub fn apply_config_patch(
     let watched_changed = apply_config_field(&mut app.config, &patch.key, patch.value);
     save_config(&app.config).map_err(|e| e.to_string())?;
     apply_config_side_effects(&mut app, watched_changed);
-    app.sync_ai_selection_from_defaults();
+    // Only resync session selection when AI Hub defaults actually changed —
+    // theme/display patches must not wipe a palette pick.
+    if patch.key.starts_with("ai_hub.") {
+        app.sync_ai_selection_from_defaults();
+    }
     state
         .desktop_revision
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let settings = desktop_settings_snapshot(&app.config, &repo_root);
     let providers = list_providers_inner(&app);
+    let default_selection = app
+        .config
+        .ai_hub
+        .resolve_default_selection(&app.config.agent);
     Ok(GetConfigHubResponse {
         settings,
         providers,
-        active_effort: app.current_ai_effort.clone(),
+        active_effort: default_selection.effort,
     })
 }
 

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -74,7 +74,7 @@ fn list_providers_inner(app: &er_engine::app::App) -> Vec<AiProviderInfo> {
         .iter()
         .map(|(id, cfg)| {
             let resolved_model = (selection.provider_id.as_deref() == Some(id.as_str()))
-                .then(|| selection.model_id.as_deref())
+                .then_some(selection.model_id.as_deref())
                 .flatten();
             AiProviderInfo {
                 id: id.clone(),
@@ -86,7 +86,7 @@ fn list_providers_inner(app: &er_engine::app::App) -> Vec<AiProviderInfo> {
                     .map(|m| AiModelInfo {
                         id: m.id.clone(),
                         label: m.display_name(),
-                        is_selected: resolved_model.as_deref() == Some(m.id.as_str()),
+                        is_selected: resolved_model == Some(m.id.as_str()),
                         description: m.description.clone(),
                         cost_per_1k_in: m.cost_per_1k_in,
                         cost_per_1k_out: m.cost_per_1k_out,

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -1862,7 +1862,6 @@ fn main() {
             config_commands::get_config_hub,
             config_commands::apply_config_patch,
             config_commands::save_config_global_cmd,
-            config_commands::set_ai_hub_defaults,
             commands::set_ai_effort,
             commands::promote_to_comment,
             commands::promote_to_note,

--- a/crates/er-engine/src/agent_runtime.rs
+++ b/crates/er-engine/src/agent_runtime.rs
@@ -261,7 +261,13 @@ pub fn resolve_invocation(
     if family == CliFamily::Claude {
         inject_allowed_tools(&mut args, request.access.claude_tools());
     }
-    crate::config::inject_agent_storage_access(&command, &mut args);
+    // Only grant managed-storage --add-dir when the task needs artifact I/O.
+    // ReadOnly must not receive a Codex-writable extra root.
+    crate::config::inject_agent_storage_access(
+        &command,
+        &mut args,
+        request.access.output_dir(),
+    );
     if family == CliFamily::Codex {
         if let Some(output_dir) = request.access.output_dir() {
             inject_codex_writable_dir(&mut args, output_dir);

--- a/crates/er-engine/src/agent_runtime.rs
+++ b/crates/er-engine/src/agent_runtime.rs
@@ -72,23 +72,6 @@ impl AgentTaskKind {
         }
     }
 
-    pub fn model_task_kind(&self) -> &str {
-        match self {
-            Self::Review => "review",
-            Self::Expert(_) => "expert",
-            Self::Professor => "professor",
-            Self::Triage => "triage",
-            Self::Tour { .. } => "tour",
-            Self::Questions => "questions",
-            Self::Summary => "summary",
-            Self::ValidateReview => "validate",
-            Self::ValidateComments => "validate-comments",
-            Self::CardReply => "card",
-            Self::ArenaRound => "arena",
-            Self::Other(name) => name,
-        }
-    }
-
     pub fn artifact_contract(&self) -> ArtifactContract {
         match self {
             Self::Review => ArtifactContract::Review,
@@ -204,7 +187,6 @@ pub enum AgentSelection<'a> {
     Runtime {
         provider_id: Option<&'a str>,
         model_id: Option<&'a str>,
-        task_aware: bool,
     },
     Exact {
         provider_id: &'a str,
@@ -231,7 +213,6 @@ pub fn resolve_invocation(
         AgentSelection::Runtime {
             provider_id,
             model_id,
-            task_aware,
         } => {
             if let Some(pid) = config.ai_hub.resolve_provider_id(provider_id) {
                 let provider = config
@@ -240,15 +221,7 @@ pub fn resolve_invocation(
                     .get(&pid)
                     .with_context(|| format!("unknown provider: {pid}"))?;
                 let mut args = provider.args.clone();
-                let resolved_model = if task_aware {
-                    config.ai_hub.resolve_spawn_model_id(
-                        &pid,
-                        model_id,
-                        request.task.model_task_kind(),
-                    )
-                } else {
-                    config.ai_hub.resolve_model_id(&pid, model_id)
-                };
+                let resolved_model = config.ai_hub.resolve_model_id(&pid, model_id);
                 if let Some(model_id) = &resolved_model {
                     if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
                         args.extend(model.args.clone());
@@ -288,6 +261,7 @@ pub fn resolve_invocation(
     if family == CliFamily::Claude {
         inject_allowed_tools(&mut args, request.access.claude_tools());
     }
+    crate::config::inject_agent_storage_access(&command, &mut args);
     if family == CliFamily::Codex {
         if let Some(output_dir) = request.access.output_dir() {
             inject_codex_writable_dir(&mut args, output_dir);
@@ -750,7 +724,6 @@ mod tests {
             selection: AgentSelection::Runtime {
                 provider_id: Some("codex"),
                 model_id: Some("gpt-5.4"),
-                task_aware: true,
             },
             task: &task,
             effort: None,
@@ -783,7 +756,6 @@ mod tests {
                 selection: AgentSelection::Runtime {
                     provider_id: Some("codex"),
                     model_id: Some("gpt-5.6-sol"),
-                    task_aware: true,
                 },
                 task: &task,
                 effort: Some("high"),
@@ -812,7 +784,6 @@ mod tests {
                 selection: AgentSelection::Runtime {
                     provider_id: Some("codex"),
                     model_id: Some("gpt-5.4"),
-                    task_aware: true,
                 },
                 task: &task,
                 effort: Some("high"),
@@ -830,6 +801,75 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_tour_and_triage_use_the_configured_default_model() {
+        let mut config = codex_config();
+        config.ai_hub.default_model = Some("gpt-5.6-luna".into());
+
+        for task in [
+            AgentTaskKind::Tour {
+                filename: "tour.json".into(),
+            },
+            AgentTaskKind::Triage,
+        ] {
+            let invocation = resolve_invocation(
+                &config,
+                AgentInvocationRequest {
+                    selection: AgentSelection::Runtime {
+                        provider_id: Some("codex"),
+                        model_id: None,
+                    },
+                    task: &task,
+                    effort: None,
+                    effort_override: None,
+                    work_dir: "/repo".into(),
+                    access: AgentAccessProfile::ReadOnly,
+                    live_logs: false,
+                },
+            )
+            .unwrap();
+            assert!(has_option_value(
+                &invocation.args,
+                "--model",
+                "gpt-5.6-luna"
+            ));
+            assert!(!has_option_value(
+                &invocation.args,
+                "--model",
+                "gpt-5.3-codex-spark"
+            ));
+        }
+    }
+
+    #[test]
+    fn explicit_runtime_model_overrides_the_default_for_one_invocation() {
+        let mut config = codex_config();
+        config.ai_hub.default_model = Some("gpt-5.6-luna".into());
+        let task = AgentTaskKind::Review;
+        let invocation = resolve_invocation(
+            &config,
+            AgentInvocationRequest {
+                selection: AgentSelection::Runtime {
+                    provider_id: Some("codex"),
+                    model_id: Some("gpt-5.5"),
+                },
+                task: &task,
+                effort: None,
+                effort_override: None,
+                work_dir: "/repo".into(),
+                access: AgentAccessProfile::ReadOnly,
+                live_logs: false,
+            },
+        )
+        .unwrap();
+        assert!(has_option_value(&invocation.args, "--model", "gpt-5.5"));
+        assert!(!has_option_value(
+            &invocation.args,
+            "--model",
+            "gpt-5.6-luna"
+        ));
+    }
+
+    #[test]
     fn codex_card_prompt_combines_system_without_claude_flag() {
         let config = codex_config();
         let task = AgentTaskKind::CardReply;
@@ -839,7 +879,6 @@ mod tests {
                 selection: AgentSelection::Runtime {
                     provider_id: Some("codex"),
                     model_id: Some("gpt-5.4"),
-                    task_aware: false,
                 },
                 task: &task,
                 effort: None,
@@ -874,7 +913,6 @@ mod tests {
                 selection: AgentSelection::Runtime {
                     provider_id: Some("claude"),
                     model_id: Some("sonnet-5"),
-                    task_aware: true,
                 },
                 task: &task,
                 effort: Some("high"),

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -662,6 +662,13 @@ impl AiState {
         self.review.as_ref()?.files.get(path)
     }
 
+    /// Active (non-resolved, non-dropped) findings for a file path.
+    pub fn file_active_findings(&self, path: &str) -> Vec<&Finding> {
+        self.file_review(path)
+            .map(|fr| fr.findings.iter().filter(|f| f.is_active()).collect())
+            .unwrap_or_default()
+    }
+
     /// Get file-level findings (no hunk or line anchor) for a file path.
     #[cfg(test)]
     pub fn findings_for_file_level(&self, path: &str) -> Vec<&Finding> {
@@ -1767,6 +1774,32 @@ mod tests {
             ("b.rs", RiskLevel::Low, vec![]),
         ]));
         assert_eq!(state.total_findings(), 0);
+    }
+
+    // ── AiState::file_active_findings ──
+
+    #[test]
+    fn file_active_findings_excludes_resolved_and_dropped() {
+        let active = make_finding("a", Some(0), RiskLevel::High);
+        let mut resolved = make_finding("b", Some(0), RiskLevel::Medium);
+        resolved.resolved = true;
+        let mut dropped = make_finding("c", Some(0), RiskLevel::Low);
+        dropped.confidence = Confidence::Dropped;
+
+        let mut state = AiState::default();
+        state.review = Some(make_review_with_files(vec![(
+            "a.rs",
+            RiskLevel::High,
+            vec![active, resolved, dropped],
+        )]));
+
+        let ids: Vec<&str> = state
+            .file_active_findings("a.rs")
+            .iter()
+            .map(|f| f.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a"]);
+        assert!(state.file_active_findings("missing.rs").is_empty());
     }
 
     // ── AiState::findings_for_hunk ──

--- a/crates/er-engine/src/ai_hub_catalog.toml
+++ b/crates/er-engine/src/ai_hub_catalog.toml
@@ -3,9 +3,6 @@
 default_provider = "claude"
 default_model = "sonnet-5"
 
-[ai_hub.reviewer_models]
-triage = "haiku-4.5"
-
 [ai_hub.providers.claude]
 label = "Claude"
 command = "claude"

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -108,34 +108,43 @@ fn inject_read_only_tools(args: &mut Vec<String>) {
     }
 }
 
-/// Build argv: system context via `--append-system-prompt`, user text via `{prompt}` or trailing arg.
+/// Build argv: Claude uses `--append-system-prompt`; other CLIs (e.g. Codex) fold
+/// system context into the `{prompt}` placeholder or trailing prompt arg.
 pub fn build_card_ai_argv(inv: &CardAiInvocation, system: &str, user: &str) -> Vec<String> {
     let mut args = inv.args.clone();
     let has_placeholder = args.iter().any(|a| a.contains("{prompt}"));
+    let combined_prompt = if inv.is_claude_compatible {
+        user.to_string()
+    } else if system.is_empty() {
+        user.to_string()
+    } else {
+        format!("{system}\n\nUser request:\n{user}")
+    };
+
     for a in args.iter_mut() {
         if a.contains("{prompt}") {
-            *a = a.replace("{prompt}", user);
+            *a = a.replace("{prompt}", &combined_prompt);
         }
     }
 
-    if args.iter().any(|a| a == "--append-system-prompt") {
-        if let Some(i) = args.iter().position(|a| a == "--append-system-prompt") {
-            if i + 1 < args.len() {
-                args[i + 1] = system.to_string();
-            } else {
-                args.push(system.to_string());
+    if inv.is_claude_compatible {
+        if args.iter().any(|a| a == "--append-system-prompt") {
+            if let Some(i) = args.iter().position(|a| a == "--append-system-prompt") {
+                if i + 1 < args.len() {
+                    args[i + 1] = system.to_string();
+                } else {
+                    args.push(system.to_string());
+                }
+            }
+        } else {
+            args.push("--append-system-prompt".to_string());
+            args.push(system.to_string());
+            if !has_placeholder {
+                args.push(user.to_string());
             }
         }
-    } else if has_placeholder {
-        // User prompt already substituted; prepend system as append-system-prompt.
-        args.push("--append-system-prompt".to_string());
-        args.push(system.to_string());
-    } else if inv.is_claude_compatible {
-        args.push("--append-system-prompt".to_string());
-        args.push(system.to_string());
-        args.push(user.to_string());
-    } else {
-        args.push(user.to_string());
+    } else if !has_placeholder {
+        args.push(combined_prompt);
     }
 
     args
@@ -254,6 +263,39 @@ fn extract_reply_from_stdout(stdout: &str, uses_stream_json: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_card_ai_argv_codex_combines_system_without_claude_flag() {
+        let inv = CardAiInvocation {
+            command: "codex".into(),
+            args: vec!["exec".into(), "{prompt}".into()],
+            work_dir: "/repo".into(),
+            is_claude_compatible: false,
+            uses_stream_json: false,
+        };
+        let args = build_card_ai_argv(&inv, "system context", "how does this work?");
+        assert!(!args.iter().any(|a| a == "--append-system-prompt"));
+        assert!(args.iter().any(|a| {
+            a.contains("system context") && a.contains("User request:\nhow does this work?")
+        }));
+    }
+
+    #[test]
+    fn build_card_ai_argv_claude_uses_append_system_prompt() {
+        let inv = CardAiInvocation {
+            command: "claude".into(),
+            args: vec!["--print".into(), "-p".into(), "{prompt}".into()],
+            work_dir: "/repo".into(),
+            is_claude_compatible: true,
+            uses_stream_json: false,
+        };
+        let args = build_card_ai_argv(&inv, "system context", "how does this work?");
+        assert!(args.windows(2).any(|pair| {
+            pair[0] == "--append-system-prompt" && pair[1] == "system context"
+        }));
+        assert!(args.iter().any(|a| a == "how does this work?"));
+        assert!(!args.iter().any(|a| a.contains("User request:")));
+    }
 
     #[test]
     fn extract_stream_json_result_field() {

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -1,6 +1,8 @@
 //! Subprocess invocation for desktop card-level AI (Ask AI / Validate with AI).
 
-use crate::config::{agent_command_uses_stream_json, inject_provider_effort, ErConfig};
+use crate::config::{
+    agent_command_uses_stream_json, inject_agent_storage_access, inject_provider_effort, ErConfig,
+};
 use std::process::Command;
 
 /// Resolved agent command + args for a card AI subprocess.
@@ -66,6 +68,7 @@ pub fn plan_card_ai_invocation(
         resolved_model_id.as_deref(),
         effort.as_deref(),
     );
+    inject_agent_storage_access(&command, &mut args);
 
     CardAiInvocation {
         command,
@@ -278,6 +281,10 @@ mod tests {
         let inv = plan_card_ai_invocation(&config, None, None, None, "/repo".into());
         assert!(inv.args.iter().any(|a| a == "Read"));
         assert!(inv.args.iter().any(|a| a.contains("grep")));
+        assert!(inv.args.windows(2).any(|pair| {
+            pair[0] == "--add-dir"
+                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
+        }));
     }
 
     #[test]
@@ -312,5 +319,44 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| { pair[0] == "-c" && pair[1] == "model_reasoning_effort=high" }));
+        assert!(inv.args.windows(2).any(|pair| {
+            pair[0] == "--add-dir"
+                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
+        }));
+    }
+
+    #[test]
+    fn plan_card_ai_uses_the_shared_default_model() {
+        let mut config = ErConfig::default();
+        config.ai_hub.default_provider = Some("codex".into());
+        config.ai_hub.default_model = Some("gpt-5.6-luna".into());
+        config.ai_hub.providers.insert(
+            "codex".into(),
+            crate::config::AiProviderConfig {
+                models: vec![
+                    crate::config::AiModelConfig {
+                        id: "gpt-5.6-luna".into(),
+                        args: vec!["--model".into(), "gpt-5.6-luna".into()],
+                        ..Default::default()
+                    },
+                    crate::config::AiModelConfig {
+                        id: "gpt-5.3-codex-spark".into(),
+                        args: vec!["--model".into(), "gpt-5.3-codex-spark".into()],
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+
+        let inv = plan_card_ai_invocation(&config, Some("codex"), None, None, "/repo".into());
+        assert!(inv
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "gpt-5.6-luna"));
+        assert!(!inv
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "gpt-5.3-codex-spark"));
     }
 }

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -1,7 +1,7 @@
 //! Subprocess invocation for desktop card-level AI (Ask AI / Validate with AI).
 
 use crate::config::{
-    agent_command_uses_stream_json, inject_agent_storage_access, inject_provider_effort, ErConfig,
+    agent_command_uses_stream_json, inject_provider_effort, ErConfig,
 };
 use std::process::Command;
 
@@ -68,7 +68,8 @@ pub fn plan_card_ai_invocation(
         resolved_model_id.as_deref(),
         effort.as_deref(),
     );
-    inject_agent_storage_access(&command, &mut args);
+    // Card AI returns text on stdout; the host persists replies. No managed
+    // storage --add-dir is required (and would be overly broad for Codex).
 
     CardAiInvocation {
         command,
@@ -323,10 +324,7 @@ mod tests {
         let inv = plan_card_ai_invocation(&config, None, None, None, "/repo".into());
         assert!(inv.args.iter().any(|a| a == "Read"));
         assert!(inv.args.iter().any(|a| a.contains("grep")));
-        assert!(inv.args.windows(2).any(|pair| {
-            pair[0] == "--add-dir"
-                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
-        }));
+        assert!(!inv.args.iter().any(|a| a.contains("--add-dir")));
     }
 
     #[test]
@@ -361,10 +359,7 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| { pair[0] == "-c" && pair[1] == "model_reasoning_effort=high" }));
-        assert!(inv.args.windows(2).any(|pair| {
-            pair[0] == "--add-dir"
-                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
-        }));
+        assert!(!inv.args.iter().any(|a| a.contains("--add-dir")));
     }
 
     #[test]

--- a/crates/er-engine/src/app/card_ai_spawn.rs
+++ b/crates/er-engine/src/app/card_ai_spawn.rs
@@ -1,8 +1,6 @@
 //! Subprocess invocation for desktop card-level AI (Ask AI / Validate with AI).
 
-use crate::config::{
-    agent_command_uses_stream_json, inject_provider_effort, ErConfig,
-};
+use crate::config::{agent_command_uses_stream_json, inject_provider_effort, ErConfig};
 use std::process::Command;
 
 /// Resolved agent command + args for a card AI subprocess.
@@ -114,9 +112,7 @@ fn inject_read_only_tools(args: &mut Vec<String>) {
 pub fn build_card_ai_argv(inv: &CardAiInvocation, system: &str, user: &str) -> Vec<String> {
     let mut args = inv.args.clone();
     let has_placeholder = args.iter().any(|a| a.contains("{prompt}"));
-    let combined_prompt = if inv.is_claude_compatible {
-        user.to_string()
-    } else if system.is_empty() {
+    let combined_prompt = if inv.is_claude_compatible || system.is_empty() {
         user.to_string()
     } else {
         format!("{system}\n\nUser request:\n{user}")
@@ -291,9 +287,9 @@ mod tests {
             uses_stream_json: false,
         };
         let args = build_card_ai_argv(&inv, "system context", "how does this work?");
-        assert!(args.windows(2).any(|pair| {
-            pair[0] == "--append-system-prompt" && pair[1] == "system context"
-        }));
+        assert!(args
+            .windows(2)
+            .any(|pair| { pair[0] == "--append-system-prompt" && pair[1] == "system context" }));
         assert!(args.iter().any(|a| a == "how does this work?"));
         assert!(!args.iter().any(|a| a.contains("User request:")));
     }

--- a/crates/er-engine/src/app/state/background.rs
+++ b/crates/er-engine/src/app/state/background.rs
@@ -128,6 +128,10 @@ pub(crate) struct PendingBackgroundTask {
     pub command_name: String,
     pub prompt: String,
     pub prepared_diff: bool,
+    /// Optional action-bound provider/model/effort selection. This is captured
+    /// when a TUI action is queued so it cannot leak into later actions or be
+    /// replaced by a changed global default before launch.
+    pub ai_selection: Option<crate::config::AiSelection>,
 }
 
 /// In-flight + recently finished background task channels. The `App` owns

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2287,13 +2287,14 @@ impl App {
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
+        let effort_override = if name == "triage" { Some("low") } else { None };
         let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
             resolved_provider_id.as_deref(),
             resolved_model_id.as_deref(),
             selection.effort.as_deref(),
-            None,
+            effort_override,
         );
         crate::config::inject_provider_effort(
             &agent_cmd,
@@ -2555,7 +2556,7 @@ impl App {
         )
     }
 
-    /// Spawn triage scan (`kind` = `triage`) using the shared default model.
+    /// Spawn triage scan (`kind` = `triage`) using the shared default model at low effort.
     pub fn spawn_background_triage_review(
         &mut self,
         target: super::background::BackgroundTaskTarget,
@@ -2612,7 +2613,16 @@ impl App {
             command_name: command_name.to_string(),
             prompt,
             prepared_diff,
-            ai_selection: self.pending_ai_selection_override.clone(),
+            // Snapshot at enqueue so a mid-queue palette change cannot retarget
+            // an already-queued job.
+            ai_selection: Some(self.pending_ai_selection_override.clone().unwrap_or_else(|| {
+                self.sync_ai_selection();
+                crate::config::AiSelection {
+                    provider_id: self.current_ai_provider.clone(),
+                    model_id: self.current_ai_model.clone(),
+                    effort: self.current_ai_effort.clone(),
+                }
+            })),
         };
 
         let cap = self.config.ai_hub.effective_max_concurrent_reviews();
@@ -2712,13 +2722,18 @@ impl App {
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
+        let effort_override = if task.kind == "triage" {
+            Some("low")
+        } else {
+            None
+        };
         let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
             resolved_provider_id.as_deref(),
             resolved_model_id.as_deref(),
             selection.effort.as_deref(),
-            None,
+            effort_override,
         );
         crate::config::inject_provider_effort(
             &agent_cmd,
@@ -3320,6 +3335,51 @@ mod background_queue_tests {
         assert!(app.cancel_queued_background_task(&queued_id));
         assert!(app.pending_background_tasks.is_empty());
         assert!(!app.cancel_queued_background_task(&queued_id));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn queued_task_snapshots_current_selection_without_override() {
+        let Some((mut app, tmp)) = test_app(1) else {
+            return;
+        };
+        app.config.ai_hub.providers.insert(
+            "codex".into(),
+            AiProviderConfig {
+                models: vec![AiModelConfig {
+                    id: "gpt-5.6-luna".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+        app.current_ai_provider = Some("codex".into());
+        app.current_ai_model = Some("gpt-5.6-luna".into());
+        app.current_ai_effort = Some("high".into());
+
+        app.spawn_background_triage_review(target(&tmp, "feat-a"), "p".into(), true)
+            .unwrap();
+        app.current_ai_model = Some("other".into());
+        app.spawn_background_triage_review(target(&tmp, "feat-b"), "p".into(), true)
+            .unwrap();
+
+        let queued = &app.pending_background_tasks[0];
+        assert_eq!(
+            queued
+                .ai_selection
+                .as_ref()
+                .and_then(|s| s.model_id.as_deref()),
+            Some("gpt-5.6-luna"),
+            "queued task keeps the selection from enqueue time"
+        );
+        assert_eq!(
+            queued
+                .ai_selection
+                .as_ref()
+                .and_then(|s| s.effort.as_deref()),
+            Some("high")
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2608,22 +2608,25 @@ impl App {
             );
         }
 
-        let pending = PendingBackgroundTask {
-            task: BackgroundTask::new(kind, target),
-            command_name: command_name.to_string(),
-            prompt,
-            prepared_diff,
-            // Snapshot at enqueue so a mid-queue palette change cannot retarget
-            // an already-queued job.
-            ai_selection: Some(self.pending_ai_selection_override.clone().unwrap_or_else(|| {
-                self.sync_ai_selection();
-                crate::config::AiSelection {
-                    provider_id: self.current_ai_provider.clone(),
-                    model_id: self.current_ai_model.clone(),
-                    effort: self.current_ai_effort.clone(),
-                }
-            })),
-        };
+        let pending =
+            PendingBackgroundTask {
+                task: BackgroundTask::new(kind, target),
+                command_name: command_name.to_string(),
+                prompt,
+                prepared_diff,
+                // Snapshot at enqueue so a mid-queue palette change cannot retarget
+                // an already-queued job.
+                ai_selection: Some(self.pending_ai_selection_override.clone().unwrap_or_else(
+                    || {
+                        self.sync_ai_selection();
+                        crate::config::AiSelection {
+                            provider_id: self.current_ai_provider.clone(),
+                            model_id: self.current_ai_model.clone(),
+                            effort: self.current_ai_effort.clone(),
+                        }
+                    },
+                )),
+            };
 
         let cap = self.config.ai_hub.effective_max_concurrent_reviews();
         if self.running_background_task_count() >= cap {

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -1537,6 +1537,7 @@ impl App {
     /// Cancel the confirm dialog
     pub fn cancel_confirm(&mut self) {
         self.input_mode = InputMode::Normal;
+        self.clear_ai_selection_override();
     }
 
     // ── Hunk Comment (Shift-C) ──
@@ -2221,7 +2222,16 @@ impl App {
         let repo_root = self.tab().repo_root.clone();
         let er_dir_path = self.tab().er_dir();
         let is_remote = self.tab().is_remote();
-        self.sync_ai_selection();
+        let selection = if let Some(selection) = self.pending_ai_selection_override.clone() {
+            selection
+        } else {
+            self.sync_ai_selection();
+            crate::config::AiSelection {
+                provider_id: self.current_ai_provider.clone(),
+                model_id: self.current_ai_model.clone(),
+                effort: self.current_ai_effort.clone(),
+            }
+        };
 
         let (
             agent_cmd,
@@ -2234,7 +2244,7 @@ impl App {
         ) = if let Some(provider_id) = self
             .config
             .ai_hub
-            .resolve_provider_id(self.current_ai_provider.as_deref())
+            .resolve_provider_id(selection.provider_id.as_deref())
         {
             let provider = self
                 .config
@@ -2243,11 +2253,10 @@ impl App {
                 .get(&provider_id)
                 .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
             let mut args = provider.args.clone();
-            let resolved_model_id = self.config.ai_hub.resolve_spawn_model_id(
-                &provider_id,
-                self.current_ai_model.as_deref(),
-                name,
-            );
+            let resolved_model_id = self
+                .config
+                .ai_hub
+                .resolve_model_id(&provider_id, selection.model_id.as_deref());
             if let Some(model_id) = &resolved_model_id {
                 if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
                     args.extend(model.args.clone());
@@ -2278,14 +2287,13 @@ impl App {
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
-        let effort_override = if name == "triage" { Some("low") } else { None };
         let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
             resolved_provider_id.as_deref(),
             resolved_model_id.as_deref(),
-            self.current_ai_effort.as_deref(),
-            effort_override,
+            selection.effort.as_deref(),
+            None,
         );
         crate::config::inject_provider_effort(
             &agent_cmd,
@@ -2296,6 +2304,7 @@ impl App {
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }
+        crate::config::inject_agent_storage_access(&agent_cmd, &mut config_args);
 
         // Ensure .er/ directory exists
         std::fs::create_dir_all(&er_dir_path)?;
@@ -2542,7 +2551,7 @@ impl App {
         )
     }
 
-    /// Spawn triage scan (`kind` = `triage`). Uses fast model from `[ai_hub.reviewer_models]`.
+    /// Spawn triage scan (`kind` = `triage`) using the shared default model.
     pub fn spawn_background_triage_review(
         &mut self,
         target: super::background::BackgroundTaskTarget,
@@ -2599,6 +2608,7 @@ impl App {
             command_name: command_name.to_string(),
             prompt,
             prepared_diff,
+            ai_selection: self.pending_ai_selection_override.clone(),
         };
 
         let cap = self.config.ai_hub.effective_max_concurrent_reviews();
@@ -2627,15 +2637,22 @@ impl App {
             command_name,
             prompt,
             prepared_diff,
+            ai_selection,
         } = pending;
         let command_name = command_name.as_str();
-        let kind = task.kind.clone();
         let target = task.target.clone();
         // The task may have waited in the queue; report runtime from launch.
         // The id (assigned at enqueue) stays stable so UI pills don't jump.
         task.started_at_ms = super::background::unix_now_ms();
 
-        self.sync_ai_selection();
+        let selection = ai_selection.unwrap_or_else(|| {
+            self.sync_ai_selection();
+            crate::config::AiSelection {
+                provider_id: self.current_ai_provider.clone(),
+                model_id: self.current_ai_model.clone(),
+                effort: self.current_ai_effort.clone(),
+            }
+        });
 
         let (
             agent_cmd,
@@ -2648,7 +2665,7 @@ impl App {
         ) = if let Some(provider_id) = self
             .config
             .ai_hub
-            .resolve_provider_id(self.current_ai_provider.as_deref())
+            .resolve_provider_id(selection.provider_id.as_deref())
         {
             let provider = self
                 .config
@@ -2657,11 +2674,10 @@ impl App {
                 .get(&provider_id)
                 .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {}", provider_id))?;
             let mut args = provider.args.clone();
-            let resolved_model_id = self.config.ai_hub.resolve_spawn_model_id(
-                &provider_id,
-                self.current_ai_model.as_deref(),
-                &kind,
-            );
+            let resolved_model_id = self
+                .config
+                .ai_hub
+                .resolve_model_id(&provider_id, selection.model_id.as_deref());
             if let Some(model_id) = &resolved_model_id {
                 if let Some(model) = provider.models.iter().find(|m| m.id == *model_id) {
                     args.extend(model.args.clone());
@@ -2692,14 +2708,13 @@ impl App {
                 (!self.config.agent.model.is_empty()).then(|| self.config.agent.model.clone()),
             )
         };
-        let effort_override = if kind == "triage" { Some("low") } else { None };
         let effort = crate::config::resolve_effort_for_model(
             &self.config.ai_hub,
             &self.config.agent,
             resolved_provider_id.as_deref(),
             resolved_model_id.as_deref(),
-            self.current_ai_effort.as_deref(),
-            effort_override,
+            selection.effort.as_deref(),
+            None,
         );
         crate::config::inject_provider_effort(
             &agent_cmd,
@@ -2710,6 +2725,7 @@ impl App {
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }
+        crate::config::inject_agent_storage_access(&agent_cmd, &mut config_args);
 
         std::fs::create_dir_all(&target.er_dir)?;
 
@@ -3211,7 +3227,7 @@ impl App {
 #[cfg(test)]
 mod background_queue_tests {
     use crate::app::{App, BackgroundTaskTarget};
-    use crate::config::{AiModelConfig, AiProviderConfig};
+    use crate::config::{AiModelConfig, AiProviderConfig, AiSelection};
 
     fn target(tmp: &std::path::Path, branch: &str) -> BackgroundTaskTarget {
         BackgroundTaskTarget {
@@ -3255,11 +3271,24 @@ mod background_queue_tests {
 
         app.spawn_background_triage_review(target(&tmp, "feat-a"), "p".into(), true)
             .unwrap();
+        app.set_ai_selection_override(AiSelection {
+            provider_id: Some("codex".into()),
+            model_id: Some("gpt-5.3-codex-spark".into()),
+            effort: None,
+        });
         app.spawn_background_triage_review(target(&tmp, "feat-b"), "p".into(), true)
             .unwrap();
+        app.clear_ai_selection_override();
 
         assert_eq!(app.running_background_task_count(), 1, "cap of 1 enforced");
         assert_eq!(app.pending_background_tasks.len(), 1, "second task queued");
+        assert_eq!(
+            app.pending_background_tasks[0]
+                .ai_selection
+                .as_ref()
+                .and_then(|selection| selection.model_id.as_deref()),
+            Some("gpt-5.3-codex-spark")
+        );
 
         // Same kind+target as the queued task is rejected as a duplicate.
         let dup = app.spawn_background_triage_review(target(&tmp, "feat-b"), "p".into(), true);

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2304,7 +2304,11 @@ impl App {
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }
-        crate::config::inject_agent_storage_access(&agent_cmd, &mut config_args);
+        crate::config::inject_agent_storage_access(
+            &agent_cmd,
+            &mut config_args,
+            Some(er_dir_path.as_str()),
+        );
 
         // Ensure .er/ directory exists
         std::fs::create_dir_all(&er_dir_path)?;
@@ -2725,7 +2729,11 @@ impl App {
         if is_codex {
             crate::config::inject_codex_ignore_user_config(&mut config_args);
         }
-        crate::config::inject_agent_storage_access(&agent_cmd, &mut config_args);
+        crate::config::inject_agent_storage_access(
+            &agent_cmd,
+            &mut config_args,
+            Some(target.er_dir.as_str()),
+        );
 
         std::fs::create_dir_all(&target.er_dir)?;
 

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -4733,9 +4733,12 @@ impl App {
         provider_id: &str,
         model_id: Option<&str>,
     ) -> Result<crate::config::AiSelection> {
-        let mut hub = self.config.ai_hub.clone();
-        let agent = self.config.agent.clone();
-        hub.set_default_selection(provider_id, model_id, &agent)
+        self.config.ai_hub.resolve_selection(
+            provider_id,
+            model_id,
+            &self.config.agent,
+            self.current_ai_effort.as_deref(),
+        )
     }
 
     pub fn set_ai_selection_override(&mut self, selection: crate::config::AiSelection) {

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -4438,6 +4438,10 @@ pub struct App {
     /// Session-local Claude Code effort level (`low` … `max`).
     pub current_ai_effort: Option<String>,
 
+    /// Ephemeral selection for the next TUI action. Action-bound model picks
+    /// use this without changing the shared default.
+    pending_ai_selection_override: Option<crate::config::AiSelection>,
+
     /// Pending action from a modal hub selection (consumed by the event loop)
     pub pending_hub_action: Option<HubAction>,
 
@@ -4478,26 +4482,15 @@ impl App {
     }
 
     fn initial_ai_selection(config: &ErConfig) -> (Option<String>, Option<String>) {
-        let provider = config.ai_hub.resolve_provider_id(None);
-        let model = provider
-            .as_deref()
-            .and_then(|provider_id| config.ai_hub.resolve_model_id(provider_id, None));
-        (provider, model)
+        let selection = config.ai_hub.resolve_default_selection(&config.agent);
+        (selection.provider_id, selection.model_id)
     }
 
     fn initial_ai_effort(config: &ErConfig) -> Option<String> {
-        let provider = config.ai_hub.resolve_provider_id(None);
-        let model = provider
-            .as_deref()
-            .and_then(|provider_id| config.ai_hub.resolve_model_id(provider_id, None));
-        crate::config::resolve_effort_for_model(
-            &config.ai_hub,
-            &config.agent,
-            provider.as_deref(),
-            model.as_deref(),
-            None,
-            None,
-        )
+        config
+            .ai_hub
+            .resolve_default_selection(&config.agent)
+            .effort
     }
 
     /// Create the app from CLI path arguments.
@@ -4572,6 +4565,7 @@ impl App {
             current_ai_provider,
             current_ai_model,
             current_ai_effort,
+            pending_ai_selection_override: None,
             pending_hub_action: None,
             last_terminal_width: 0,
             panels_visible: PanelsVisible::default(),
@@ -4614,6 +4608,7 @@ impl App {
             current_ai_provider,
             current_ai_model,
             current_ai_effort,
+            pending_ai_selection_override: None,
             pending_hub_action: None,
             last_terminal_width: 0,
             panels_visible: PanelsVisible::default(),
@@ -4649,6 +4644,7 @@ impl App {
             current_ai_provider,
             current_ai_model,
             current_ai_effort,
+            pending_ai_selection_override: None,
             pending_hub_action: None,
             last_terminal_width: 0,
             panels_visible: PanelsVisible::default(),
@@ -4679,6 +4675,7 @@ impl App {
             current_ai_provider: None,
             current_ai_model: None,
             current_ai_effort: None,
+            pending_ai_selection_override: None,
             pending_hub_action: None,
             last_terminal_width: 0,
             panels_visible: PanelsVisible::default(),
@@ -4712,13 +4709,53 @@ impl App {
         );
     }
 
+    /// Validate and apply a standalone provider/model choice to the shared
+    /// in-memory default. TUI persists it when the config hub is saved.
+    pub fn set_ai_default_selection(
+        &mut self,
+        provider_id: &str,
+        model_id: Option<&str>,
+    ) -> Result<()> {
+        let agent = self.config.agent.clone();
+        let selection = self
+            .config
+            .ai_hub
+            .set_default_selection(provider_id, model_id, &agent)?;
+        self.current_ai_provider = selection.provider_id;
+        self.current_ai_model = selection.model_id;
+        self.current_ai_effort = selection.effort;
+        Ok(())
+    }
+
+    /// Resolve an action-bound selection without mutating the shared default.
+    pub fn resolve_ai_selection_override(
+        &self,
+        provider_id: &str,
+        model_id: Option<&str>,
+    ) -> Result<crate::config::AiSelection> {
+        let mut hub = self.config.ai_hub.clone();
+        let agent = self.config.agent.clone();
+        hub.set_default_selection(provider_id, model_id, &agent)
+    }
+
+    pub fn set_ai_selection_override(&mut self, selection: crate::config::AiSelection) {
+        self.pending_ai_selection_override = Some(selection);
+    }
+
+    pub fn clear_ai_selection_override(&mut self) {
+        self.pending_ai_selection_override = None;
+    }
+
     /// Make the session follow the persisted global hub defaults after a
     /// settings change.
     pub fn sync_ai_selection_from_defaults(&mut self) {
-        self.current_ai_provider = self.config.ai_hub.default_provider.clone();
-        self.current_ai_model = self.config.ai_hub.default_model.clone();
-        self.current_ai_effort = self.config.ai_hub.default_effort.clone();
-        self.sync_ai_selection();
+        let selection = self
+            .config
+            .ai_hub
+            .resolve_default_selection(&self.config.agent);
+        self.current_ai_provider = selection.provider_id;
+        self.current_ai_model = selection.model_id;
+        self.current_ai_effort = selection.effort;
     }
 
     pub fn active_ai_selection_label(&self) -> String {
@@ -4817,11 +4854,13 @@ impl App {
         };
 
         if provider.models.is_empty() {
-            self.current_ai_provider = Some(provider_id);
-            self.current_ai_model = None;
             if let Some(action) = action {
                 self.pending_hub_action = Some(HubAction::RunAiAction(action));
             } else {
+                if self.set_ai_default_selection(&provider_id, None).is_err() {
+                    self.notify("Unknown AI provider");
+                    return;
+                }
                 self.notify(&format!("AI target: {}", self.active_ai_selection_label()));
             }
             return;
@@ -5250,7 +5289,7 @@ impl App {
                 label: "Triage branch".into(),
                 hint: "".into(),
                 description: format!(
-                    "Fast scan — first impression and review routing via {selection_label} (Haiku-class model)"
+                    "Fast scan — first impression and review routing via {selection_label}"
                 ),
                 action: HubAction::RunTriageReview,
                 is_header: false,
@@ -5353,7 +5392,7 @@ impl App {
                 label: "Copy review.json".into(),
                 hint: "".into(),
                 description: if has_review {
-                    "Copy .er/review.json to clipboard".into()
+                    "Copy review.json to clipboard".into()
                 } else {
                     "No review data — run a review first".into()
                 },
@@ -5365,7 +5404,7 @@ impl App {
                 label: "Copy questions.json".into(),
                 hint: "".into(),
                 description: if has_questions {
-                    "Copy .er/questions.json to clipboard".into()
+                    "Copy questions.json to clipboard".into()
                 } else {
                     "No questions — add some with q first".into()
                 },
@@ -5417,7 +5456,7 @@ impl App {
                 label: "Cleanup questions & notes".into(),
                 hint: "z".into(),
                 description: if has_questions_or_notes {
-                    "Delete .er/questions.json + notes.json".into()
+                    "Delete questions.json + notes.json".into()
                 } else {
                     "no questions or notes to clean up".into()
                 },
@@ -5429,7 +5468,7 @@ impl App {
                 label: "Cleanup reviews".into(),
                 hint: "Z".into(),
                 description: if has_review {
-                    "Delete .er/review.json".into()
+                    "Delete review sidecars (review.json, …)".into()
                 } else {
                     "no review data to clean up".into()
                 },
@@ -8638,6 +8677,7 @@ mod tests {
             current_ai_provider: None,
             current_ai_model: None,
             current_ai_effort: None,
+            pending_ai_selection_override: None,
             pending_hub_action: None,
             last_terminal_width: 0,
             panels_visible: PanelsVisible::default(),

--- a/crates/er-engine/src/arena/adapter.rs
+++ b/crates/er-engine/src/arena/adapter.rs
@@ -30,6 +30,7 @@ pub fn resolve_provider_command(
     provider_id: &str,
     model_id: &str,
     effort: Option<&str>,
+    storage_dir: Option<&str>,
 ) -> Result<ProviderCommand> {
     let provider = hub
         .providers
@@ -49,7 +50,7 @@ pub fn resolve_provider_command(
     if agent_command_is_codex(&provider.command) {
         inject_codex_ignore_user_config(&mut args);
     }
-    inject_agent_storage_access(&provider.command, &mut args);
+    inject_agent_storage_access(&provider.command, &mut args, storage_dir);
     Ok(ProviderCommand {
         command: provider.command.clone(),
         args,
@@ -317,6 +318,7 @@ mod tests {
 
     #[test]
     fn codex_provider_command_ignores_user_config() {
+        const DIR: &str = "/managed/repos/demo/branches/main/view-buckets/branch";
         let mut hub = AiHubConfig::default();
         hub.providers.insert(
             "codex".to_string(),
@@ -332,7 +334,7 @@ mod tests {
             },
         );
 
-        let cmd = resolve_provider_command(&hub, "codex", "gpt-5.5", None).unwrap();
+        let cmd = resolve_provider_command(&hub, "codex", "gpt-5.5", None, Some(DIR)).unwrap();
 
         assert_eq!(cmd.args[0], "exec");
         assert_eq!(
@@ -342,10 +344,31 @@ mod tests {
                 .count(),
             1
         );
-        assert!(cmd.args.windows(2).any(|pair| {
-            pair[0] == "--add-dir"
-                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
-        }));
+        assert!(cmd
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--add-dir" && pair[1] == DIR));
+    }
+
+    #[test]
+    fn codex_provider_command_skips_storage_without_dir() {
+        let mut hub = AiHubConfig::default();
+        hub.providers.insert(
+            "codex".to_string(),
+            crate::config::AiProviderConfig {
+                command: "codex".to_string(),
+                args: vec!["exec".to_string(), "{prompt}".to_string()],
+                models: vec![crate::config::AiModelConfig {
+                    id: "gpt-5.5".to_string(),
+                    args: vec!["--model".to_string(), "gpt-5.5".to_string()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+
+        let cmd = resolve_provider_command(&hub, "codex", "gpt-5.5", None, None).unwrap();
+        assert!(!cmd.args.iter().any(|arg| arg.contains("--add-dir")));
     }
 
     #[test]

--- a/crates/er-engine/src/arena/adapter.rs
+++ b/crates/er-engine/src/arena/adapter.rs
@@ -1,5 +1,6 @@
 use crate::config::{
-    agent_command_is_codex, inject_codex_ignore_user_config, inject_provider_effort, AiHubConfig,
+    agent_command_is_codex, inject_agent_storage_access, inject_codex_ignore_user_config,
+    inject_provider_effort, AiHubConfig,
 };
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -48,6 +49,7 @@ pub fn resolve_provider_command(
     if agent_command_is_codex(&provider.command) {
         inject_codex_ignore_user_config(&mut args);
     }
+    inject_agent_storage_access(&provider.command, &mut args);
     Ok(ProviderCommand {
         command: provider.command.clone(),
         args,
@@ -333,7 +335,6 @@ mod tests {
         let cmd = resolve_provider_command(&hub, "codex", "gpt-5.5", None).unwrap();
 
         assert_eq!(cmd.args[0], "exec");
-        assert_eq!(cmd.args[1], "--ignore-user-config");
         assert_eq!(
             cmd.args
                 .iter()
@@ -341,6 +342,10 @@ mod tests {
                 .count(),
             1
         );
+        assert!(cmd.args.windows(2).any(|pair| {
+            pair[0] == "--add-dir"
+                && pair[1] == crate::storage::storage_root().to_string_lossy().as_ref()
+        }));
     }
 
     #[test]

--- a/crates/er-engine/src/arena/orchestrator.rs
+++ b/crates/er-engine/src/arena/orchestrator.rs
@@ -554,6 +554,7 @@ fn run_round1_parallel(
     let cancelled: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
     let paths = paths.clone();
+    let storage_dir = paths.root.to_string_lossy().into_owned();
     let mut handles = Vec::new();
     for reviewer in reviewers {
         let reviewer = reviewer.clone();
@@ -562,6 +563,7 @@ fn run_round1_parallel(
         let repo_root = repo_root.clone();
         let patch_path = patch_path.clone();
         let paths = paths.clone();
+        let storage_dir = storage_dir.clone();
         let cancel = Arc::clone(&cancel);
         let children = Arc::clone(&children);
         let ok = Arc::clone(&ok);
@@ -584,6 +586,7 @@ fn run_round1_parallel(
                 &reviewer.provider_id,
                 &reviewer.model_id,
                 effort.as_deref(),
+                Some(storage_dir.as_str()),
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -688,6 +691,7 @@ fn run_round2_parallel(
     let cancelled: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
     let paths = paths.clone();
+    let storage_dir = paths.root.to_string_lossy().into_owned();
     let mut handles = Vec::new();
     for reviewer in reviewers {
         let reviewer = reviewer.clone();
@@ -697,6 +701,7 @@ fn run_round2_parallel(
         let patch_path = patch_path.clone();
         let findings_json = findings_json.clone();
         let paths = paths.clone();
+        let storage_dir = storage_dir.clone();
         let cancel = Arc::clone(&cancel);
         let children = Arc::clone(&children);
         let ok = Arc::clone(&ok);
@@ -717,6 +722,7 @@ fn run_round2_parallel(
                 &reviewer.provider_id,
                 &reviewer.model_id,
                 effort.as_deref(),
+                Some(storage_dir.as_str()),
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -986,6 +992,7 @@ fn run_supervisor(
         &arbiter_ref.provider_id,
         &arbiter_ref.model_id,
         run_effort.as_deref(),
+        Some(paths.root.to_string_lossy().as_ref()),
     )?;
     emit(
         registry,

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -556,15 +556,20 @@ pub fn agent_command_is_cursor(command: &str) -> bool {
     command == "agent" || command.ends_with("/agent")
 }
 
-/// Allow built-in agent CLIs to read and write Easy Review's managed storage.
+/// Allow built-in agent CLIs to access a specific Easy Review storage directory.
 ///
 /// Managed sidecars normally live outside the repository, so a child CLI with
 /// a workspace sandbox cannot reach them through its current working directory.
-/// The supported CLIs all expose `--add-dir`; passing the storage root grants
-/// access to its descendants without making the directory globally writable.
-/// Unknown/custom provider commands are left unchanged because their command
-/// line contracts are not known to us.
-pub fn inject_agent_storage_access(command: &str, args: &mut Vec<String>) {
+/// Callers must pass the active review bucket (`er_dir`), never the global
+/// storage root — Codex `--add-dir` under `workspace-write` makes that path
+/// writable. Pass `None` for read-only invocations or when artifacts already
+/// live inside the worktree. Unknown/custom provider commands are left
+/// unchanged because their command line contracts are not known to us.
+pub fn inject_agent_storage_access(
+    command: &str,
+    args: &mut Vec<String>,
+    storage_dir: Option<&str>,
+) {
     if !(agent_command_is_claude(command)
         || agent_command_is_codex(command)
         || agent_command_is_cursor(command))
@@ -572,9 +577,10 @@ pub fn inject_agent_storage_access(command: &str, args: &mut Vec<String>) {
         return;
     }
 
-    let storage_dir = crate::storage::storage_root()
-        .to_string_lossy()
-        .into_owned();
+    let Some(directory) = storage_dir.map(str::trim).filter(|dir| !dir.is_empty()) else {
+        return;
+    };
+
     let insert_at = if agent_command_is_codex(command) {
         args.iter()
             .position(|arg| arg == "exec")
@@ -582,15 +588,27 @@ pub fn inject_agent_storage_access(command: &str, args: &mut Vec<String>) {
             .or_else(|| args.iter().position(|arg| arg.contains("{prompt}")))
             .unwrap_or(args.len())
     } else {
-        // Claude accepts multiple values for --add-dir. Put the next option
-        // immediately after the directory so the eventual prompt cannot be
-        // consumed as another directory.
-        0
+        // Insert before the first dashed option so a bare `{prompt}` token is
+        // never treated as another `--add-dir` value. Prefer the `=` form for
+        // Claude/Cursor so multi-value `--add-dir` cannot swallow the next arg.
+        args.iter()
+            .position(|arg| arg.starts_with('-'))
+            .unwrap_or(0)
     };
-    inject_additional_dir(args, &storage_dir, insert_at);
+
+    if agent_command_is_codex(command) {
+        inject_additional_dir(args, directory, insert_at, false);
+    } else {
+        inject_additional_dir(args, directory, insert_at, true);
+    }
 }
 
-fn inject_additional_dir(args: &mut Vec<String>, directory: &str, insert_at: usize) {
+fn inject_additional_dir(
+    args: &mut Vec<String>,
+    directory: &str,
+    insert_at: usize,
+    equals_form: bool,
+) {
     if args
         .windows(2)
         .any(|pair| pair[0] == "--add-dir" && pair[1] == directory)
@@ -601,8 +619,12 @@ fn inject_additional_dir(args: &mut Vec<String>, directory: &str, insert_at: usi
         return;
     }
 
-    args.insert(insert_at, directory.to_string());
-    args.insert(insert_at, "--add-dir".to_string());
+    if equals_form {
+        args.insert(insert_at, format!("--add-dir={directory}"));
+    } else {
+        args.insert(insert_at, directory.to_string());
+        args.insert(insert_at, "--add-dir".to_string());
+    }
 }
 
 /// App-launched Codex runs should be hermetic from user plugins/MCP hooks.
@@ -1874,9 +1896,7 @@ mod tests {
 
     #[test]
     fn supported_agent_commands_receive_managed_storage_access_once() {
-        let expected_dir = crate::storage::storage_root()
-            .to_string_lossy()
-            .into_owned();
+        const DIR: &str = "/managed/repos/demo/branches/main/view-buckets/branch";
 
         for command in ["claude", "codex", "agent"] {
             let mut args = match command {
@@ -1892,30 +1912,70 @@ mod tests {
                     "{prompt}".to_string(),
                 ],
             };
-            inject_agent_storage_access(command, &mut args);
-            inject_agent_storage_access(command, &mut args);
+            inject_agent_storage_access(command, &mut args, Some(DIR));
+            inject_agent_storage_access(command, &mut args, Some(DIR));
 
+            let add_dir_count = args
+                .windows(2)
+                .filter(|pair| pair[0] == "--add-dir" && pair[1] == DIR)
+                .count()
+                + args
+                    .iter()
+                    .filter(|arg| arg.as_str() == &format!("--add-dir={DIR}"))
+                    .count();
             assert_eq!(
-                args.windows(2)
-                    .filter(|pair| pair[0] == "--add-dir" && pair[1] == expected_dir)
-                    .count(),
-                1,
+                add_dir_count, 1,
                 "managed storage should be added once for {command}"
             );
-            let add_dir_index = args.iter().position(|arg| arg == "--add-dir").unwrap();
             if command == "codex" {
+                let add_dir_index = args.iter().position(|arg| arg == "--add-dir").unwrap();
                 assert_eq!(add_dir_index, 1);
+                assert!(add_dir_index < args.iter().position(|arg| arg == "{prompt}").unwrap());
             } else {
-                assert_eq!(add_dir_index, 0);
+                assert_eq!(args[0], format!("--add-dir={DIR}"));
+                assert!(args.iter().any(|arg| arg == "{prompt}"));
             }
-            assert!(add_dir_index < args.iter().position(|arg| arg == "{prompt}").unwrap());
         }
+    }
+
+    #[test]
+    fn storage_access_skipped_without_directory() {
+        let mut args = vec![
+            "exec".to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "{prompt}".to_string(),
+        ];
+        inject_agent_storage_access("codex", &mut args, None);
+        inject_agent_storage_access("codex", &mut args, Some(""));
+        assert!(!args.iter().any(|arg| arg.contains("--add-dir")));
+    }
+
+    #[test]
+    fn claude_add_dir_does_not_swallow_bare_prompt() {
+        let mut args = vec!["{prompt}".to_string()];
+        inject_agent_storage_access(
+            "claude",
+            &mut args,
+            Some("/managed/repos/demo/view-buckets/branch"),
+        );
+        assert_eq!(
+            args,
+            vec![
+                "--add-dir=/managed/repos/demo/view-buckets/branch".to_string(),
+                "{prompt}".to_string(),
+            ]
+        );
     }
 
     #[test]
     fn custom_agent_commands_do_not_receive_unknown_flags() {
         let mut args = vec!["{prompt}".to_string()];
-        inject_agent_storage_access("my-custom-provider", &mut args);
+        inject_agent_storage_access(
+            "my-custom-provider",
+            &mut args,
+            Some("/managed/repos/demo"),
+        );
         assert_eq!(args, vec!["{prompt}".to_string()]);
     }
 

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -425,6 +425,43 @@ impl AiHubConfig {
         }
     }
 
+    /// Validate a provider/model choice and normalize effort without mutating
+    /// persisted defaults. Used for session-only (palette) selection.
+    pub fn resolve_selection(
+        &self,
+        provider_id: &str,
+        model_id: Option<&str>,
+        agent: &AgentConfig,
+        runtime_effort: Option<&str>,
+    ) -> Result<AiSelection> {
+        let provider = self
+            .providers
+            .get(provider_id)
+            .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {provider_id}"))?;
+        if let Some(model_id) = model_id {
+            if !provider.models.iter().any(|model| model.id == model_id) {
+                return Err(anyhow::anyhow!(
+                    "Unknown model '{model_id}' for provider '{provider_id}'"
+                ));
+            }
+        }
+
+        let resolved_model = self.resolve_model_id(provider_id, model_id);
+        let effort = resolve_effort_for_model(
+            self,
+            agent,
+            Some(provider_id),
+            resolved_model.as_deref(),
+            runtime_effort,
+            None,
+        );
+        Ok(AiSelection {
+            provider_id: Some(provider_id.to_string()),
+            model_id: resolved_model,
+            effort,
+        })
+    }
+
     /// Validate and persist a new global provider/model selection. A missing
     /// model means the provider's first valid model (or no model for a
     /// command-only provider). Existing effort is retained only when the
@@ -2226,5 +2263,40 @@ mod tests {
                 .to_string(),
             "Unknown model 'missing' for provider 'codex'"
         );
+    }
+
+    #[test]
+    fn resolve_selection_keeps_runtime_effort_without_mutating_defaults() {
+        let mut config = ErConfig::default();
+        config.ai_hub.default_provider = Some("codex".into());
+        config.ai_hub.default_model = Some("gpt-5.6-luna".into());
+        config.ai_hub.default_effort = Some("medium".into());
+        config.ai_hub.providers.insert(
+            "codex".into(),
+            AiProviderConfig {
+                models: vec![
+                    AiModelConfig {
+                        id: "gpt-5.6-luna".into(),
+                        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                        ..Default::default()
+                    },
+                    AiModelConfig {
+                        id: "gpt-5.5".into(),
+                        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+
+        let selected = config
+            .ai_hub
+            .resolve_selection("codex", Some("gpt-5.5"), &config.agent, Some("high"))
+            .unwrap();
+        assert_eq!(selected.model_id.as_deref(), Some("gpt-5.5"));
+        assert_eq!(selected.effort.as_deref(), Some("high"));
+        assert_eq!(config.ai_hub.default_model.as_deref(), Some("gpt-5.6-luna"));
+        assert_eq!(config.ai_hub.default_effort.as_deref(), Some("medium"));
     }
 }

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -156,12 +156,10 @@ pub struct AiHubConfig {
     pub default_provider: Option<String>,
     #[serde(default)]
     pub default_model: Option<String>,
-    /// Default Claude Code `--effort` for spawns (overridden per arena run).
+    /// Default reasoning/effort override for ordinary AI Hub spawns.
+    /// Arena reviewer and arbiter selections remain exact per-run values.
     #[serde(default)]
     pub default_effort: Option<String>,
-    /// Per-reviewer model overrides (e.g. `triage = "haiku-4.5"`).
-    #[serde(default)]
-    pub reviewer_models: BTreeMap<String, String>,
     #[serde(default)]
     pub providers: BTreeMap<String, AiProviderConfig>,
     /// Max agent processes running at once (background reviews + arena
@@ -173,6 +171,17 @@ pub struct AiHubConfig {
 
 /// Default cap on concurrently running agent processes.
 pub const DEFAULT_MAX_CONCURRENT_REVIEWS: usize = 3;
+
+/// A validated provider/model/effort choice used by ordinary AI actions.
+///
+/// Arena reviewers intentionally do not use this type: their `ReviewerRef`
+/// values are exact per-run selections.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AiSelection {
+    pub provider_id: Option<String>,
+    pub model_id: Option<String>,
+    pub effort: Option<String>,
+}
 
 impl AiHubConfig {
     /// Effective concurrency cap — configured value, or the default when unset.
@@ -393,64 +402,69 @@ impl AiHubConfig {
             .or_else(|| provider.models.first().map(|m| m.id.clone()))
     }
 
+    /// Resolve the persisted default into a provider/model/effort tuple that
+    /// is valid against the current catalog. This is the single fallback
+    /// path shared by Settings, Desktop, TUI, and ordinary AI spawns.
+    pub fn resolve_default_selection(&self, agent: &AgentConfig) -> AiSelection {
+        let provider_id = self.resolve_provider_id(self.default_provider.as_deref());
+        let model_id = provider_id
+            .as_deref()
+            .and_then(|id| self.resolve_model_id(id, self.default_model.as_deref()));
+        let effort = resolve_effort_for_model(
+            self,
+            agent,
+            provider_id.as_deref(),
+            model_id.as_deref(),
+            self.default_effort.as_deref(),
+            None,
+        );
+        AiSelection {
+            provider_id,
+            model_id,
+            effort,
+        }
+    }
+
+    /// Validate and persist a new global provider/model selection. A missing
+    /// model means the provider's first valid model (or no model for a
+    /// command-only provider). Existing effort is retained only when the
+    /// selected model still supports it.
+    pub fn set_default_selection(
+        &mut self,
+        provider_id: &str,
+        model_id: Option<&str>,
+        agent: &AgentConfig,
+    ) -> Result<AiSelection> {
+        let provider = self
+            .providers
+            .get(provider_id)
+            .ok_or_else(|| anyhow::anyhow!("Unknown AI provider: {provider_id}"))?;
+        if let Some(model_id) = model_id {
+            if !provider.models.iter().any(|model| model.id == model_id) {
+                return Err(anyhow::anyhow!(
+                    "Unknown model '{model_id}' for provider '{provider_id}'"
+                ));
+            }
+        }
+
+        let resolved_model = self.resolve_model_id(provider_id, model_id);
+        self.default_provider = Some(provider_id.to_string());
+        self.default_model = resolved_model;
+        self.default_effort = normalize_effort(
+            self,
+            Some(provider_id),
+            self.default_model.as_deref(),
+            self.default_effort.as_deref(),
+        );
+
+        Ok(self.resolve_default_selection(agent))
+    }
+
     /// Whether any configured provider exposes this model id.
     pub fn hub_model_exists(&self, model_id: &str) -> bool {
         self.providers
             .values()
             .any(|provider| provider.models.iter().any(|model| model.id == model_id))
-    }
-
-    /// Explicit triage model override, if configured.
-    pub fn triage_model_id(&self) -> Option<&str> {
-        self.reviewer_models.get("triage").map(String::as_str)
-    }
-
-    /// Model id for a reviewer kind when spawning (e.g. triage → haiku).
-    pub fn resolve_reviewer_model(&self, reviewer_kind: &str, provider_id: &str) -> Option<String> {
-        let provider = self.providers.get(provider_id)?;
-        if let Some(configured) = self.reviewer_models.get(reviewer_kind) {
-            if provider.models.iter().any(|m| &m.id == configured) {
-                return Some(configured.clone());
-            }
-        }
-        if reviewer_kind == "triage" {
-            return provider
-                .models
-                .iter()
-                .min_by_key(|m| m.avg_latency_ms.unwrap_or(u32::MAX))
-                .map(|m| m.id.clone());
-        }
-        if reviewer_kind == "tour" {
-            // Tour generation is clustering + short descriptions — Opus is
-            // overkill. Default to a Sonnet-class model (good quality, far
-            // cheaper/faster); fall back to the fastest model when none exists.
-            if let Some(m) = provider
-                .models
-                .iter()
-                .find(|m| m.id.to_lowercase().contains("sonnet"))
-            {
-                return Some(m.id.clone());
-            }
-            return provider
-                .models
-                .iter()
-                .min_by_key(|m| m.avg_latency_ms.unwrap_or(u32::MAX))
-                .map(|m| m.id.clone());
-        }
-        None
-    }
-
-    /// Resolve model for spawn: reviewer override when configured, else user selection.
-    pub fn resolve_spawn_model_id(
-        &self,
-        provider_id: &str,
-        user_model: Option<&str>,
-        task_kind: &str,
-    ) -> Option<String> {
-        if let Some(id) = self.resolve_reviewer_model(task_kind, provider_id) {
-            return Some(id);
-        }
-        self.resolve_model_id(provider_id, user_model)
     }
 }
 
@@ -485,8 +499,6 @@ pub fn supplement_ai_hub(hub: &mut AiHubConfig) {
             .models
             .retain(|model| !DEPRECATED_CLAUDE_MODEL_IDS.contains(&model.id.as_str()));
     }
-    hub.reviewer_models
-        .retain(|_, model_id| !DEPRECATED_CLAUDE_MODEL_IDS.contains(&model_id.as_str()));
     if deprecated_default {
         hub.default_model = catalog.default_model.clone();
     }
@@ -537,6 +549,60 @@ pub fn agent_command_is_claude(command: &str) -> bool {
 /// True when the provider command is the Codex CLI (supports `-c model_reasoning_effort=...`).
 pub fn agent_command_is_codex(command: &str) -> bool {
     command == "codex" || command.ends_with("/codex")
+}
+
+/// True when the provider command is Cursor Agent (supports `--add-dir`).
+pub fn agent_command_is_cursor(command: &str) -> bool {
+    command == "agent" || command.ends_with("/agent")
+}
+
+/// Allow built-in agent CLIs to read and write Easy Review's managed storage.
+///
+/// Managed sidecars normally live outside the repository, so a child CLI with
+/// a workspace sandbox cannot reach them through its current working directory.
+/// The supported CLIs all expose `--add-dir`; passing the storage root grants
+/// access to its descendants without making the directory globally writable.
+/// Unknown/custom provider commands are left unchanged because their command
+/// line contracts are not known to us.
+pub fn inject_agent_storage_access(command: &str, args: &mut Vec<String>) {
+    if !(agent_command_is_claude(command)
+        || agent_command_is_codex(command)
+        || agent_command_is_cursor(command))
+    {
+        return;
+    }
+
+    let storage_dir = crate::storage::storage_root()
+        .to_string_lossy()
+        .into_owned();
+    let insert_at = if agent_command_is_codex(command) {
+        args.iter()
+            .position(|arg| arg == "exec")
+            .map(|index| index + 1)
+            .or_else(|| args.iter().position(|arg| arg.contains("{prompt}")))
+            .unwrap_or(args.len())
+    } else {
+        // Claude accepts multiple values for --add-dir. Put the next option
+        // immediately after the directory so the eventual prompt cannot be
+        // consumed as another directory.
+        0
+    };
+    inject_additional_dir(args, &storage_dir, insert_at);
+}
+
+fn inject_additional_dir(args: &mut Vec<String>, directory: &str, insert_at: usize) {
+    if args
+        .windows(2)
+        .any(|pair| pair[0] == "--add-dir" && pair[1] == directory)
+        || args
+            .iter()
+            .any(|arg| arg == &format!("--add-dir={directory}"))
+    {
+        return;
+    }
+
+    args.insert(insert_at, directory.to_string());
+    args.insert(insert_at, "--add-dir".to_string());
 }
 
 /// App-launched Codex runs should be hermetic from user plugins/MCP hooks.
@@ -1044,16 +1110,17 @@ fn hub_provider_options(config: &ErConfig) -> Vec<String> {
 fn hub_provider_value(config: &ErConfig) -> String {
     config
         .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+        .resolve_default_selection(&config.agent)
+        .provider_id
         .unwrap_or_else(|| "Auto".into())
 }
 
 fn hub_model_options(config: &ErConfig) -> Vec<String> {
-    let Some(provider) = config
-        .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
-        .and_then(|id| config.ai_hub.providers.get(&id))
-    else {
+    let selection = config.ai_hub.resolve_default_selection(&config.agent);
+    let Some(provider_id) = selection.provider_id else {
+        return vec!["Auto".into()];
+    };
+    let Some(provider) = config.ai_hub.providers.get(&provider_id) else {
         return vec!["Auto".into()];
     };
     provider
@@ -1066,29 +1133,22 @@ fn hub_model_options(config: &ErConfig) -> Vec<String> {
 fn hub_model_value(config: &ErConfig) -> String {
     config
         .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
-        .and_then(|provider| {
-            config
-                .ai_hub
-                .resolve_model_id(&provider, config.ai_hub.default_model.as_deref())
-        })
+        .resolve_default_selection(&config.agent)
+        .model_id
         .unwrap_or_else(|| "Auto".into())
 }
 
 fn hub_effort_options(config: &ErConfig) -> Vec<String> {
-    let provider = config
-        .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref());
-    let model = provider.as_deref().and_then(|id| {
-        config
-            .ai_hub
-            .resolve_model_id(id, config.ai_hub.default_model.as_deref())
-    });
+    let selection = config.ai_hub.resolve_default_selection(&config.agent);
     let mut options = vec![AUTO_EFFORT.into()];
     options.extend(
-        effort_levels_for_hub_model(&config.ai_hub, provider.as_deref(), model.as_deref())
-            .iter()
-            .cloned(),
+        effort_levels_for_hub_model(
+            &config.ai_hub,
+            selection.provider_id.as_deref(),
+            selection.model_id.as_deref(),
+        )
+        .iter()
+        .cloned(),
     );
     options
 }
@@ -1096,63 +1156,36 @@ fn hub_effort_options(config: &ErConfig) -> Vec<String> {
 fn hub_effort_value(config: &ErConfig) -> String {
     config
         .ai_hub
-        .default_effort
-        .clone()
+        .resolve_default_selection(&config.agent)
+        .effort
         .unwrap_or_else(|| AUTO_EFFORT.into())
 }
 
 fn set_hub_provider(config: &mut ErConfig, provider: String) {
-    if !config.ai_hub.providers.contains_key(&provider) {
-        return;
-    }
-    config.ai_hub.default_provider = Some(provider.clone());
-    config.ai_hub.default_model = config.ai_hub.resolve_model_id(&provider, None);
-    config.ai_hub.default_effort = normalize_effort(
-        &config.ai_hub,
-        Some(&provider),
-        config.ai_hub.default_model.as_deref(),
-        config.ai_hub.default_effort.as_deref(),
-    );
+    let agent = config.agent.clone();
+    let _ = config.ai_hub.set_default_selection(&provider, None, &agent);
 }
 
 fn set_hub_model(config: &mut ErConfig, model: String) {
     let Some(provider) = config
         .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref())
+        .resolve_default_selection(&config.agent)
+        .provider_id
     else {
         return;
     };
-    if !config
+    let agent = config.agent.clone();
+    let _ = config
         .ai_hub
-        .providers
-        .get(&provider)
-        .is_some_and(|p| p.models.iter().any(|m| m.id == model))
-    {
-        return;
-    }
-    config.ai_hub.default_provider = Some(provider.clone());
-    config.ai_hub.default_model = Some(model.clone());
-    config.ai_hub.default_effort = normalize_effort(
-        &config.ai_hub,
-        Some(&provider),
-        Some(&model),
-        config.ai_hub.default_effort.as_deref(),
-    );
+        .set_default_selection(&provider, Some(&model), &agent);
 }
 
 fn set_hub_effort(config: &mut ErConfig, effort: String) {
-    let provider = config
-        .ai_hub
-        .resolve_provider_id(config.ai_hub.default_provider.as_deref());
-    let model = provider.as_deref().and_then(|id| {
-        config
-            .ai_hub
-            .resolve_model_id(id, config.ai_hub.default_model.as_deref())
-    });
+    let selection = config.ai_hub.resolve_default_selection(&config.agent);
     config.ai_hub.default_effort = normalize_effort(
         &config.ai_hub,
-        provider.as_deref(),
-        model.as_deref(),
+        selection.provider_id.as_deref(),
+        selection.model_id.as_deref(),
         Some(&effort),
     );
 }
@@ -1270,12 +1303,12 @@ fn terminal_config_hub_items(_config: &ErConfig) -> Vec<ConfigItem> {
         ConfigItem::SectionHeader("AI".into()),
         ConfigItem::Action {
             label: "Copy review.json".into(),
-            description: "Copy .er/review.json to clipboard".into(),
+            description: "Copy review.json to clipboard".into(),
             action_id: "copy_review_json",
         },
         ConfigItem::Action {
             label: "Copy questions.json".into(),
-            description: "Copy .er/questions.json to clipboard".into(),
+            description: "Copy questions.json to clipboard".into(),
             action_id: "copy_questions_json",
         },
     ]
@@ -1840,6 +1873,53 @@ mod tests {
     }
 
     #[test]
+    fn supported_agent_commands_receive_managed_storage_access_once() {
+        let expected_dir = crate::storage::storage_root()
+            .to_string_lossy()
+            .into_owned();
+
+        for command in ["claude", "codex", "agent"] {
+            let mut args = match command {
+                "codex" => vec![
+                    "exec".to_string(),
+                    "--sandbox".to_string(),
+                    "workspace-write".to_string(),
+                    "{prompt}".to_string(),
+                ],
+                _ => vec![
+                    "--print".to_string(),
+                    "-p".to_string(),
+                    "{prompt}".to_string(),
+                ],
+            };
+            inject_agent_storage_access(command, &mut args);
+            inject_agent_storage_access(command, &mut args);
+
+            assert_eq!(
+                args.windows(2)
+                    .filter(|pair| pair[0] == "--add-dir" && pair[1] == expected_dir)
+                    .count(),
+                1,
+                "managed storage should be added once for {command}"
+            );
+            let add_dir_index = args.iter().position(|arg| arg == "--add-dir").unwrap();
+            if command == "codex" {
+                assert_eq!(add_dir_index, 1);
+            } else {
+                assert_eq!(add_dir_index, 0);
+            }
+            assert!(add_dir_index < args.iter().position(|arg| arg == "{prompt}").unwrap());
+        }
+    }
+
+    #[test]
+    fn custom_agent_commands_do_not_receive_unknown_flags() {
+        let mut args = vec!["{prompt}".to_string()];
+        inject_agent_storage_access("my-custom-provider", &mut args);
+        assert_eq!(args, vec!["{prompt}".to_string()]);
+    }
+
+    #[test]
     fn supplement_ai_hub_adds_missing_catalog_models() {
         let mut hub = AiHubConfig {
             providers: BTreeMap::from([(
@@ -1980,27 +2060,6 @@ mod tests {
     }
 
     #[test]
-    fn triage_model_override_must_exist_in_hub() {
-        let mut hub = AiHubConfig::default();
-        hub.providers.insert(
-            "claude".into(),
-            AiProviderConfig {
-                models: vec![AiModelConfig {
-                    id: "haiku-4.5".into(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            },
-        );
-        assert!(hub.hub_model_exists("haiku-4.5"));
-        assert!(!hub.hub_model_exists("missing-model"));
-        assert_eq!(hub.triage_model_id(), None);
-        hub.reviewer_models
-            .insert("triage".into(), "haiku-4.5".into());
-        assert_eq!(hub.triage_model_id(), Some("haiku-4.5"));
-    }
-
-    #[test]
     fn resolve_effort_precedence() {
         let hub = AiHubConfig {
             default_effort: Some("medium".into()),
@@ -2030,76 +2089,82 @@ mod tests {
     }
 
     #[test]
-    fn resolve_reviewer_model_prefers_configured_triage() {
+    fn default_selection_uses_the_configured_model_for_every_action() {
         let mut hub = AiHubConfig::default();
-        hub.reviewer_models
-            .insert("triage".into(), "haiku-4.5".into());
+        hub.default_provider = Some("codex".into());
+        hub.default_model = Some("gpt-5.6-luna".into());
+        hub.default_effort = Some("high".into());
         hub.providers.insert(
-            "claude".into(),
+            "codex".into(),
             AiProviderConfig {
                 models: vec![
                     AiModelConfig {
-                        id: "sonnet-4.6".into(),
-                        avg_latency_ms: Some(12_000),
+                        id: "gpt-5.6-luna".into(),
+                        effort_levels: vec!["high".into()],
                         ..Default::default()
                     },
                     AiModelConfig {
-                        id: "haiku-4.5".into(),
-                        avg_latency_ms: Some(5_000),
+                        id: "gpt-5.3-codex-spark".into(),
+                        avg_latency_ms: Some(1),
                         ..Default::default()
                     },
                 ],
                 ..Default::default()
             },
         );
+
+        let selection = hub.resolve_default_selection(&AgentConfig::default());
+        assert_eq!(selection.provider_id.as_deref(), Some("codex"));
+        assert_eq!(selection.model_id.as_deref(), Some("gpt-5.6-luna"));
+        assert_eq!(selection.effort.as_deref(), Some("high"));
         assert_eq!(
-            hub.resolve_reviewer_model("triage", "claude").as_deref(),
-            Some("haiku-4.5")
+            hub.resolve_model_id("codex", None).as_deref(),
+            Some("gpt-5.6-luna")
         );
     }
 
     #[test]
-    fn resolve_reviewer_model_tour_defaults_to_sonnet() {
-        let mut hub = AiHubConfig::default();
-        hub.providers.insert(
-            "claude".into(),
+    fn legacy_reviewer_models_are_ignored_when_loading_config() {
+        let config: ErConfig = toml::from_str(
+            r#"
+            [ai_hub.reviewer_models]
+            triage = "gpt-5.3-codex-spark"
+            "#,
+        )
+        .unwrap();
+        assert!(config.ai_hub.providers.is_empty());
+    }
+
+    #[test]
+    fn set_default_selection_validates_and_normalizes_the_shared_choice() {
+        let mut config = ErConfig::default();
+        config.ai_hub.providers.insert(
+            "codex".into(),
             AiProviderConfig {
-                models: vec![
-                    AiModelConfig {
-                        id: "claude-opus-4-8".into(),
-                        avg_latency_ms: Some(20_000),
-                        ..Default::default()
-                    },
-                    AiModelConfig {
-                        id: "claude-sonnet-4-6".into(),
-                        avg_latency_ms: Some(12_000),
-                        ..Default::default()
-                    },
-                    AiModelConfig {
-                        id: "claude-haiku-4-5".into(),
-                        avg_latency_ms: Some(5_000),
-                        ..Default::default()
-                    },
-                ],
+                models: vec![AiModelConfig {
+                    id: "gpt-5.6-luna".into(),
+                    effort_levels: vec!["high".into()],
+                    ..Default::default()
+                }],
                 ..Default::default()
             },
         );
-        // No override → defaults to the Sonnet-class model (not Opus, not Haiku).
+        config.ai_hub.default_effort = Some("high".into());
+
+        let selected = config
+            .ai_hub
+            .set_default_selection("codex", Some("gpt-5.6-luna"), &config.agent)
+            .unwrap();
+        assert_eq!(config.ai_hub.default_provider.as_deref(), Some("codex"));
+        assert_eq!(config.ai_hub.default_model.as_deref(), Some("gpt-5.6-luna"));
+        assert_eq!(selected.model_id.as_deref(), Some("gpt-5.6-luna"));
         assert_eq!(
-            hub.resolve_reviewer_model("tour", "claude").as_deref(),
-            Some("claude-sonnet-4-6")
-        );
-        assert_eq!(
-            hub.resolve_spawn_model_id("claude", Some("claude-opus-4-8"), "tour")
-                .as_deref(),
-            Some("claude-sonnet-4-6")
-        );
-        // Explicit override is honored.
-        hub.reviewer_models
-            .insert("tour".into(), "claude-haiku-4-5".into());
-        assert_eq!(
-            hub.resolve_reviewer_model("tour", "claude").as_deref(),
-            Some("claude-haiku-4-5")
+            config
+                .ai_hub
+                .set_default_selection("codex", Some("missing"), &config.agent)
+                .unwrap_err()
+                .to_string(),
+            "Unknown model 'missing' for provider 'codex'"
         );
     }
 }

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -1952,14 +1952,12 @@ mod tests {
             inject_agent_storage_access(command, &mut args, Some(DIR));
             inject_agent_storage_access(command, &mut args, Some(DIR));
 
+            let add_dir_flag = format!("--add-dir={DIR}");
             let add_dir_count = args
                 .windows(2)
                 .filter(|pair| pair[0] == "--add-dir" && pair[1] == DIR)
                 .count()
-                + args
-                    .iter()
-                    .filter(|arg| arg.as_str() == &format!("--add-dir={DIR}"))
-                    .count();
+                + args.iter().filter(|arg| **arg == add_dir_flag).count();
             assert_eq!(
                 add_dir_count, 1,
                 "managed storage should be added once for {command}"
@@ -2008,11 +2006,7 @@ mod tests {
     #[test]
     fn custom_agent_commands_do_not_receive_unknown_flags() {
         let mut args = vec!["{prompt}".to_string()];
-        inject_agent_storage_access(
-            "my-custom-provider",
-            &mut args,
-            Some("/managed/repos/demo"),
-        );
+        inject_agent_storage_access("my-custom-provider", &mut args, Some("/managed/repos/demo"));
         assert_eq!(args, vec!["{prompt}".to_string()]);
     }
 
@@ -2187,10 +2181,12 @@ mod tests {
 
     #[test]
     fn default_selection_uses_the_configured_model_for_every_action() {
-        let mut hub = AiHubConfig::default();
-        hub.default_provider = Some("codex".into());
-        hub.default_model = Some("gpt-5.6-luna".into());
-        hub.default_effort = Some("high".into());
+        let mut hub = AiHubConfig {
+            default_provider: Some("codex".into()),
+            default_model: Some("gpt-5.6-luna".into()),
+            default_effort: Some("high".into()),
+            ..Default::default()
+        };
         hub.providers.insert(
             "codex".into(),
             AiProviderConfig {
@@ -2267,28 +2263,35 @@ mod tests {
 
     #[test]
     fn resolve_selection_keeps_runtime_effort_without_mutating_defaults() {
-        let mut config = ErConfig::default();
-        config.ai_hub.default_provider = Some("codex".into());
-        config.ai_hub.default_model = Some("gpt-5.6-luna".into());
-        config.ai_hub.default_effort = Some("medium".into());
-        config.ai_hub.providers.insert(
-            "codex".into(),
-            AiProviderConfig {
-                models: vec![
-                    AiModelConfig {
-                        id: "gpt-5.6-luna".into(),
-                        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+        let config = ErConfig {
+            ai_hub: AiHubConfig {
+                default_provider: Some("codex".into()),
+                default_model: Some("gpt-5.6-luna".into()),
+                default_effort: Some("medium".into()),
+                providers: [(
+                    "codex".into(),
+                    AiProviderConfig {
+                        models: vec![
+                            AiModelConfig {
+                                id: "gpt-5.6-luna".into(),
+                                effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                                ..Default::default()
+                            },
+                            AiModelConfig {
+                                id: "gpt-5.5".into(),
+                                effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                                ..Default::default()
+                            },
+                        ],
                         ..Default::default()
                     },
-                    AiModelConfig {
-                        id: "gpt-5.5".into(),
-                        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
-                        ..Default::default()
-                    },
-                ],
+                )]
+                .into_iter()
+                .collect(),
                 ..Default::default()
             },
-        );
+            ..Default::default()
+        };
 
         let selected = config
             .ai_hub

--- a/crates/er-engine/src/config_desktop_settings.rs
+++ b/crates/er-engine/src/config_desktop_settings.rs
@@ -233,19 +233,6 @@ pub fn apply_config_field(config: &mut ErConfig, key: &str, value: ConfigFieldVa
                 config.ai_hub.max_concurrent_reviews = n;
             }
         }
-        "ai_hub.reviewer_models.triage" => {
-            if let ConfigFieldValue::String(v) = value {
-                let model_id = v.trim();
-                if model_id.is_empty() {
-                    config.ai_hub.reviewer_models.remove("triage");
-                } else if config.ai_hub.hub_model_exists(model_id) {
-                    config
-                        .ai_hub
-                        .reviewer_models
-                        .insert("triage".into(), model_id.to_string());
-                }
-            }
-        }
         "watched.diff_mode" => {
             if let ConfigFieldValue::String(v) = value {
                 if v == "content" || v == "snapshot" {
@@ -331,56 +318,6 @@ mod tests {
             ConfigFieldValue::String("high".into()),
         );
         assert_eq!(config.agent.effort.as_deref(), Some("high"));
-    }
-
-    #[test]
-    fn apply_config_field_updates_triage_model_only_when_known() {
-        let mut config = ErConfig::default();
-        config.ai_hub.providers.insert(
-            "claude".into(),
-            crate::config::AiProviderConfig {
-                models: vec![crate::config::AiModelConfig {
-                    id: "haiku-4.5".into(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            },
-        );
-
-        apply_config_field(
-            &mut config,
-            "ai_hub.reviewer_models.triage",
-            ConfigFieldValue::String("haiku-4.5".into()),
-        );
-        assert_eq!(
-            config
-                .ai_hub
-                .reviewer_models
-                .get("triage")
-                .map(String::as_str),
-            Some("haiku-4.5")
-        );
-
-        apply_config_field(
-            &mut config,
-            "ai_hub.reviewer_models.triage",
-            ConfigFieldValue::String("unknown".into()),
-        );
-        assert_eq!(
-            config
-                .ai_hub
-                .reviewer_models
-                .get("triage")
-                .map(String::as_str),
-            Some("haiku-4.5")
-        );
-
-        apply_config_field(
-            &mut config,
-            "ai_hub.reviewer_models.triage",
-            ConfigFieldValue::String(String::new()),
-        );
-        assert!(!config.ai_hub.reviewer_models.contains_key("triage"));
     }
 
     #[test]

--- a/crates/er-tui/src/input/mod.rs
+++ b/crates/er-tui/src/input/mod.rs
@@ -223,11 +223,13 @@ pub(super) fn dispatch_hub_action(app: &mut App, action: HubAction) -> Result<()
                 if provider.models.len() > 1 {
                     app.open_ai_model_picker(provider_id, action);
                 } else {
-                    app.current_ai_provider = Some(provider_id.clone());
-                    app.current_ai_model = provider.models.first().map(|m| m.id.clone());
+                    let model_id = provider.models.first().map(|m| m.id.clone());
                     if let Some(action) = action {
-                        execute_ai_action(app, action)?;
+                        let selection =
+                            app.resolve_ai_selection_override(&provider_id, model_id.as_deref())?;
+                        execute_ai_action_with_selection(app, action, selection)?;
                     } else {
+                        app.set_ai_default_selection(&provider_id, model_id.as_deref())?;
                         app.notify(&format!("AI target: {}", app.active_ai_selection_label()));
                     }
                 }
@@ -240,11 +242,11 @@ pub(super) fn dispatch_hub_action(app: &mut App, action: HubAction) -> Result<()
             provider_id,
             model_id,
         } => {
-            app.current_ai_provider = Some(provider_id);
-            app.current_ai_model = Some(model_id);
             if let Some(action) = action {
-                execute_ai_action(app, action)?;
+                let selection = app.resolve_ai_selection_override(&provider_id, Some(&model_id))?;
+                execute_ai_action_with_selection(app, action, selection)?;
             } else {
+                app.set_ai_default_selection(&provider_id, Some(&model_id))?;
                 app.notify(&format!("AI target: {}", app.active_ai_selection_label()));
             }
         }
@@ -425,6 +427,26 @@ fn execute_ai_action(app: &mut App, action: AiActionKind) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn execute_ai_action_with_selection(
+    app: &mut App,
+    action: AiActionKind,
+    selection: er_engine::config::AiSelection,
+) -> Result<()> {
+    app.set_ai_selection_override(selection);
+    let result = execute_ai_action(app, action);
+    let waiting_for_confirmation = matches!(
+        app.input_mode,
+        er_engine::app::InputMode::Confirm(
+            er_engine::app::ConfirmAction::RunAgentReview { .. }
+                | er_engine::app::ConfirmAction::RunAgentQuestions { .. }
+        )
+    );
+    if !waiting_for_confirmation {
+        app.clear_ai_selection_override();
+    }
+    result
 }
 
 pub fn handle_search_input(app: &mut App, key: KeyEvent) {
@@ -609,6 +631,7 @@ pub fn handle_confirm_input(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(prompt) = build_agent_review_prompt(app) {
                     app.spawn_agent_prompt("review", &prompt)?;
                 }
+                app.clear_ai_selection_override();
             } else if let InputMode::Confirm(ConfirmAction::RunAgentQuestions { .. }) = action {
                 // User said "yes" to clearing previous answers — clear answers, then run
                 app.input_mode = InputMode::Normal;
@@ -618,6 +641,7 @@ pub fn handle_confirm_input(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(prompt) = build_agent_questions_prompt(app) {
                     app.spawn_agent_prompt("questions", &prompt)?;
                 }
+                app.clear_ai_selection_override();
             } else if let InputMode::Confirm(ConfirmAction::ApprovePR) = action {
                 app.input_mode = InputMode::Normal;
                 let repo_root = app.tab().repo_root.clone();
@@ -651,6 +675,7 @@ pub fn handle_confirm_input(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(prompt) = build_agent_review_prompt(app) {
                     app.spawn_agent_prompt("review", &prompt)?;
                 }
+                app.clear_ai_selection_override();
             } else if let InputMode::Confirm(ConfirmAction::RunAgentQuestions { .. }) =
                 &app.input_mode
             {
@@ -658,6 +683,7 @@ pub fn handle_confirm_input(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(prompt) = build_agent_questions_prompt(app) {
                     app.spawn_agent_prompt("questions", &prompt)?;
                 }
+                app.clear_ai_selection_override();
             }
         }
         KeyCode::Esc => {
@@ -1809,5 +1835,41 @@ mod tests {
 
         let expert = build_agent_expert_prompt(&mut app, "security").expect("expert prompt");
         assert_managed_prompt(&expert, output_dir, "experts/security.json");
+    }
+
+    #[test]
+    fn action_bound_model_selection_does_not_change_the_next_default_action() {
+        let mut app = App::new_for_test(vec![]);
+        app.config.ai_hub.default_provider = Some("codex".into());
+        app.config.ai_hub.default_model = Some("gpt-5.6-luna".into());
+        app.config.ai_hub.providers.insert(
+            "codex".into(),
+            er_engine::config::AiProviderConfig {
+                models: vec![
+                    er_engine::config::AiModelConfig {
+                        id: "gpt-5.6-luna".into(),
+                        ..Default::default()
+                    },
+                    er_engine::config::AiModelConfig {
+                        id: "gpt-5.3-codex-spark".into(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        app.sync_ai_selection_from_defaults();
+
+        let selected_for_run = app
+            .resolve_ai_selection_override("codex", Some("gpt-5.3-codex-spark"))
+            .unwrap();
+        execute_ai_action_with_selection(&mut app, AiActionKind::Validate, selected_for_run)
+            .unwrap();
+
+        assert_eq!(app.current_ai_model.as_deref(), Some("gpt-5.6-luna"));
+        assert_eq!(
+            app.config.ai_hub.default_model.as_deref(),
+            Some("gpt-5.6-luna")
+        );
     }
 }

--- a/crates/er-tui/src/ui/diff_view.rs
+++ b/crates/er-tui/src/ui/diff_view.rs
@@ -340,7 +340,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App, hl: &mut Highlighter) {
             };
             header_spans.push(Span::styled("  ", ratatui::style::Style::default()));
             header_spans.push(Span::styled(
-                format!("{} {}", fr.risk.symbol(), risk_label),
+                format!("Risk {risk_label}"),
                 risk_style,
             ));
             if !fr.risk_reason.is_empty() {

--- a/crates/er-tui/src/ui/diff_view.rs
+++ b/crates/er-tui/src/ui/diff_view.rs
@@ -339,10 +339,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App, hl: &mut Highlighter) {
                 RiskLevel::Info => "INFO",
             };
             header_spans.push(Span::styled("  ", ratatui::style::Style::default()));
-            header_spans.push(Span::styled(
-                format!("Risk {risk_label}"),
-                risk_style,
-            ));
+            header_spans.push(Span::styled(format!("Risk {risk_label}"), risk_style));
             if !fr.risk_reason.is_empty() {
                 header_spans.push(Span::styled(
                     format!(" — {}", fr.risk_reason),

--- a/crates/er-tui/src/ui/file_tree.rs
+++ b/crates/er-tui/src/ui/file_tree.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 
 use super::styles;
 use super::utils::{horizontal_rule, word_wrap};
-use er_engine::ai::RiskLevel;
+use er_engine::ai::{Finding, RiskLevel};
 use er_engine::app::{App, DiffMode};
 use er_engine::git::FileStatus;
 
@@ -26,6 +26,54 @@ fn format_relative_time(mtime: SystemTime) -> String {
         return format!("{}h ago", secs / 3600);
     }
     format!("{}d ago", secs / 86400)
+}
+
+fn finding_severity_style(severity: RiskLevel, stale: bool) -> ratatui::style::Style {
+    if stale {
+        styles::stale_style()
+    } else {
+        match severity {
+            RiskLevel::High => styles::risk_high(),
+            RiskLevel::Medium => styles::risk_medium(),
+            RiskLevel::Low => styles::risk_low(),
+            RiskLevel::Info => ratatui::style::Style::default().fg(styles::BLUE()),
+        }
+    }
+}
+
+fn finding_dots_display_width(count: usize) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    const MAX_DOTS: usize = 3;
+    if count > MAX_DOTS {
+        MAX_DOTS + format!("+{} ", count - MAX_DOTS).chars().count()
+    } else {
+        count + 1
+    }
+}
+
+fn finding_dot_spans(findings: &[&Finding], stale: bool) -> Vec<Span<'static>> {
+    const MAX_DOTS: usize = 3;
+    if findings.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    for f in findings.iter().take(MAX_DOTS) {
+        spans.push(Span::styled(
+            f.severity.symbol().to_string(),
+            finding_severity_style(f.severity, stale),
+        ));
+    }
+    if findings.len() > MAX_DOTS {
+        spans.push(Span::styled(
+            format!("+{} ", findings.len() - MAX_DOTS),
+            ratatui::style::Style::default().fg(styles::DIM()),
+        ));
+    } else {
+        spans.push(Span::raw(" "));
+    }
+    spans
 }
 
 /// Render the file tree panel (left side)
@@ -126,28 +174,13 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                 }
             };
 
-            // Risk dot (only in overlay mode with AI data)
-            let risk_dot = if in_overlay {
-                if let Some(fr) = tab.ai.file_review(&file.path) {
-                    let file_stale = tab.ai.is_file_stale(&file.path);
-                    let dot_style = if file_stale {
-                        styles::stale_style()
-                    } else {
-                        match fr.risk {
-                            RiskLevel::High => styles::risk_high(),
-                            RiskLevel::Medium => styles::risk_medium(),
-                            RiskLevel::Low => styles::risk_low(),
-                            RiskLevel::Info => ratatui::style::Style::default().fg(styles::BLUE()),
-                        }
-                    };
-                    Some(Span::styled(format!("{} ", fr.risk.symbol()), dot_style))
-                } else {
-                    // No AI data for this file — show empty dot
-                    Some(Span::styled("  ", ratatui::style::Style::default()))
-                }
+            let file_stale = in_overlay && tab.ai.is_file_stale(&file.path);
+            let active_findings = if in_overlay {
+                tab.ai.file_active_findings(&file.path)
             } else {
-                None
+                Vec::new()
             };
+            let finding_width = finding_dots_display_width(active_findings.len());
 
             // Comment indicators (questions = yellow ◆N, notes = yellow ▪N, github = cyan ◆N)
             let question_count = tab.ai.file_question_count(&file.path);
@@ -192,11 +225,11 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                 + n_indicator.chars().count()
                 + gh_indicator.chars().count();
 
-            // Adjust path width to account for risk dot, comment indicators, and time column
-            let extra_width = if risk_dot.is_some() { 2 } else { 0 };
+            // Adjust path width to account for finding dots, comment indicators, and time column
             let path = shorten_path(
                 &file.path,
-                (area.width as usize).saturating_sub(16 + extra_width + comment_width + time_width),
+                (area.width as usize)
+                    .saturating_sub(16 + finding_width + comment_width + time_width),
             );
 
             // Stats: +adds -dels
@@ -223,18 +256,13 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             };
 
             let path_width = (area.width as usize)
-                .saturating_sub(14 + extra_width + comment_width + time_width)
+                .saturating_sub(14 + finding_width + comment_width + time_width)
                 .max(1);
 
             let mut spans = vec![Span::styled(
                 format!(" {} ", symbol),
                 effective_symbol_style,
             )];
-
-            // Insert risk dot after status symbol
-            if let Some(dot) = risk_dot {
-                spans.push(dot);
-            }
 
             spans.push(Span::styled(
                 format!("{:<width$}", path, width = path_width),
@@ -246,6 +274,9 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                     ratatui::style::Style::default().fg(styles::TEXT())
                 },
             ));
+
+            spans.extend(finding_dot_spans(&active_findings, file_stale));
+
             // Comment indicators after path (with counts)
             if has_questions {
                 spans.push(Span::styled(

--- a/crates/er-tui/src/ui/panel.rs
+++ b/crates/er-tui/src/ui/panel.rs
@@ -186,30 +186,27 @@ fn render_file_detail<'a>(
     }
     lines.push(Line::from(""));
 
-    // AI file review
+    // AI file risk (assessment metadata — distinct from line-anchored findings below)
     if tab.layers.show_ai_findings {
         if let Some(fr) = tab.ai.file_review(path) {
-            let risk_style = if file_stale {
-                styles::stale_style()
-            } else {
-                match fr.risk {
-                    RiskLevel::High => styles::risk_high(),
-                    RiskLevel::Medium => styles::risk_medium(),
-                    RiskLevel::Low => styles::risk_low(),
-                    RiskLevel::Info => Style::default().fg(styles::BLUE()),
-                }
-            };
             let risk_label = match fr.risk {
-                RiskLevel::High => "[HIGH]",
-                RiskLevel::Medium => "[MED]",
-                RiskLevel::Low => "[LOW]",
-                RiskLevel::Info => "[INFO]",
+                RiskLevel::High => "HIGH",
+                RiskLevel::Medium => "MED",
+                RiskLevel::Low => "LOW",
+                RiskLevel::Info => "INFO",
+            };
+            let header_style = if file_stale {
+                styles::stale_style().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+                    .fg(styles::CYAN())
+                    .add_modifier(Modifier::BOLD)
             };
 
-            lines.push(Line::from(vec![
-                Span::styled(format!(" {} ", fr.risk.symbol()), risk_style),
-                Span::styled(risk_label, risk_style),
-            ]));
+            lines.push(Line::from(vec![Span::styled(
+                format!(" ─── File risk: {risk_label} ───"),
+                header_style,
+            )]));
 
             let max_w = area.width.saturating_sub(3) as usize;
 
@@ -223,7 +220,10 @@ fn render_file_detail<'a>(
             }
 
             if !fr.summary.is_empty() {
-                lines.push(Line::from(""));
+                lines.push(Line::from(vec![Span::styled(
+                    " Summary",
+                    Style::default().fg(styles::DIM()),
+                )]));
                 for wrapped in word_wrap(&fr.summary, max_w) {
                     lines.push(Line::from(vec![Span::styled(
                         format!(" {}", wrapped),
@@ -717,13 +717,21 @@ fn render_ai_summary<'a>(lines: &mut Vec<Line<'a>>, area: Rect, tab: &'a er_engi
                 Style::default().fg(styles::BRIGHT())
             };
 
+            let risk_label = match fr.risk {
+                RiskLevel::High => "HIGH",
+                RiskLevel::Medium => "MED",
+                RiskLevel::Low => "LOW",
+                RiskLevel::Info => "INFO",
+            };
+
             let prefix = if is_selected { "▸" } else { " " };
 
             let max_path_w = area.width.saturating_sub(5) as usize;
             let display_path = shorten_path(path, max_path_w);
             lines.push(Line::from(vec![
+                Span::styled(format!("{prefix} "), Style::default()),
                 Span::styled(
-                    format!("{}{} ", prefix, fr.risk.symbol()),
+                    format!("{risk_label} "),
                     if is_selected {
                         risk_style.bg(bg)
                     } else {

--- a/desktop-ui/src/lib/components/AiActionPalette.svelte
+++ b/desktop-ui/src/lib/components/AiActionPalette.svelte
@@ -191,7 +191,7 @@
       id: "triage-current",
       label: "Triage branch",
       description: reviewScope
-        ? "Fast scan — first impression and review routing (uses the default model)"
+        ? "Fast scan — first impression and review routing (default model, low effort)"
         : "Not available in this view",
       run: () => {
         if (!reviewScope) return;

--- a/desktop-ui/src/lib/components/AiActionPalette.svelte
+++ b/desktop-ui/src/lib/components/AiActionPalette.svelte
@@ -187,7 +187,7 @@
       id: "triage-current",
       label: "Triage branch",
       description: reviewScope
-        ? "Fast scan — first impression and review routing (Haiku-class model)"
+        ? "Fast scan — first impression and review routing (uses the default model)"
         : "Not available in this view",
       run: () => {
         if (!reviewScope) return;

--- a/desktop-ui/src/lib/components/AiActionPalette.svelte
+++ b/desktop-ui/src/lib/components/AiActionPalette.svelte
@@ -123,7 +123,7 @@
 
   function selectProvider(provider: AiProviderInfo) {
     if (provider.models.length === 0) {
-      app.cmd("set_ai_selection", { providerId: provider.id, modelId: null });
+      app.cmd("set_ai_selection", { providerId: provider.id, modelId: null, persist: false });
       close();
     } else {
       selectedProvider = provider;
@@ -137,7 +137,11 @@
   function selectModel(modelId: string) {
     if (!selectedProvider) return;
     selectedModelId = modelId;
-    app.cmd("set_ai_selection", { providerId: selectedProvider.id, modelId: modelId });
+    app.cmd("set_ai_selection", {
+      providerId: selectedProvider.id,
+      modelId: modelId,
+      persist: false,
+    });
     const model = selectedProvider.models.find((item) => item.id === modelId);
     if (!modelSupportsEffort(model)) {
       close();
@@ -145,7 +149,7 @@
   }
 
   function setEffort(level: string) {
-    void app.cmd("set_ai_effort", { effort: level === "Auto" ? null : level });
+    void app.cmd("set_ai_effort", { effort: level === "Auto" ? null : level, persist: false });
   }
 
   const activeAiLabel = $derived(app.snapshot?.active_ai_label ?? "");

--- a/desktop-ui/src/lib/components/diff-rows/FileHeaderContent.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/FileHeaderContent.svelte
@@ -123,12 +123,12 @@
   title={reviewed ? "Marked reviewed — click to unmark" : "Mark file reviewed"}
   aria-label={reviewed ? "Unmark as reviewed" : "Mark as reviewed"}
   aria-pressed={reviewed}
-  class="shrink-0 w-6 h-6 rounded flex items-center justify-center transition hover:bg-hover
+  class="shrink-0 w-6 h-6 rounded flex items-center justify-center transition hover:bg-hover group
     {reviewed ? 'text-periwinkle' : 'text-fg-3 hover:text-fg'}"
 >
   <span
     class="w-3.5 h-3.5 rounded-[3px] flex items-center justify-center border
-      {reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-ink-500 text-transparent'}"
+      {reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-muted text-transparent group-hover:border-fg-3'}"
   >
     <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
       <polyline points="20 6 9 17 4 12" />

--- a/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/PillarRail.svelte
@@ -107,7 +107,7 @@
     <button
       type="button"
       class="shrink-0 w-[14px] h-[14px] rounded-[3px] flex items-center justify-center border transition
-        {f.reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-ink-500 text-transparent hover:border-fg-3'}"
+        {f.reviewed ? 'bg-periwinkle border-periwinkle text-on-accent' : 'border-muted text-transparent hover:border-fg-3'}"
       title={f.reviewed ? "Marked reviewed — click to unmark" : "Mark file reviewed"}
       aria-label={f.reviewed ? "Unmark as reviewed" : "Mark as reviewed"}
       aria-pressed={f.reviewed}

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -36,7 +36,6 @@
   let generalFields = $state<ConfigHubField[]>([]);
   let terminalFields = $state<ConfigHubField[]>([]);
   let providers = $state<AiProviderInfo[]>([]);
-  let triageModelId = $state("");
   let selectedEffort = $state("Auto");
   let repoRoot = $state("");
   let addPattern = $state("");
@@ -52,13 +51,6 @@
   const selectedModels = $derived(selectedProvider?.models ?? []);
   const selectedModel = $derived(selectedModels.find((model) => model.is_selected) ?? null);
   const effortOptions = $derived(["Auto", ...(selectedModel?.effort_levels ?? [])]);
-  const hasInactiveTriageModel = $derived(
-    triageModelId !== "" && !selectedModels.some((model) => model.id === triageModelId),
-  );
-  const triageProviderGroups = $derived(
-    selectedProvider && selectedProvider.models.length > 0 ? [selectedProvider] : [],
-  );
-
   interface FieldSection {
     title: string | null;
     fields: ConfigHubField[];
@@ -90,7 +82,6 @@
     generalFields = res.settings.general;
     terminalFields = res.settings.terminal;
     providers = res.providers;
-    triageModelId = res.triageModelId ?? "";
     selectedEffort = res.activeEffort ?? "Auto";
     if (!effortOptions.includes(selectedEffort)) selectedEffort = "Auto";
     repoRoot = res.settings.repoRoot;
@@ -141,24 +132,15 @@
     await reload();
   }
 
-  function selectTriageModel(modelId: string) {
-    void patch("ai_hub.reviewer_models.triage", modelId);
-  }
-
-  async function saveDefaults() {
-    const p = selectedProvider;
-    if (!p) return;
-    const model = p.models.find((m) => m.is_selected);
+  async function selectEffort(level: string) {
+    selectedEffort = level;
     try {
-      const res = await invoke<GetConfigHubResponse>("set_ai_hub_defaults", {
-        providerId: p.id,
-        modelId: model?.id ?? null,
-        effort: selectedEffort === "Auto" ? null : selectedEffort,
+      await invoke("set_ai_effort", {
+        effort: level === "Auto" ? null : level,
       });
-      applySettings(res);
-      app.showToast("success", "Saved AI defaults to config");
+      await reload();
     } catch (e) {
-      app.showToast("error", `set_ai_hub_defaults: ${e}`);
+      app.showToast("error", `set_ai_effort: ${e}`);
     }
   }
 
@@ -353,7 +335,7 @@
           {#if providers.length > 0}
             <div class="bg-card border border-hairline rounded-xl px-4 py-3">
               <p class="text-xs text-muted mb-3">
-                Session selection. “Save as default” writes to config TOML.
+                The default provider, model, and reasoning effort for all AI Hub actions. Changes apply immediately.
               </p>
               <div class="py-1">
                 <div class="text-sm text-fg mb-1.5">Provider</div>
@@ -398,7 +380,7 @@
                       class="px-2.5 py-1 text-xs rounded-md border transition-colors {selectedEffort === level
                         ? 'bg-accent-soft text-accent border-accent-border font-medium'
                         : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
-                      onclick={() => (selectedEffort = level)}
+                      onclick={() => void selectEffort(level)}
                     >
                       {level === 'xhigh' ? 'XHigh' : level}
                     </button>
@@ -406,57 +388,6 @@
                 </div>
                 <p class="text-[11px] text-muted mt-1.5">Auto uses the provider default.</p>
               </div>
-              <div class="mt-2 pt-2 border-t border-hairline/60">
-                <Button onclick={() => void saveDefaults()}>Save as default</Button>
-              </div>
-            </div>
-            <div class="bg-card border border-hairline rounded-xl px-4 py-3 mt-3">
-              <div class="mb-3">
-                <p class="text-sm text-fg">Triage model</p>
-                <p class="text-xs text-muted mt-0.5">
-                  Override the model used for fast triage reviews on the active provider.
-                </p>
-              </div>
-              {#if hasInactiveTriageModel}
-                <div
-                  class="mb-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning"
-                  role="status"
-                >
-                  Saved triage model <code class="font-mono">{triageModelId}</code> is unavailable on
-                  {selectedProvider?.label ?? "the active provider"}. Triage will use the fastest
-                  available model. Choose a model below to replace this inactive override, or “Use fastest
-                  available” to clear it.
-                </div>
-              {/if}
-              <button
-                type="button"
-                class="px-2.5 py-1 text-xs rounded-md border transition-colors {triageModelId === ''
-                  ? 'bg-accent-soft text-accent border-accent-border font-medium'
-                  : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
-                onclick={() => selectTriageModel("")}
-              >
-                Use fastest available
-              </button>
-              {#each triageProviderGroups as provider (provider.id)}
-                <div class="mt-3">
-                  <p class="text-[10px] uppercase tracking-wider text-muted font-semibold mb-1.5">
-                    {provider.label}
-                  </p>
-                  <div class="flex flex-wrap gap-1.5">
-                    {#each provider.models as model (model.id)}
-                      <button
-                        type="button"
-                        class="px-2.5 py-1 text-xs rounded-md border transition-colors {triageModelId === model.id
-                          ? 'bg-accent-soft text-accent border-accent-border font-medium'
-                          : 'bg-surface text-fg-2 border-hairline hover:bg-hover hover:border-border'}"
-                        onclick={() => selectTriageModel(model.id)}
-                      >
-                        {model.label}
-                      </button>
-                    {/each}
-                  </div>
-                </div>
-              {/each}
             </div>
           {:else}
             <div class="border border-dashed border-border rounded-xl px-6 py-8 text-center">

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -114,19 +114,19 @@
     const p = providers.find((x) => x.id === providerId);
     if (!p) return;
     if (p.models.length === 0) {
-      await invoke("set_ai_selection", { providerId, modelId: null });
+      await invoke("set_ai_selection", { providerId, modelId: null, persist: true });
       await reload();
       return;
     }
     const model = p.models.find((m) => m.is_selected) ?? p.models[0];
-    await invoke("set_ai_selection", { providerId, modelId: model?.id ?? null });
+    await invoke("set_ai_selection", { providerId, modelId: model?.id ?? null, persist: true });
     await reload();
   }
 
   async function selectModel(modelId: string) {
     const p = selectedProvider;
     if (!p) return;
-    await invoke("set_ai_selection", { providerId: p.id, modelId });
+    await invoke("set_ai_selection", { providerId: p.id, modelId, persist: true });
     const model = p.models.find((item) => item.id === modelId);
     if (!model?.effort_levels.includes(selectedEffort)) selectedEffort = "Auto";
     await reload();
@@ -137,6 +137,7 @@
     try {
       await invoke("set_ai_effort", {
         effort: level === "Auto" ? null : level,
+        persist: true,
       });
       await reload();
     } catch (e) {
@@ -335,7 +336,9 @@
           {#if providers.length > 0}
             <div class="bg-card border border-hairline rounded-xl px-4 py-3">
               <p class="text-xs text-muted mb-3">
-                The default provider, model, and reasoning effort for all AI Hub actions. Changes apply immediately.
+                The default provider, model, and reasoning effort for all AI Hub actions. Changes
+                save to config immediately. Mid-session picks in the AI action palette stay
+                session-only.
               </p>
               <div class="py-1">
                 <div class="text-sm text-fg mb-1.5">Provider</div>

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -664,9 +664,7 @@ export interface DesktopSettingsSnapshot {
 export interface GetConfigHubResponse {
   settings: DesktopSettingsSnapshot;
   providers: AiProviderInfo[];
-  triageModelId: string | null;
   activeEffort: string | null;
-  defaultEffort: string | null;
 }
 
 export interface FeatureFlagsSnapshot {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -161,7 +161,7 @@ Rules:
 - Model `args` are appended after provider args.
 - If `[ai_hub]` is absent, `er` falls back to the single `[agent]` configuration.
 - On load, `er` merges missing current built-in catalog models into your config in memory without rewriting your TOML file; unknown legacy reviewer-model entries are ignored and disappear the next time the config is saved.
-- The selected default provider/model is used by every ordinary AI Hub action, including review, triage, tours, experts, Professor, validation, questions, summary, and card AI. An explicit model selected for a single review run overrides it only for that run.
+- The selected default provider/model is used by every ordinary AI Hub action, including review, triage, tours, experts, Professor, validation, questions, summary, and card AI. Triage still forces low effort. An explicit model selected for a single review run overrides it only for that run.
 - Each model's `effort_levels` metadata is authoritative. `Auto` (the default) omits the override; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>` only for supported levels.
 - Built-in Claude, Codex, and Cursor Agent launches that write review sidecars receive the active review bucket (`er_dir`) as an additional directory via `--add-dir` — not the global storage root. Codex treats that path as writable under `workspace-write`. Custom provider commands are not given unknown CLI flags.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -60,7 +60,7 @@ args = ["--print", "-p", "{prompt}"]    # Arguments ({prompt} is replaced)
 
 ### `[ai_hub]`
 
-Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor. Desktop Settings persists the selected default immediately; the TUI persists it when you save General settings.
+Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor. Desktop Settings persists the selected default immediately; the AI action palette keeps mid-session picks session-only. The TUI persists defaults when you save General settings.
 
 ```toml
 [ai_hub]
@@ -163,7 +163,7 @@ Rules:
 - On load, `er` merges missing current built-in catalog models into your config in memory without rewriting your TOML file; unknown legacy reviewer-model entries are ignored and disappear the next time the config is saved.
 - The selected default provider/model is used by every ordinary AI Hub action, including review, triage, tours, experts, Professor, validation, questions, summary, and card AI. An explicit model selected for a single review run overrides it only for that run.
 - Each model's `effort_levels` metadata is authoritative. `Auto` (the default) omits the override; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>` only for supported levels.
-- Built-in Claude, Codex, and Cursor Agent launches receive the managed storage root as an additional read/write directory. On macOS this is `~/Library/Application Support/easy-review/`; custom provider commands are not given unknown CLI flags.
+- Built-in Claude, Codex, and Cursor Agent launches that write review sidecars receive the active review bucket (`er_dir`) as an additional directory via `--add-dir` — not the global storage root. Codex treats that path as writable under `workspace-write`. Custom provider commands are not given unknown CLI flags.
 
 ### `[watched]`
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -60,7 +60,7 @@ args = ["--print", "-p", "{prompt}"]    # Arguments ({prompt} is replaced)
 
 ### `[ai_hub]`
 
-Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor. The selected provider, model, and effort can be saved globally from Desktop Settings or the TUI General settings.
+Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, and Cursor. Desktop Settings persists the selected default immediately; the TUI persists it when you save General settings.
 
 ```toml
 [ai_hub]
@@ -68,9 +68,6 @@ default_provider = "claude"
 default_model = "sonnet-5"
 # Optional; omit or use Auto in the UI for the provider default.
 # default_effort = "high"
-
-[ai_hub.reviewer_models]
-triage = "haiku-4.5"
 
 [ai_hub.providers.claude]
 label = "Claude"
@@ -163,10 +160,10 @@ Rules:
 - Provider `args` are the shared base arguments for that CLI.
 - Model `args` are appended after provider args.
 - If `[ai_hub]` is absent, `er` falls back to the single `[agent]` configuration.
-- On load, `er` merges missing current built-in catalog models into your config in memory without rewriting your TOML file; user-defined legacy entries are preserved.
-- The selected provider/model applies to AI Hub actions such as review, triage, experts, professor, questions, and summary.
-- `[ai_hub.reviewer_models]` overrides the hub model for specific reviewer kinds. Triage uses `triage = "haiku-4.5"` by default in the example config; when unset, triage falls back to the fastest model in the active provider list.
+- On load, `er` merges missing current built-in catalog models into your config in memory without rewriting your TOML file; unknown legacy reviewer-model entries are ignored and disappear the next time the config is saved.
+- The selected default provider/model is used by every ordinary AI Hub action, including review, triage, tours, experts, Professor, validation, questions, summary, and card AI. An explicit model selected for a single review run overrides it only for that run.
 - Each model's `effort_levels` metadata is authoritative. `Auto` (the default) omits the override; Claude receives `--effort <level>` and Codex receives `-c model_reasoning_effort=<level>` only for supported levels.
+- Built-in Claude, Codex, and Cursor Agent launches receive the managed storage root as an additional read/write directory. On macOS this is `~/Library/Application Support/easy-review/`; custom provider commands are not given unknown CLI flags.
 
 ### `[watched]`
 
@@ -213,24 +210,26 @@ diff_mode = "snapshot"
 
 Result: `view_conflicts = false` and `wrap_lines = true` from global, `tab_width = 4` and extra watched paths from local.
 
-## `.er/` AI artifacts
+## Review sidecar files (managed storage)
+
+TUI and Desktop share the same sidecar directory per repo/branch/view bucket under managed app data (default: `~/.local/share/easy-review/repos/<repo>/branches/<branch>/view-buckets/<bucket>/`). Set `ER_REPO_LOCAL=1` to use repo-local `.er/` instead (debug only).
 
 General review (AI Hub **Run review**) writes:
 
 | File | Purpose |
 |------|---------|
-| `.er/review.json` | Per-file risk, summaries, findings |
-| `.er/order.json` | Suggested review order |
-| `.er/checklist.json` | Manual verification items |
-| `.er/summary.md` | Overall summary |
+| `review.json` | Per-file risk, summaries, findings |
+| `order.json` | Suggested review order |
+| `checklist.json` | Manual verification items |
+| `summary.md` | Overall summary |
 
-**Specialized expert reviews** (AI Hub **Specialized review**) write findings only to `.er/experts/<id>.json` (e.g. `security`, `patterns`). They do not overwrite general artifacts.
+**Specialized expert reviews** (AI Hub **Specialized review**) write findings only to `experts/<id>.json` (e.g. `security`, `patterns`). They do not overwrite general artifacts.
 
 At load time, `er` merges fresh expert sidecars (matching `diff_hash`) into the in-memory review so expert findings appear as **additional inline banners** labeled by expert (e.g. "Security finding"). Order/checklist/summary panels still require a general review run.
 
 Expert ids (v1): `security`, `performance`, `reliability`, `testing`, `api`, `patterns`, `simplifying`, `mentorship`.
 
-**Professor** (AI Hub **Professor**) writes teaching insights to `.er/professor.json` (merged inline at load; labeled with agent pill **Professor**). Not a code review — see `skills/PROFESSOR_PHILOSOPHY.md`.
+**Professor** (AI Hub **Professor**) writes teaching insights to `professor.json` (merged inline at load; labeled with agent pill **Professor**). Not a code review — see `skills/PROFESSOR_PHILOSOPHY.md`.
 
 **Multi-reviewer runs** (AI Hub **Run reviewers…** or **Review select files** → choose reviewers): spawn General + any experts + Professor concurrently. Each finding shows an agent pill (`General`, `Security`, …).
 

--- a/docs/guide/configuration.html
+++ b/docs/guide/configuration.html
@@ -100,9 +100,6 @@ default_model    = <span class="tok-str">"sonnet-5"</span>
 default_effort   = <span class="tok-str">"medium"</span>  <span class="cmt"># reasoning effort passed to providers that support it</span>
 max_concurrent_reviews = <span class="tok-key">3</span>  <span class="cmt"># queue further reviews beyond this many at once (1–16)</span>
 
-[ai_hub.reviewer_models]
-triage = <span class="tok-str">"haiku-4.5"</span>          <span class="cmt"># pin specific reviewer kinds to specific models</span>
-
 [ai_hub.providers.claude]
 label   = <span class="tok-str">"Claude"</span>
 command = <span class="tok-str">"claude"</span>
@@ -120,7 +117,8 @@ effort_levels = [<span class="tok-str">"low"</span>, <span class="tok-str">"medi
       <li>On load, <code>er</code> merges any missing built-in catalog models into your config <em>in memory</em> — it does
       not rewrite your file.</li>
       <li>The current built-in catalog includes Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, the GPT-5.6 Sol/Terra/Luna family, GPT-5.5, GPT-5.4, GPT-5.4 Mini, and GPT-5.3 Codex Spark.</li>
-      <li>The selected provider/model applies to AI Hub actions: review, triage, experts, professor, questions, and summary.</li>
+      <li>The selected default provider/model applies to every ordinary AI Hub action, including review, triage, tours, experts, Professor, validation, questions, summary, and card AI. Explicit review-run selections apply only to that run.</li>
+      <li>Built-in Claude, Codex, and Cursor Agent launches can read and write managed review storage. On macOS this is <code>~/Library/Application Support/easy-review/</code>; custom provider commands are left unchanged.</li>
     </ul>
 
     <h2><code>[summary]</code> — diff summaries</h2>


### PR DESCRIPTION
## Summary

- Grant Claude, Codex, and Cursor Agent subprocesses access to Easy Review managed storage via `--add-dir`, so background reviews and card AI actions can read/write sidecars outside the repo worktree.
- Fix Codex **Elaborate** / **Validate** card AI: stop passing Claude-only `--append-system-prompt`; fold system context into the exec prompt instead.
- Unify AI Hub default provider/model/effort resolution through `AiSelection` so Settings, desktop, TUI, and ordinary spawns share one fallback path.
- Polish review UI: brighter unchecked reviewed-checkbox borders on desktop; clearer TUI file-risk labels separate from inline findings; add `file_active_findings` helper.

## Test plan

- [ ] Desktop with Codex as default provider: **Elaborate** on a question returns an AI reply (no `--append-system-prompt` CLI error)
- [ ] Background review / card AI can read and write managed sidecars (`review.json`, `questions.json`, etc.) when `ER_REPO_LOCAL` is unset
- [ ] Claude **Elaborate** / **Validate** still work (system prompt via `--append-system-prompt`)
- [ ] Desktop reviewed checkbox is visible when unchecked (file header + pillar rail)
- [ ] TUI side panel shows file risk assessment distinctly from line-anchored findings
- [ ] Settings AI Hub default provider/model selection persists and applies to new spawns
- [ ] `cargo test -p er-engine -- card_ai_spawn` passes


Made with [Cursor](https://cursor.com)