### PR TITLE
feat(ai-hub): add Cursor Grok 4.5 model

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,7 @@
 
 ## AI Hub model refresh
 
-- Refreshed the built-in catalog with Claude Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, the GPT-5.6 Sol/Terra/Luna family, GPT-5.5, GPT-5.4, GPT-5.4 Mini, and GPT-5.3 Codex Spark.
+- Refreshed the built-in catalog with Claude Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, the GPT-5.6 Sol/Terra/Luna family, GPT-5.5, GPT-5.4, GPT-5.4 Mini, GPT-5.3 Codex Spark, and Cursor Grok 4.5.
 - Deprecated built-in entries are no longer advertised; deprecated Claude IDs are also removed from persisted model selections and reviewer assignments, while other user-defined models remain untouched.
 - Added model metadata-driven effort/reasoning controls across Desktop, TUI, the action palette, and Arena. `Auto` omits provider overrides.
 - Added atomic global persistence for provider, model, and effort selections, plus validation before Claude/Codex invocation.
@@ -17,7 +17,7 @@
 
 ## Highlights
 
-- **Refreshed AI Hub models and effort controls.** The built-in catalog now includes the latest supported Claude and GPT families, while deprecated built-in entries are no longer advertised. Effort and reasoning controls are metadata-driven and consistent across Desktop, TUI, the action palette, and Arena; `Auto` leaves provider-specific overrides unset.
+- **Refreshed AI Hub models and effort controls.** The built-in catalog now includes the latest supported Claude and GPT families plus Cursor Grok 4.5, while deprecated built-in entries are no longer advertised. Effort and reasoning controls are metadata-driven and consistent across Desktop, TUI, the action palette, and Arena; `Auto` leaves provider-specific overrides unset.
 - **Deprecated Claude selections are cleaned up.** Persisted selections for deprecated Claude models are removed, and a deprecated default automatically falls back to the current catalog default without affecting other custom models.
 - **More reliable GPT reviews.** GPT review configuration and invocation paths now handle the refreshed model metadata and provider settings correctly.
 - **Correct linked-worktree path copying (desktop).** The branch context bar now copies the filesystem path of the selected linked worktree rather than the project root.

--- a/config.toml.example
+++ b/config.toml.example
@@ -180,6 +180,15 @@ args = [
 ]
 
 [[ai_hub.providers.cursor.models]]
+id = "grok-4.5"
+label = "Grok 4.5"
+description = "Long-running agentic · coding + knowledge work"
+args = ["--model", "grok-4.5"]
+cost_per_1k_in = 0.002
+cost_per_1k_out = 0.006
+avg_latency_ms = 18000
+
+[[ai_hub.providers.cursor.models]]
 id = "composer-2.5"
 label = "Composer 2.5"
 description = "Agentic coding · frontier quality at low cost"

--- a/crates/er-engine/src/ai_hub_catalog.toml
+++ b/crates/er-engine/src/ai_hub_catalog.toml
@@ -140,6 +140,15 @@ args = [
 ]
 
 [[ai_hub.providers.cursor.models]]
+id = "grok-4.5"
+label = "Grok 4.5"
+description = "Long-running agentic · coding + knowledge work"
+args = ["--model", "grok-4.5"]
+cost_per_1k_in = 0.002
+cost_per_1k_out = 0.006
+avg_latency_ms = 18000
+
+[[ai_hub.providers.cursor.models]]
 id = "composer-2.5"
 label = "Composer 2.5"
 description = "Agentic coding · frontier quality at low cost"

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -1925,6 +1925,15 @@ mod tests {
             claude.models.iter().any(|m| m.id == "opus-4.8"),
             "catalog should include opus-4.8"
         );
+        let cursor = hub.providers.get("cursor").unwrap();
+        assert!(
+            cursor.models.iter().any(|m| m.id == "grok-4.5"),
+            "catalog should include grok-4.5"
+        );
+        assert!(
+            cursor.models.iter().any(|m| m.id == "composer-2.5"),
+            "catalog should include composer-2.5"
+        );
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -154,6 +154,11 @@ command = "agent"
 args = ["--print", "--trust", "--force", "--output-format", "stream-json", "-p", "{prompt}"]
 
 [[ai_hub.providers.cursor.models]]
+id = "grok-4.5"
+label = "Grok 4.5"
+args = ["--model", "grok-4.5"]
+
+[[ai_hub.providers.cursor.models]]
 id = "composer-2.5"
 label = "Composer 2.5"
 args = ["--model", "composer-2.5"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add Grok 4.5 to the shared AI Hub catalog under the Cursor provider so it appears in both TUI and Desktop model pickers (settings, action palette, Arena).

## Changes
- Catalog entry: `grok-4.5` → `agent --model grok-4.5` (alongside Composer 2.5)
- Pricing metadata from Cursor model docs ($2/M in, $6/M out)
- Mirrored in `config.toml.example` and config reference
- Catalog seed test asserts Grok is present
- Release notes updated

No UI code changes required — TUI and Desktop both consume the catalog via `supplement_ai_hub`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5338b4da-13b4-448b-9d73-d562cc1a70ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5338b4da-13b4-448b-9d73-d562cc1a70ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

