### PR TITLE
feat: easy-review-mcp npm launcher (npx)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  # npm publish uses OIDC trusted publishing when configured; token fallback via secrets.
+  id-token: write
 
 jobs:
   build:
@@ -30,20 +32,26 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build
+      - name: Build er (TUI)
         run: cargo build --release --target ${{ matrix.target }} -p er-tui
+
+      - name: Build er-mcp
+        run: cargo build --release --target ${{ matrix.target }} -p er-mcp
 
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release
           tar -czf ../../../er-${{ matrix.target }}.tar.gz er
+          tar -czf ../../../er-mcp-${{ matrix.target }}.tar.gz er-mcp
           cd ../../..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: er-${{ matrix.target }}
-          path: er-${{ matrix.target }}.tar.gz
+          name: bins-${{ matrix.target }}
+          path: |
+            er-${{ matrix.target }}.tar.gz
+            er-mcp-${{ matrix.target }}.tar.gz
 
   release:
     name: Create Release
@@ -61,4 +69,37 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: er-*.tar.gz
+          files: |
+            er-*.tar.gz
+            er-mcp-*.tar.gz
+
+  npm:
+    name: Publish easy-review-mcp to npm
+    needs: release
+    runs-on: ubuntu-latest
+    # Opt-in: set repo variable PUBLISH_NPM=true and configure NPM_TOKEN (or trusted publishing).
+    if: ${{ vars.PUBLISH_NPM == 'true' }}
+    defaults:
+      run:
+        working-directory: npm/er-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify package version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag v$TAG does not match npm/er-mcp version $PKG"
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ scripts/aliases below, so either form works.
 | Test TUI/engine | `./scripts/er-tui.sh test -p er-engine -p er-tui` or `cargo tui-test` |
 | Test desktop backend | `cargo test -p er-desktop` |
 | Build Easy Review MCP | `cargo build -p er-mcp` (stdio server; setup: `docs/guide/mcp.html`) |
+| npm MCP launcher | `npm/er-mcp` — `npx -y easy-review-mcp` (downloads release binary) |
 | Install ER agent skill | `npx skills add VilfredSikker/easy-review -s er-review -g` — see `skills/er-review/` |
 | Desktop dev | `./scripts/tauri-dev.sh` |
 | Desktop release | `./scripts/tauri-build.sh` or `cargo desktop-release` |

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ low-hanging fruit, production-only diff line counts, and client-owned AI sidecar
 (also in-repo: [`docs/guide/mcp.html`](docs/guide/mcp.html)) — `claude mcp add` / `codex mcp add` and `mcp.json`.
 
 ```bash
-# MCP (no Rust required once a release ships er-mcp assets)
+# MCP via npm
 npx -y easy-review-mcp
 
 # Agent skill ("ER review") — same as: npx skills add github/gh-stack
 npx skills add VilfredSikker/easy-review -s er-review -g
 
-# Or build from source
+# Or build MCP from source
 cargo install --path crates/er-mcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ low-hanging fruit, production-only diff line counts, and client-owned AI sidecar
 (also in-repo: [`docs/guide/mcp.html`](docs/guide/mcp.html)) — `claude mcp add` / `codex mcp add` and `mcp.json`.
 
 ```bash
-cargo install --path crates/er-mcp
+# MCP (no Rust required once a release ships er-mcp assets)
+npx -y easy-review-mcp
 
 # Agent skill ("ER review") — same as: npx skills add github/gh-stack
 npx skills add VilfredSikker/easy-review -s er-review -g
+
+# Or build from source
+cargo install --path crates/er-mcp
 ```
 
 Tool reference: [`crates/er-mcp/README.md`](crates/er-mcp/README.md).
+npm launcher: [`npm/er-mcp`](npm/er-mcp).
 Skill: [`skills/er-review/SKILL.md`](skills/er-review/SKILL.md).
 
 ## Documentation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **Easy Review MCP (`er-mcp`)** — stdio MCP server for PR queues and client-owned sidecar upload (`prepare_review` → author → `upload_artifacts`).
+- **`easy-review-mcp` npm package** — `npx -y easy-review-mcp` downloads the platform binary from GitHub Releases (`npm/er-mcp`). Release CI also ships `er-mcp-<triple>.tar.gz` assets.
 - **`er-review` agent skill** — `npx skills add VilfredSikker/easy-review -s er-review` so agents can run “ER review” end-to-end. Source: `skills/er-review/SKILL.md`.
 
 # Easy Review v0.4.3

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -70,6 +70,10 @@ authoring contract.
 ## Build / run
 
 ```bash
+# Recommended for agents — no Rust required once a release exists:
+npx -y easy-review-mcp
+
+# From source:
 cargo build -p er-mcp --release
 # binary: target/release/er-mcp
 
@@ -85,29 +89,30 @@ Full guide with **`mcp.json`**, **`claude mcp add`**, and **`codex mcp add`**:
 [docs/guide/mcp.html](../../docs/guide/mcp.html)
 ([published](https://vilfredsikker.github.io/easy-review/guide/mcp.html)).
 
-Quick add (replace the path with your `er-mcp` binary):
+npm launcher (package: [`npm/er-mcp`](../../npm/er-mcp)):
 
 ```bash
-export ER_MCP="$HOME/.cargo/bin/er-mcp"
-
-# Claude Code (user scope)
-claude mcp add --scope user easy-review -- "$ER_MCP"
+# Claude Code
+claude mcp add --scope user easy-review -- npx -y easy-review-mcp
 
 # Codex
-codex mcp add easy-review -- "$ER_MCP"
+codex mcp add easy-review -- npx -y easy-review-mcp
 ```
 
-Cursor — put this in `~/.cursor/mcp.json` or `.cursor/mcp.json`:
+Cursor — `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "easy-review": {
-      "command": "/absolute/path/to/er-mcp"
+      "command": "npx",
+      "args": ["-y", "easy-review-mcp"]
     }
   }
 }
 ```
+
+Source-built binary alternative: point `command` at `/absolute/path/to/er-mcp`.
 
 ### Agent skill (“ER review”)
 

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -70,10 +70,10 @@ authoring contract.
 ## Build / run
 
 ```bash
-# Recommended for agents — no Rust required once a release exists:
+# npm launcher (downloads the release binary on first run)
 npx -y easy-review-mcp
 
-# From source:
+# From source
 cargo build -p er-mcp --release
 # binary: target/release/er-mcp
 
@@ -112,7 +112,7 @@ Cursor — `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 }
 ```
 
-Source-built binary alternative: point `command` at `/absolute/path/to/er-mcp`.
+Or point `command` at a source-built `/absolute/path/to/er-mcp`.
 
 ### Agent skill (“ER review”)
 

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -24,7 +24,34 @@
       <li>A built <code>er-mcp</code> binary (next section)</li>
     </ul>
 
-    <h2>Install the binary</h2>
+    <h2>Install (recommended: npx)</h2>
+    <p>
+      No Rust toolchain needed. The <code>easy-review-mcp</code> npm package downloads the
+      matching <code>er-mcp</code> binary from GitHub Releases on first run.
+    </p>
+    <pre><code><span class="cmt"># Smoke-test</span>
+npx -y easy-review-mcp
+
+<span class="cmt"># Cursor — ~/.cursor/mcp.json (or .cursor/mcp.json)</span>
+{
+  "mcpServers": {
+    "easy-review": {
+      "command": "npx",
+      "args": ["-y", "easy-review-mcp"]
+    }
+  }
+}
+
+<span class="cmt"># Claude Code</span>
+claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+
+<span class="cmt"># Codex</span>
+codex mcp add easy-review -- npx -y easy-review-mcp
+</code></pre>
+    <p>Requires Node 18+. Supported hosts: macOS arm64/x64, Linux x64.
+    Override with <code>ER_MCP_PATH=/path/to/er-mcp</code> if you already built from source.</p>
+
+    <h2>Install from source (optional)</h2>
     <pre><code>git clone https://github.com/VilfredSikker/easy-review.git
 cd easy-review
 cargo install --path crates/er-mcp
@@ -37,12 +64,12 @@ er-mcp --help</code></pre>
 <span class="cmt"># binary: target/release/er-mcp</span></code></pre>
     <div class="callout note">
       <span class="ico">◆</span>
-      <div><p>Below, replace <code>$ER_MCP</code> with the absolute path to the binary
-      (e.g. <code>$HOME/.cargo/bin/er-mcp</code> or
-      <code>$HOME/src/easy-review/target/release/er-mcp</code>).</p></div>
+      <div><p>When using a source-built binary, set <code>$ER_MCP</code> to its absolute path
+      (e.g. <code>$HOME/.cargo/bin/er-mcp</code>) in the client commands below.
+      Prefer the npx form above when you can.</p></div>
     </div>
 
-    <h2>Fast add (one command)</h2>
+    <h2>Fast add (source binary)</h2>
 
     <h3>Claude Code</h3>
     <pre><code><span class="cmt"># User scope — available in every project</span>
@@ -77,7 +104,17 @@ mkdir -p .cursor
     <p>Same shape for Cursor global (<code>~/.cursor/mcp.json</code>), Cursor project (<code>.cursor/mcp.json</code>),
     and Claude project scope (<code>.mcp.json</code> at the repo root).</p>
 
-    <h3>Minimal (recommended)</h3>
+    <h3>Minimal (recommended — npx)</h3>
+    <pre><code>{
+  "mcpServers": {
+    "easy-review": {
+      "command": "npx",
+      "args": ["-y", "easy-review-mcp"]
+    }
+  }
+}</code></pre>
+
+    <h3>Source-built binary</h3>
     <pre><code>{
   "mcpServers": {
     "easy-review": {
@@ -124,7 +161,8 @@ mkdir -p .cursor
     <h3>Codex TOML equivalent</h3>
     <pre><code><span class="cmt"># ~/.codex/config.toml</span>
 [mcp_servers.easy-review]
-command = "/absolute/path/to/er-mcp"</code></pre>
+command = "npx"
+args = ["-y", "easy-review-mcp"]</code></pre>
 
     <h2>Install the agent skill</h2>
     <p>
@@ -167,7 +205,7 @@ npx skills add VilfredSikker/easy-review -s er-review --all
 
     <h2>Troubleshooting</h2>
     <ul>
-      <li><strong>Server not listed</strong> — absolute path to <code>er-mcp</code>, restart client, check <code>which er-mcp</code>.</li>
+      <li><strong>Server not listed</strong> — try <code>npx -y easy-review-mcp</code> in a terminal; or check the absolute path / restart client.</li>
       <li><strong>Tools fail on GitHub</strong> — run <code>gh auth status</code>; MCP shells out to <code>gh</code> like Desktop.</li>
       <li><strong>No projects</strong> — pass <code>repo=owner/name</code>, or open the repo in Easy Review Desktop once so <code>projects.json</code> exists.</li>
       <li><strong>Claude “unknown option --command”</strong> — use <code>claude mcp add easy-review -- "$ER_MCP"</code> (options before name, command after <code>--</code>).</li>

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -21,37 +21,21 @@
     <ul>
       <li><strong>git</strong> and <strong>gh</strong> on <code>PATH</code> (<code>gh auth login</code>)</li>
       <li>Optional: Easy Review projects at <code>~/.config/er/projects.json</code> (Desktop writes this) so you can omit <code>repo=</code></li>
-      <li>A built <code>er-mcp</code> binary (next section)</li>
+      <li>Node 18+ (for the npm launcher) <em>or</em> a Rust toolchain (to build from source)</li>
     </ul>
 
-    <h2>Install (recommended: npx)</h2>
+    <h2>Install</h2>
+
+    <h3>npm</h3>
     <p>
-      No Rust toolchain needed. The <code>easy-review-mcp</code> npm package downloads the
-      matching <code>er-mcp</code> binary from GitHub Releases on first run.
+      The <code>easy-review-mcp</code> package runs the MCP server. On first use it downloads
+      <code>er-mcp</code> from the matching GitHub Release and caches it locally.
     </p>
-    <pre><code><span class="cmt"># Smoke-test</span>
-npx -y easy-review-mcp
+    <pre><code>npx -y easy-review-mcp</code></pre>
+    <p>Supported hosts: macOS arm64/x64, Linux x64.
+    Set <code>ER_MCP_PATH=/path/to/er-mcp</code> to use a specific binary instead of downloading.</p>
 
-<span class="cmt"># Cursor — ~/.cursor/mcp.json (or .cursor/mcp.json)</span>
-{
-  "mcpServers": {
-    "easy-review": {
-      "command": "npx",
-      "args": ["-y", "easy-review-mcp"]
-    }
-  }
-}
-
-<span class="cmt"># Claude Code</span>
-claude mcp add --scope user easy-review -- npx -y easy-review-mcp
-
-<span class="cmt"># Codex</span>
-codex mcp add easy-review -- npx -y easy-review-mcp
-</code></pre>
-    <p>Requires Node 18+. Supported hosts: macOS arm64/x64, Linux x64.
-    Override with <code>ER_MCP_PATH=/path/to/er-mcp</code> if you already built from source.</p>
-
-    <h2>Install from source (optional)</h2>
+    <h3>From source</h3>
     <pre><code>git clone https://github.com/VilfredSikker/easy-review.git
 cd easy-review
 cargo install --path crates/er-mcp
@@ -62,21 +46,19 @@ er-mcp --help</code></pre>
     <p>From a clone without installing globally:</p>
     <pre><code>cargo build -p er-mcp --release
 <span class="cmt"># binary: target/release/er-mcp</span></code></pre>
-    <div class="callout note">
-      <span class="ico">◆</span>
-      <div><p>When using a source-built binary, set <code>$ER_MCP</code> to its absolute path
-      (e.g. <code>$HOME/.cargo/bin/er-mcp</code>) in the client commands below.
-      Prefer the npx form above when you can.</p></div>
-    </div>
 
-    <h2>Fast add (source binary)</h2>
+    <h2>Add to a client</h2>
 
     <h3>Claude Code</h3>
-    <pre><code><span class="cmt"># User scope — available in every project</span>
+    <pre><code><span class="cmt"># npm launcher</span>
+claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+
+<span class="cmt"># or a source-built binary</span>
+export ER_MCP="$HOME/.cargo/bin/er-mcp"
 claude mcp add --scope user easy-review -- "$ER_MCP"
 
 <span class="cmt"># Project scope — writes .mcp.json for the team (commit it)</span>
-claude mcp add --scope project easy-review -- "$ER_MCP"
+claude mcp add --scope project easy-review -- npx -y easy-review-mcp
 
 claude mcp list
 claude mcp get easy-review</code></pre>
@@ -84,14 +66,15 @@ claude mcp get easy-review</code></pre>
     There is no <code>--command</code> flag.</p>
 
     <h3>Codex</h3>
-    <pre><code>codex mcp add easy-review -- "$ER_MCP"
+    <pre><code>codex mcp add easy-review -- npx -y easy-review-mcp
+<span class="cmt"># or: codex mcp add easy-review -- "$HOME/.cargo/bin/er-mcp"</span>
 codex mcp list
 codex mcp get easy-review</code></pre>
     <p>Config is stored in <code>~/.codex/config.toml</code> (or project <code>.codex/config.toml</code> for trusted projects).</p>
 
     <h3>Cursor</h3>
     <p>Cursor uses <code>mcp.json</code> (no first-party <code>cursor mcp add</code> equivalent for custom stdio servers).
-    Fastest path: paste the JSON below, or add via <strong>Cursor Settings → Tools &amp; MCP → New MCP Server</strong>.</p>
+    Add via <strong>Cursor Settings → Tools &amp; MCP → New MCP Server</strong>, or edit the file:</p>
     <pre><code><span class="cmt"># Global (all workspaces)</span>
 mkdir -p ~/.cursor
 <span class="cmt"># then edit ~/.cursor/mcp.json — see structure below</span>
@@ -104,7 +87,7 @@ mkdir -p .cursor
     <p>Same shape for Cursor global (<code>~/.cursor/mcp.json</code>), Cursor project (<code>.cursor/mcp.json</code>),
     and Claude project scope (<code>.mcp.json</code> at the repo root).</p>
 
-    <h3>Minimal (recommended — npx)</h3>
+    <h3>npm launcher</h3>
     <pre><code>{
   "mcpServers": {
     "easy-review": {

--- a/justfile
+++ b/justfile
@@ -127,6 +127,11 @@ build-mcp:
 install-mcp:
     cargo install --path crates/er-mcp
 
+# Test the npm launcher (Node 18+).
+[group('test')]
+test-mcp-npm:
+    cd npm/er-mcp && npm test
+
 # Test the desktop frontend (bun).
 [group('test')]
 test-ui:

--- a/npm/er-mcp/README.md
+++ b/npm/er-mcp/README.md
@@ -1,0 +1,71 @@
+# easy-review-mcp
+
+npx launcher for the Easy Review MCP server (`er-mcp`).
+
+On first run it downloads the matching platform binary from the GitHub Release
+that matches this package version (`vX.Y.Z`), caches it under
+`~/.cache/easy-review/er-mcp/` (or `~/Library/Caches/…` on macOS), and execs it
+with inherited stdio.
+
+## Quick start
+
+```bash
+npx -y easy-review-mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "easy-review": {
+      "command": "npx",
+      "args": ["-y", "easy-review-mcp"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+```
+
+### Codex
+
+```bash
+codex mcp add easy-review -- npx -y easy-review-mcp
+```
+
+## Overrides
+
+| Env | Meaning |
+|-----|---------|
+| `ER_MCP_PATH` / `ER_MCP_BINARY` | Use this binary instead of downloading |
+| `XDG_CACHE_HOME` | Cache root (Linux/default) |
+
+If no release asset exists yet, install from source:
+
+```bash
+cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
+```
+
+## Supported platforms
+
+- macOS arm64 / x64
+- Linux x64
+
+## Version lockstep
+
+`npm/er-mcp/package.json` `version` must match the Cargo workspace version and
+the GitHub release tag (`vX.Y.Z`). Release CI publishes `er-mcp-<triple>.tar.gz`
+assets consumed by this launcher.
+
+## Develop
+
+```bash
+cd npm/er-mcp
+npm test
+node bin/er-mcp.js   # needs binary via PATH, ER_MCP_PATH, or a published release
+```

--- a/npm/er-mcp/bin/er-mcp.js
+++ b/npm/er-mcp/bin/er-mcp.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * npx entrypoint for Easy Review MCP.
+ * Resolves (or downloads) the native `er-mcp` binary, then execs it with
+ * inherited stdio so MCP clients can speak the protocol over stdin/stdout.
+ */
+
+const { spawn } = require("node:child_process");
+const { ensureBinary } = require("../lib/ensure-binary.js");
+
+async function main() {
+  const binary = await ensureBinary();
+  const child = spawn(binary, process.argv.slice(2), {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  const forward = (signal) => {
+    if (child.pid) {
+      try {
+        child.kill(signal);
+      } catch {
+        // ignore
+      }
+    }
+  };
+  process.on("SIGINT", () => forward("SIGINT"));
+  process.on("SIGTERM", () => forward("SIGTERM"));
+
+  child.on("error", (err) => {
+    console.error(`easy-review-mcp: failed to start ${binary}: ${err.message}`);
+    process.exit(1);
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch((err) => {
+  console.error(`easy-review-mcp: ${err.message || err}`);
+  process.exit(1);
+});

--- a/npm/er-mcp/lib/ensure-binary.js
+++ b/npm/er-mcp/lib/ensure-binary.js
@@ -1,0 +1,154 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { execFile } = require("node:child_process");
+const { promisify } = require("node:util");
+const { pipeline } = require("node:stream/promises");
+const { createWriteStream } = require("node:fs");
+const { downloadUrl, rustTarget, releaseTag } = require("./platform.js");
+
+const execFileAsync = promisify(execFile);
+
+function packageVersion() {
+  // Keep in lockstep with Cargo workspace version / GitHub release tag.
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  return require("../package.json").version;
+}
+
+function cacheDir(version = packageVersion()) {
+  const base =
+    process.env.XDG_CACHE_HOME ||
+    (process.platform === "darwin"
+      ? path.join(os.homedir(), "Library", "Caches")
+      : path.join(os.homedir(), ".cache"));
+  return path.join(base, "easy-review", "er-mcp", releaseTag(version));
+}
+
+function cachedBinaryPath(version = packageVersion()) {
+  return path.join(cacheDir(version), "er-mcp");
+}
+
+async function whichOnPath(name) {
+  const cmd = process.platform === "win32" ? "where" : "which";
+  try {
+    const { stdout } = await execFileAsync(cmd, [name]);
+    const first = stdout.split(/\r?\n/).map((s) => s.trim()).find(Boolean);
+    return first || null;
+  } catch {
+    return null;
+  }
+}
+
+async function pathLooksExecutable(file) {
+  try {
+    await fsp.access(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the native er-mcp binary.
+ *
+ * Order:
+ * 1. ER_MCP_PATH / ER_MCP_BINARY env
+ * 2. Cached download for this package version
+ * 3. `er-mcp` on PATH
+ * 4. Download from GitHub Releases (v<package.version>)
+ */
+async function ensureBinary() {
+  const envPath = process.env.ER_MCP_PATH || process.env.ER_MCP_BINARY;
+  if (envPath) {
+    if (!(await pathLooksExecutable(envPath))) {
+      throw new Error(`ER_MCP_PATH is set but not executable: ${envPath}`);
+    }
+    return envPath;
+  }
+
+  const version = packageVersion();
+  const cached = cachedBinaryPath(version);
+  if (await pathLooksExecutable(cached)) {
+    return cached;
+  }
+
+  const onPath = await whichOnPath("er-mcp");
+  if (onPath && (await pathLooksExecutable(onPath))) {
+    return onPath;
+  }
+
+  return downloadBinary(version);
+}
+
+async function downloadBinary(version = packageVersion()) {
+  const target = rustTarget();
+  const url = downloadUrl(version);
+  const dir = cacheDir(version);
+  await fsp.mkdir(dir, { recursive: true });
+
+  const archivePath = path.join(dir, `er-mcp-${target}.tar.gz`);
+  const destBinary = path.join(dir, "er-mcp");
+
+  process.stderr.write(`easy-review-mcp: downloading ${url}\n`);
+
+  let res;
+  try {
+    res = await fetch(url, {
+      redirect: "follow",
+      headers: { "User-Agent": "easy-review-mcp-npm" },
+    });
+  } catch (err) {
+    throw new Error(
+      `failed to download ${url}: ${err.message}. ` +
+        `Install from source: cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `download failed (${res.status}) for ${url}. ` +
+        `A GitHub Release ${releaseTag(version)} with er-mcp-${target}.tar.gz is required. ` +
+        `Or: cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp`,
+    );
+  }
+
+  const tmp = `${archivePath}.partial`;
+  await pipeline(res.body, createWriteStream(tmp));
+  await fsp.rename(tmp, archivePath);
+
+  try {
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", dir]);
+  } catch (err) {
+    throw new Error(`failed to extract ${archivePath}: ${err.message}`);
+  }
+
+  // tarball contains a top-level `er-mcp` binary
+  if (!(await pathLooksExecutable(destBinary))) {
+    // Some archives nest the binary; search one level.
+    const entries = await fsp.readdir(dir);
+    const found = entries.find((e) => e === "er-mcp" || e.endsWith("/er-mcp"));
+    if (!found) {
+      throw new Error(
+        `archive extracted but er-mcp binary missing in ${dir} (contents: ${entries.join(", ")})`,
+      );
+    }
+  }
+
+  await fsp.chmod(destBinary, 0o755);
+  // Best-effort cleanup of the archive to save disk.
+  await fsp.unlink(archivePath).catch(() => {});
+
+  process.stderr.write(`easy-review-mcp: installed ${destBinary}\n`);
+  return destBinary;
+}
+
+module.exports = {
+  packageVersion,
+  cacheDir,
+  cachedBinaryPath,
+  ensureBinary,
+  downloadBinary,
+};

--- a/npm/er-mcp/lib/platform.js
+++ b/npm/er-mcp/lib/platform.js
@@ -1,0 +1,50 @@
+"use strict";
+
+/**
+ * Map process.platform / process.arch to the Rust target triples used in
+ * GitHub Release assets (see .github/workflows/release.yml).
+ */
+
+const TARGETS = {
+  "darwin-arm64": "aarch64-apple-darwin",
+  "darwin-x64": "x86_64-apple-darwin",
+  "linux-x64": "x86_64-unknown-linux-gnu",
+};
+
+function rustTarget(platform = process.platform, arch = process.arch) {
+  const key = `${platform}-${arch}`;
+  const target = TARGETS[key];
+  if (!target) {
+    const supported = Object.keys(TARGETS).join(", ");
+    throw new Error(
+      `unsupported platform ${key}. Supported: ${supported}. ` +
+        `Build from source: cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp`,
+    );
+  }
+  return target;
+}
+
+function assetName(version, target = rustTarget()) {
+  const v = String(version).replace(/^v/, "");
+  return `er-mcp-${target}.tar.gz`;
+}
+
+function releaseTag(version) {
+  const v = String(version).replace(/^v/, "");
+  return `v${v}`;
+}
+
+function downloadUrl(version, owner = "VilfredSikker", repo = "easy-review") {
+  const tag = releaseTag(version);
+  const target = rustTarget();
+  const asset = assetName(version, target);
+  return `https://github.com/${owner}/${repo}/releases/download/${tag}/${asset}`;
+}
+
+module.exports = {
+  TARGETS,
+  rustTarget,
+  assetName,
+  releaseTag,
+  downloadUrl,
+};

--- a/npm/er-mcp/lib/platform.test.js
+++ b/npm/er-mcp/lib/platform.test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  rustTarget,
+  assetName,
+  releaseTag,
+  downloadUrl,
+  TARGETS,
+} = require("./platform.js");
+
+describe("platform", () => {
+  it("maps common host triples", () => {
+    assert.equal(rustTarget("darwin", "arm64"), "aarch64-apple-darwin");
+    assert.equal(rustTarget("darwin", "x64"), "x86_64-apple-darwin");
+    assert.equal(rustTarget("linux", "x64"), "x86_64-unknown-linux-gnu");
+  });
+
+  it("rejects unsupported platforms", () => {
+    assert.throws(() => rustTarget("win32", "x64"), /unsupported platform/);
+  });
+
+  it("builds release asset names", () => {
+    assert.equal(
+      assetName("0.4.3", "x86_64-unknown-linux-gnu"),
+      "er-mcp-x86_64-unknown-linux-gnu.tar.gz",
+    );
+    assert.equal(releaseTag("0.4.3"), "v0.4.3");
+    assert.equal(releaseTag("v0.4.3"), "v0.4.3");
+  });
+
+  it("builds github download urls", () => {
+    // Force linux mapping via direct asset helpers; downloadUrl uses process.platform.
+    assert.ok(Object.keys(TARGETS).length >= 3);
+    const url = downloadUrl("0.4.3");
+    assert.match(url, /^https:\/\/github.com\/VilfredSikker\/easy-review\/releases\/download\/v0\.4\.3\/er-mcp-.+\.tar\.gz$/);
+  });
+});

--- a/npm/er-mcp/package.json
+++ b/npm/er-mcp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "easy-review-mcp",
+  "version": "0.4.3",
+  "description": "npx launcher for the Easy Review MCP server (er-mcp). Downloads the platform binary from GitHub Releases on first run.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VilfredSikker/easy-review.git",
+    "directory": "npm/er-mcp"
+  },
+  "homepage": "https://vilfredsikker.github.io/easy-review/guide/mcp.html",
+  "bugs": {
+    "url": "https://github.com/VilfredSikker/easy-review/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "easy-review",
+    "code-review",
+    "github",
+    "pull-request"
+  ],
+  "bin": {
+    "easy-review-mcp": "./bin/er-mcp.js",
+    "er-mcp": "./bin/er-mcp.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test lib/*.test.js",
+    "start": "node ./bin/er-mcp.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an npm package so agents can run Easy Review MCP without a Rust toolchain:

```bash
npx -y easy-review-mcp
```

Cursor / Claude / Codex config examples use `npx -y easy-review-mcp` instead of an absolute cargo-built path.

### Package (`npm/er-mcp`)
- Name: `easy-review-mcp` (bins: `easy-review-mcp`, `er-mcp`)
- On first run: downloads `er-mcp-<rust-triple>.tar.gz` from GitHub Release `v<package.version>`, caches under `~/.cache/easy-review/er-mcp/` (or macOS Library Caches)
- Overrides: `ER_MCP_PATH` / `ER_MCP_BINARY`, or `er-mcp` already on `PATH`
- Platforms: macOS arm64/x64, Linux x64 (same as existing release matrix)
- Tests: `cd npm/er-mcp && npm test`

### Release CI
- Builds **both** `er` and `er-mcp` per target and attaches `er-mcp-*.tar.gz` to the GitHub Release
- Optional npm publish when repo variable `PUBLISH_NPM=true` (+ `NPM_TOKEN`)

### Docs
- MCP guide, READMEs, `AGENTS.md`, `RELEASE_NOTES` (Unreleased)

## Publish checklist (after merge)
1. Keep `npm/er-mcp/package.json` `version` in lockstep with Cargo workspace + tag `vX.Y.Z`
2. Tag a release so `er-mcp-*.tar.gz` assets exist (needed before `npx` download works for that version)
3. Set `PUBLISH_NPM=true` + `NPM_TOKEN` (or npm trusted publishing) to auto-publish on tag

## Test plan
- [x] `cd npm/er-mcp && npm test`
- [x] `ER_MCP_PATH=<stub> node bin/er-mcp.js` smoke
- [ ] Tag/release dry-run produces `er-mcp-*.tar.gz`
- [ ] After first npm publish: `npx -y easy-review-mcp` starts MCP stdio
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6cae-f7c6-76c4-93f7-49300545aa37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6cae-f7c6-76c4-93f7-49300545aa37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

