### PR TITLE
docs: Claude Code should use absolute er-mcp (not npx)

### DIFF
--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -92,10 +92,11 @@ Full guide with **`mcp.json`**, **`claude mcp add`**, and **`codex mcp add`**:
 npm launcher (package: [`npm/er-mcp`](../../npm/er-mcp)):
 
 ```bash
-# Claude Code
-claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+# Claude Code — use an absolute er-mcp path (npx often sticks on "connecting…")
+cargo install --path crates/er-mcp   # or: cargo install --git … --locked er-mcp
+claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
 
-# Codex
+# Codex / Cursor can use npx:
 codex mcp add easy-review -- npx -y easy-review-mcp
 ```
 
@@ -112,7 +113,7 @@ Cursor — `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 }
 ```
 
-Or point `command` at a source-built `/absolute/path/to/er-mcp`.
+Or point `command` at a source-built `/absolute/path/to/er-mcp` (recommended for Claude Code).
 
 ### Agent skill (“ER review”)
 

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -50,20 +50,26 @@ er-mcp --help</code></pre>
     <h2>Add to a client</h2>
 
     <h3>Claude Code</h3>
-    <pre><code><span class="cmt"># npm launcher</span>
-claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+    <p>
+      Prefer an absolute path to the <code>er-mcp</code> binary. Wrapping with <code>npx</code>
+      often leaves Claude stuck on <em>connecting…</em> (npx can write to stdout or delay the handshake).
+    </p>
+    <pre><code><span class="cmt"># 1) Install / locate the binary</span>
+cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
+<span class="cmt"># or use the npm-downloaded cache after one local run:</span>
+<span class="cmt">#   ~/Library/Caches/easy-review/er-mcp/v*/er-mcp   (macOS)</span>
+<span class="cmt">#   ~/.cache/easy-review/er-mcp/v*/er-mcp           (Linux)</span>
 
-<span class="cmt"># or a source-built binary</span>
-export ER_MCP="$HOME/.cargo/bin/er-mcp"
-claude mcp add --scope user easy-review -- "$ER_MCP"
-
-<span class="cmt"># Project scope — writes .mcp.json for the team (commit it)</span>
-claude mcp add --scope project easy-review -- npx -y easy-review-mcp
+<span class="cmt"># 2) Point Claude at it (no npx)</span>
+claude mcp remove easy-review 2>/dev/null || true
+claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
 
 claude mcp list
 claude mcp get easy-review</code></pre>
     <p>Flags go <em>before</em> the server name; everything after <code>--</code> is the stdio command.
     There is no <code>--command</code> flag.</p>
+    <p>Project scope (writes <code>.mcp.json</code>):</p>
+    <pre><code>claude mcp add --scope project easy-review -- "$(command -v er-mcp)"</code></pre>
 
     <h3>Codex</h3>
     <pre><code>codex mcp add easy-review -- npx -y easy-review-mcp
@@ -188,12 +194,16 @@ npx skills add VilfredSikker/easy-review -s er-review --all
 
     <h2>Troubleshooting</h2>
     <ul>
-      <li><strong>Claude stuck on “connecting…”</strong> — first run downloads a binary; on macOS Gatekeeper may block it. Clear quarantine and reconnect:
-        <pre><code>xattr -dr com.apple.quarantine ~/Library/Caches/easy-review/er-mcp
-<span class="cmt"># then in Claude: /mcp → easy-review → Reconnect</span></code></pre>
-        Or skip npx and point at a local binary:
-        <pre><code>cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
-claude mcp add --scope user easy-review -- "$(command -v er-mcp)"</code></pre>
+      <li><strong>Claude stuck on “connecting…”</strong> — do not use <code>npx</code> as the MCP command.
+        Remove the server and re-add with an absolute binary path:
+        <pre><code>xattr -dr com.apple.quarantine ~/Library/Caches/easy-review/er-mcp 2>/dev/null || true
+cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
+claude mcp remove easy-review
+claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
+<span class="cmt"># then /mcp → Reconnect (or restart Claude Code)</span></code></pre>
+        Verify the binary answers MCP initialize:
+        <pre><code>printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}' \
+  | "$(command -v er-mcp)" 2>/dev/null | head -c 200</code></pre>
       </li>
       <li><strong>Server not listed</strong> — try <code>npx -y easy-review-mcp</code> in a terminal (should print a setup hint); or check the absolute path / restart client.</li>
       <li><strong>Tools fail on GitHub</strong> — run <code>gh auth status</code>; MCP shells out to <code>gh</code> like Desktop.</li>

--- a/npm/er-mcp/README.md
+++ b/npm/er-mcp/README.md
@@ -33,8 +33,12 @@ Running that in a bare terminal prints a short setup hint and exits.
 
 ### Claude Code
 
+Prefer an absolute `er-mcp` path — `npx` often leaves Claude on **connecting…**:
+
 ```bash
-claude mcp add --scope user easy-review -- npx -y easy-review-mcp
+cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
+claude mcp remove easy-review 2>/dev/null || true
+claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
 ```
 
 ### Codex
@@ -50,17 +54,20 @@ codex mcp add easy-review -- npx -y easy-review-mcp
 | `ER_MCP_PATH` / `ER_MCP_BINARY` | Use this binary instead of downloading |
 | `XDG_CACHE_HOME` | Cache root (Linux/default) |
 
-If Claude Code stays on **connecting…**, clear macOS quarantine on the cached binary and reconnect:
+If Claude Code stays on **connecting…**, stop using `npx` for the MCP command. Point at the binary:
 
 ```bash
-xattr -dr com.apple.quarantine ~/Library/Caches/easy-review/er-mcp
+xattr -dr com.apple.quarantine ~/Library/Caches/easy-review/er-mcp 2>/dev/null || true
+cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
+claude mcp remove easy-review
+claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
 ```
 
-Or point Claude at a source-built binary:
+Or use the npm cache binary after a local download:
 
 ```bash
-cargo install --git https://github.com/VilfredSikker/easy-review --locked er-mcp
-claude mcp add --scope user easy-review -- "$(command -v er-mcp)"
+# macOS
+claude mcp add --scope user easy-review -- "$HOME/Library/Caches/easy-review/er-mcp/v0.4.4/er-mcp"
 ```
 
 If no release asset exists yet, install from source:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Claude Code stuck on **connecting…** with `npx -y easy-review-mcp` is a known class of stdio MCP failure (`npx` stdout / first-run delay). Docs now tell Claude users to point at an absolute `er-mcp` binary instead.

## Test plan
- [ ] `cargo install … er-mcp` then `claude mcp add --scope user easy-review -- "$(command -v er-mcp)"` reaches connected
- [ ] Initialize smoke: pipe JSON-RPC initialize to `er-mcp` and get a result
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6cae-f7c6-76c4-93f7-49300545aa37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6cae-f7c6-76c4-93f7-49300545aa37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

