### PR TITLE
feat(er-mcp): pin and list reviewed PR artifacts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+# Easy Review (Unreleased)
+
+## In plain terms
+
+- **What changed.** After an agent uploads triage/review/tour sidecars via MCP, there was no way to bookmark that PR or list what was already reviewed. New tools pin into Desktop Saved PRs and scan managed storage for uploaded artifacts.
+- **Why it matters.** You can find agent-reviewed PRs again from MCP (`list_pinned_prs` / `list_artifacts`) and see the same pins in the Desktop sidebar.
+- **TL;DR.** MCP `pin_pr` / `list_pinned_prs` / `list_artifacts` for reviewed sidecars.
+
+## What's Changed
+
+### Features
+- MCP `pin_pr` / `unpin_pr` / `list_pinned_prs` write Desktop Saved PRs (`projects.json` `saved_prs`) with Value-preserving updates (`er-engine::projects_pins`).
+- MCP `list_artifacts` scans managed `prs/pr-*` buckets for uploaded triage/review/tour and marks whether each is pinned.
+- `er-review` skill documents pin + find-reviewed-work flow.
+
+---
+
 # Easy Review v0.4.4
 
 ## In plain terms

--- a/crates/er-engine/src/lib.rs
+++ b/crates/er-engine/src/lib.rs
@@ -19,6 +19,7 @@ pub mod github;
 #[cfg(feature = "highlight")]
 pub mod highlight;
 pub mod paths;
+pub mod projects_pins;
 pub mod review_queue;
 pub mod sidecar_specs;
 pub mod sidecar_summary;

--- a/crates/er-engine/src/projects_pins.rs
+++ b/crates/er-engine/src/projects_pins.rs
@@ -1,0 +1,501 @@
+//! Value-preserving pin/unpin of PRs into Desktop's `saved_prs`
+//! (`~/.config/er/projects.json`).
+//!
+//! Mutations go through `serde_json::Value` so unknown project fields
+//! (tracked_prs, auto_triage, …) are never dropped — critical for MCP, which
+//! must not round-trip a partial `ProjectRecord`.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_PR_HISTORY: usize = 50;
+
+/// One entry in a project's `saved_prs` array (Desktop Saved sidebar).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PinnedPr {
+    pub number: u64,
+    pub saved_at_ms: u64,
+    #[serde(default)]
+    pub title: String,
+}
+
+/// Path to `projects.json`. Overridable via `ER_PROJECTS_JSON` for tests.
+pub fn projects_path() -> PathBuf {
+    if let Ok(override_path) = std::env::var("ER_PROJECTS_JSON") {
+        if !override_path.is_empty() {
+            return PathBuf::from(override_path);
+        }
+    }
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("er")
+        .join("projects.json")
+}
+
+fn now_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Normalize a GitHub remote reference to a lowercase `owner/repo` slug.
+pub fn normalize_remote_slug(remote: &str) -> String {
+    let trimmed = remote.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://github.com/")
+        .or_else(|| trimmed.strip_prefix("http://github.com/"))
+        .or_else(|| trimmed.strip_prefix("git@github.com:"))
+        .unwrap_or(trimmed);
+    without_scheme
+        .trim_end_matches(".git")
+        .trim_matches('/')
+        .to_ascii_lowercase()
+}
+
+fn valid_remote_slug(remote: &str) -> Option<String> {
+    let slug = normalize_remote_slug(remote);
+    if !slug.is_empty() && slug.split('/').count() == 2 {
+        Some(slug)
+    } else {
+        None
+    }
+}
+
+fn sanitize_id(name: &str) -> String {
+    let s: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = s.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "project".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn load_value(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Ok(json!({ "projects": [], "active_id": null }));
+    }
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    if bytes.is_empty() {
+        return Ok(json!({ "projects": [], "active_id": null }));
+    }
+    serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))
+}
+
+fn save_value(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(value).context("serialize projects.json")?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &bytes).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn projects_array_mut(root: &mut Value) -> Result<&mut Vec<Value>> {
+    if root.get("projects").is_none() {
+        root.as_object_mut()
+            .context("projects.json root must be an object")?
+            .insert("projects".into(), Value::Array(Vec::new()));
+    }
+    root.get_mut("projects")
+        .and_then(|v| v.as_array_mut())
+        .context("projects.json projects must be an array")
+}
+
+fn find_project_mut<'a>(projects: &'a mut [Value], project_id: &str) -> Result<&'a mut Value> {
+    projects
+        .iter_mut()
+        .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(project_id))
+        .with_context(|| format!("Project not found: {project_id}"))
+}
+
+fn parse_saved_prs(project: &Value) -> Vec<PinnedPr> {
+    project
+        .get("saved_prs")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| serde_json::from_value::<PinnedPr>(e.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn write_saved_prs(project: &mut Value, entries: &[PinnedPr]) -> Result<()> {
+    let obj = project
+        .as_object_mut()
+        .context("project entry must be an object")?;
+    obj.insert(
+        "saved_prs".into(),
+        serde_json::to_value(entries).context("serialize saved_prs")?,
+    );
+    Ok(())
+}
+
+/// Find an existing project for `owner/repo` without creating one.
+pub fn find_project_for_remote(owner: &str, repo: &str) -> Result<Option<(String, String)>> {
+    find_project_for_remote_at(&projects_path(), owner, repo)
+}
+
+fn find_project_for_remote_at(
+    path: &Path,
+    owner: &str,
+    repo: &str,
+) -> Result<Option<(String, String)>> {
+    let remote = valid_remote_slug(&format!("{owner}/{repo}"))
+        .with_context(|| format!("invalid GitHub remote slug: {owner}/{repo}"))?;
+    let root = load_value(path)?;
+    let Some(projects) = root.get("projects").and_then(|v| v.as_array()) else {
+        return Ok(None);
+    };
+    for p in projects {
+        let existing = p
+            .get("remote")
+            .and_then(|v| v.as_str())
+            .and_then(valid_remote_slug);
+        if existing.as_deref() == Some(remote.as_str()) {
+            let id = p
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let name = p
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&remote)
+                .to_string();
+            if id.is_empty() {
+                bail!("project for {remote} has empty id");
+            }
+            return Ok(Some((id, name)));
+        }
+    }
+    Ok(None)
+}
+
+/// Find or create a Desktop project for `owner/repo`. Returns `(project_id, project_name)`.
+pub fn ensure_project_for_remote(owner: &str, repo: &str) -> Result<(String, String)> {
+    ensure_project_for_remote_at(&projects_path(), owner, repo)
+}
+
+fn ensure_project_for_remote_at(
+    path: &Path,
+    owner: &str,
+    repo: &str,
+) -> Result<(String, String)> {
+    if let Some(found) = find_project_for_remote_at(path, owner, repo)? {
+        return Ok(found);
+    }
+
+    let remote = valid_remote_slug(&format!("{owner}/{repo}"))
+        .with_context(|| format!("invalid GitHub remote slug: {owner}/{repo}"))?;
+
+    let mut root = load_value(path)?;
+    let projects = projects_array_mut(&mut root)?;
+
+    let base_id = format!("remote-{}", sanitize_id(&remote));
+    let mut unique_id = base_id.clone();
+    let mut n = 2;
+    while projects
+        .iter()
+        .any(|p| p.get("id").and_then(|v| v.as_str()) == Some(unique_id.as_str()))
+    {
+        unique_id = format!("{base_id}-{n}");
+        n += 1;
+    }
+
+    let record = json!({
+        "id": unique_id,
+        "name": remote,
+        "root_path": "",
+        "remote": remote,
+        "dismissed_prs": [],
+        "tracked_prs": [],
+        "tracked_branches": [],
+        "dismissed_branches": [],
+        "recent_prs": [],
+        "saved_prs": [],
+        "auto_triage": false,
+        "auto_triage_own_prs": false,
+        "auto_triage_when": "new-and-push",
+        "auto_triage_max_diff_kb": 0,
+        "review_ignore_globs": [],
+    });
+    let id = unique_id.clone();
+    let name = remote.clone();
+    projects.push(record);
+    save_value(path, &root)?;
+    Ok((id, name))
+}
+
+/// Resolve a project id for pinning: explicit id, else match by remote, else create.
+pub fn resolve_project_for_pin(
+    project_id: Option<&str>,
+    owner: &str,
+    repo: &str,
+) -> Result<(String, String)> {
+    resolve_project_for_pin_at(&projects_path(), project_id, owner, repo, true)
+}
+
+/// Resolve a project for list tools: explicit id or remote match — never creates.
+pub fn resolve_project_for_list(
+    project_id: Option<&str>,
+    owner: &str,
+    repo: &str,
+) -> Result<Option<(String, String)>> {
+    let path = projects_path();
+    if let Some(id) = project_id {
+        let root = load_value(&path)?;
+        let projects = root
+            .get("projects")
+            .and_then(|v| v.as_array())
+            .context("projects.json projects must be an array")?;
+        let p = projects
+            .iter()
+            .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(id))
+            .with_context(|| format!("project not found: {id}"))?;
+        let name = p
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(id)
+            .to_string();
+        return Ok(Some((id.to_string(), name)));
+    }
+    find_project_for_remote_at(&path, owner, repo)
+}
+
+fn resolve_project_for_pin_at(
+    path: &Path,
+    project_id: Option<&str>,
+    owner: &str,
+    repo: &str,
+    create: bool,
+) -> Result<(String, String)> {
+    if let Some(id) = project_id {
+        let root = load_value(path)?;
+        let projects = root
+            .get("projects")
+            .and_then(|v| v.as_array())
+            .context("projects.json projects must be an array")?;
+        let p = projects
+            .iter()
+            .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(id))
+            .with_context(|| format!("project not found: {id}"))?;
+        let name = p
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(id)
+            .to_string();
+        return Ok((id.to_string(), name));
+    }
+    if create {
+        ensure_project_for_remote_at(path, owner, repo)
+    } else {
+        find_project_for_remote_at(path, owner, repo)?
+            .with_context(|| format!("no Easy Review project for {owner}/{repo}"))
+    }
+}
+
+/// Pin a PR into the project's `saved_prs` (Desktop Saved). Upserts, newest first, max 50.
+pub fn pin_pr(project_id: &str, number: u64, title: &str) -> Result<PinnedPr> {
+    pin_pr_at(&projects_path(), project_id, number, title)
+}
+
+fn pin_pr_at(path: &Path, project_id: &str, number: u64, title: &str) -> Result<PinnedPr> {
+    let mut root = load_value(path)?;
+    let projects = projects_array_mut(&mut root)?;
+    let project = find_project_mut(projects, project_id)?;
+    let mut entries = parse_saved_prs(project);
+    entries.retain(|e| e.number != number);
+    let entry = PinnedPr {
+        number,
+        saved_at_ms: now_epoch_ms(),
+        title: title.to_string(),
+    };
+    entries.insert(0, entry.clone());
+    entries.truncate(MAX_PR_HISTORY);
+    write_saved_prs(project, &entries)?;
+    save_value(path, &root)?;
+    Ok(entry)
+}
+
+/// Remove a PR from the project's `saved_prs`. Returns whether an entry was removed.
+pub fn unpin_pr(project_id: &str, number: u64) -> Result<bool> {
+    unpin_pr_at(&projects_path(), project_id, number)
+}
+
+fn unpin_pr_at(path: &Path, project_id: &str, number: u64) -> Result<bool> {
+    let mut root = load_value(path)?;
+    let projects = projects_array_mut(&mut root)?;
+    let project = find_project_mut(projects, project_id)?;
+    let mut entries = parse_saved_prs(project);
+    let before = entries.len();
+    entries.retain(|e| e.number != number);
+    if entries.len() == before {
+        return Ok(false);
+    }
+    write_saved_prs(project, &entries)?;
+    save_value(path, &root)?;
+    Ok(true)
+}
+
+/// List pinned PRs for a project (most recently pinned first).
+pub fn list_pinned(project_id: &str) -> Result<Vec<PinnedPr>> {
+    list_pinned_at(&projects_path(), project_id)
+}
+
+fn list_pinned_at(path: &Path, project_id: &str) -> Result<Vec<PinnedPr>> {
+    let root = load_value(path)?;
+    let projects = root
+        .get("projects")
+        .and_then(|v| v.as_array())
+        .context("projects.json projects must be an array")?;
+    let project = projects
+        .iter()
+        .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(project_id))
+        .with_context(|| format!("Project not found: {project_id}"))?;
+    Ok(parse_saved_prs(project))
+}
+
+/// Set of pinned PR numbers for a project (empty if project missing).
+pub fn pinned_numbers(project_id: &str) -> std::collections::HashSet<u64> {
+    list_pinned(project_id)
+        .map(|v| v.into_iter().map(|e| e.number).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize env-var tests so parallel cargo test doesn't race on ER_PROJECTS_JSON.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_projects<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Path) -> R,
+    {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projects.json");
+        std::env::set_var("ER_PROJECTS_JSON", &path);
+        let result = f(&path);
+        std::env::remove_var("ER_PROJECTS_JSON");
+        result
+    }
+
+    #[test]
+    fn pin_unpin_list_round_trip() {
+        with_temp_projects(|path| {
+            let (id, name) = ensure_project_for_remote_at(path, "Acme", "Widgets").unwrap();
+            assert_eq!(name, "acme/widgets");
+            assert!(id.starts_with("remote-"));
+
+            let pinned = pin_pr_at(path, &id, 42, "Fix thing").unwrap();
+            assert_eq!(pinned.number, 42);
+            assert_eq!(pinned.title, "Fix thing");
+
+            let list = list_pinned_at(path, &id).unwrap();
+            assert_eq!(list.len(), 1);
+            assert_eq!(list[0].number, 42);
+
+            // Upsert moves to front and updates title.
+            pin_pr_at(path, &id, 7, "Other").unwrap();
+            pin_pr_at(path, &id, 42, "Fix thing v2").unwrap();
+            let list = list_pinned_at(path, &id).unwrap();
+            assert_eq!(list.len(), 2);
+            assert_eq!(list[0].number, 42);
+            assert_eq!(list[0].title, "Fix thing v2");
+            assert_eq!(list[1].number, 7);
+
+            assert!(unpin_pr_at(path, &id, 42).unwrap());
+            assert!(!unpin_pr_at(path, &id, 42).unwrap());
+            let list = list_pinned_at(path, &id).unwrap();
+            assert_eq!(list.len(), 1);
+            assert_eq!(list[0].number, 7);
+        });
+    }
+
+    #[test]
+    fn preserves_unknown_project_fields() {
+        with_temp_projects(|path| {
+            let initial = json!({
+                "active_id": "p1",
+                "projects": [{
+                    "id": "p1",
+                    "name": "Widgets",
+                    "root_path": "/tmp/widgets",
+                    "remote": "acme/widgets",
+                    "tracked_prs": [99],
+                    "auto_triage": true,
+                    "auto_triage_when": "new-only",
+                    "custom_future_field": {"nested": true},
+                    "saved_prs": []
+                }]
+            });
+            save_value(path, &initial).unwrap();
+
+            pin_pr_at(path, "p1", 5, "Pinned").unwrap();
+
+            let root = load_value(path).unwrap();
+            let p = &root["projects"][0];
+            assert_eq!(p["tracked_prs"], json!([99]));
+            assert_eq!(p["auto_triage"], json!(true));
+            assert_eq!(p["auto_triage_when"], json!("new-only"));
+            assert_eq!(p["custom_future_field"], json!({"nested": true}));
+            assert_eq!(p["root_path"], json!("/tmp/widgets"));
+            let saved = parse_saved_prs(p);
+            assert_eq!(saved.len(), 1);
+            assert_eq!(saved[0].number, 5);
+        });
+    }
+
+    #[test]
+    fn ensure_reuses_existing_remote_project() {
+        with_temp_projects(|path| {
+            let (id1, _) = ensure_project_for_remote_at(path, "acme", "widgets").unwrap();
+            let (id2, _) = ensure_project_for_remote_at(path, "ACME", "Widgets").unwrap();
+            assert_eq!(id1, id2);
+            let root = load_value(path).unwrap();
+            assert_eq!(root["projects"].as_array().unwrap().len(), 1);
+        });
+    }
+
+    #[test]
+    fn resolve_explicit_project_id() {
+        with_temp_projects(|path| {
+            let initial = json!({
+                "projects": [{
+                    "id": "local-1",
+                    "name": "Local",
+                    "root_path": "/x",
+                    "remote": "acme/widgets",
+                    "saved_prs": []
+                }]
+            });
+            save_value(path, &initial).unwrap();
+            let (id, name) =
+                resolve_project_for_pin_at(path, Some("local-1"), "acme", "widgets", true).unwrap();
+            assert_eq!(id, "local-1");
+            assert_eq!(name, "Local");
+        });
+    }
+}

--- a/crates/er-engine/src/projects_pins.rs
+++ b/crates/er-engine/src/projects_pins.rs
@@ -97,8 +97,7 @@ fn load_value(path: &Path) -> Result<Value> {
 
 fn save_value(path: &Path, value: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("mkdir {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
     }
     let bytes = serde_json::to_vec_pretty(value).context("serialize projects.json")?;
     let tmp = path.with_extension("json.tmp");
@@ -195,11 +194,7 @@ pub fn ensure_project_for_remote(owner: &str, repo: &str) -> Result<(String, Str
     ensure_project_for_remote_at(&projects_path(), owner, repo)
 }
 
-fn ensure_project_for_remote_at(
-    path: &Path,
-    owner: &str,
-    repo: &str,
-) -> Result<(String, String)> {
+fn ensure_project_for_remote_at(path: &Path, owner: &str, repo: &str) -> Result<(String, String)> {
     if let Some(found) = find_project_for_remote_at(path, owner, repo)? {
         return Ok(found);
     }

--- a/crates/er-engine/src/sidecar_summary.rs
+++ b/crates/er-engine/src/sidecar_summary.rs
@@ -487,13 +487,8 @@ mod tests {
         assert!(!numbers.contains(&1));
         assert!(!numbers.contains(&30));
 
-        let tours_only = list_repo_pr_artifacts_in_dir(
-            "acme",
-            "widgets",
-            prs,
-            Some(&[SidecarKind::Tour]),
-            50,
-        );
+        let tours_only =
+            list_repo_pr_artifacts_in_dir("acme", "widgets", prs, Some(&[SidecarKind::Tour]), 50);
         assert_eq!(tours_only.len(), 1);
         assert_eq!(tours_only[0].summary.number, 20);
         assert_eq!(tours_only[0].kinds, vec!["tour".to_string()]);

--- a/crates/er-engine/src/sidecar_summary.rs
+++ b/crates/er-engine/src/sidecar_summary.rs
@@ -2,10 +2,12 @@
 
 use crate::ai::{load_tour_sidecar, load_triage_review, ErReview, ErTour, RiskLevel, TriageReview};
 use crate::github::owner_repo_storage_slug;
-use crate::storage::pr_bucket_dir;
+use crate::sidecar_upload::SidecarKind;
+use crate::storage::{pr_bucket_dir, storage_root};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::time::UNIX_EPOCH;
 
 /// Slim view of what Easy Review already knows about a PR from local sidecars.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,6 +127,130 @@ fn summarize_tour(t: &ErTour) -> TourSummary {
         diff_hash: t.diff_hash.clone(),
         created_at: t.created_at.clone(),
     }
+}
+
+/// Kind labels present in a PR bucket (`triage` / `review` / `tour`).
+pub fn present_kinds(summary: &PrSidecarSummary) -> Vec<&'static str> {
+    let mut kinds = Vec::new();
+    if summary.triage.is_some() {
+        kinds.push("triage");
+    }
+    if summary.review.is_some() {
+        kinds.push("review");
+    }
+    if summary.tour.is_some() {
+        kinds.push("tour");
+    }
+    kinds
+}
+
+fn kind_matches_filter(kinds: &[&str], filter: Option<&[SidecarKind]>) -> bool {
+    let Some(filter) = filter else {
+        return !kinds.is_empty();
+    };
+    if filter.is_empty() {
+        return !kinds.is_empty();
+    }
+    filter.iter().any(|k| match k {
+        SidecarKind::Triage => kinds.contains(&"triage"),
+        SidecarKind::Review => kinds.contains(&"review"),
+        SidecarKind::Tour => kinds.contains(&"tour"),
+    })
+}
+
+fn file_mtime_secs(path: &Path) -> Option<u64> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified = meta.modified().ok()?;
+    Some(
+        modified
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    )
+}
+
+fn bucket_sidecar_mtime_secs(bucket: &Path) -> u64 {
+    ["triage.json", "review.json", "tour.json"]
+        .iter()
+        .filter_map(|name| file_mtime_secs(&bucket.join(name)))
+        .max()
+        .unwrap_or(0)
+}
+
+/// One PR bucket that has at least one triage/review/tour sidecar.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListedPrArtifacts {
+    #[serde(flatten)]
+    pub summary: PrSidecarSummary,
+    /// Present kinds: `triage`, `review`, `tour`.
+    pub kinds: Vec<String>,
+    /// Max mtime (unix seconds) among present sidecar files.
+    pub mtime_secs: u64,
+}
+
+/// Scan managed `prs/pr-*` buckets for uploaded triage/review/tour sidecars.
+///
+/// Newest sidecar mtime first. `kinds_filter` keeps PRs that have *any* of the
+/// requested kinds. `limit` caps the result (callers should clamp).
+pub fn list_repo_pr_artifacts(
+    owner: &str,
+    repo: &str,
+    kinds_filter: Option<&[SidecarKind]>,
+    limit: usize,
+) -> Vec<ListedPrArtifacts> {
+    let slug = owner_repo_storage_slug(owner, repo);
+    let prs_dir = storage_root().join("repos").join(&slug).join("prs");
+    list_repo_pr_artifacts_in_dir(owner, repo, &prs_dir, kinds_filter, limit)
+}
+
+/// Test / custom-root variant of [`list_repo_pr_artifacts`].
+pub fn list_repo_pr_artifacts_in_dir(
+    owner: &str,
+    repo: &str,
+    prs_dir: &Path,
+    kinds_filter: Option<&[SidecarKind]>,
+    limit: usize,
+) -> Vec<ListedPrArtifacts> {
+    let Ok(entries) = std::fs::read_dir(prs_dir) else {
+        return Vec::new();
+    };
+
+    let mut listed = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Some(number_str) = name.strip_prefix("pr-") else {
+            continue;
+        };
+        let Ok(number) = number_str.parse::<u64>() else {
+            continue;
+        };
+
+        let summary = summarize_pr_bucket(owner, repo, number, &path);
+        let kinds = present_kinds(&summary);
+        if !kind_matches_filter(&kinds, kinds_filter) {
+            continue;
+        }
+        let mtime_secs = bucket_sidecar_mtime_secs(&path);
+        listed.push(ListedPrArtifacts {
+            summary,
+            kinds: kinds.into_iter().map(str::to_string).collect(),
+            mtime_secs,
+        });
+    }
+
+    listed.sort_by(|a, b| {
+        b.mtime_secs
+            .cmp(&a.mtime_secs)
+            .then_with(|| b.summary.number.cmp(&a.summary.number))
+    });
+    listed.truncate(limit);
+    listed
 }
 
 /// Read managed PR-bucket sidecars for `owner/repo` PR `#number`.
@@ -296,5 +422,80 @@ mod tests {
         assert_eq!(tour_sum.files, 1);
         assert_eq!(tour_sum.pillar_titles, vec!["Core".to_string()]);
         assert!(summary.missing.is_empty());
+    }
+
+    #[test]
+    fn list_repo_pr_artifacts_finds_triage_and_tour_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let prs = dir.path();
+
+        let empty = prs.join("pr-1");
+        std::fs::create_dir_all(&empty).unwrap();
+
+        let with_triage = prs.join("pr-10");
+        std::fs::create_dir_all(&with_triage).unwrap();
+        let triage = TriageReview {
+            version: 1,
+            diff_hash: "h1".into(),
+            diff_scope: "pr".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            first_impression: "ok".into(),
+            diff_stats: TriageDiffStats {
+                files_changed: 1,
+                approx_risk: "low".into(),
+                domains: vec![],
+            },
+            verdict: TriageVerdict {
+                primary: TriageVerdictPrimary::General,
+                experts: vec![],
+                rationale: "r".into(),
+                confidence: "high".into(),
+            },
+            priority_files: vec![],
+        };
+        std::fs::write(
+            with_triage.join("triage.json"),
+            serde_json::to_string(&triage).unwrap(),
+        )
+        .unwrap();
+
+        let with_tour = prs.join("pr-20");
+        std::fs::create_dir_all(&with_tour).unwrap();
+        let tour = ErTour {
+            version: 1,
+            diff_hash: "h2".into(),
+            created_at: "2026-01-02T00:00:00Z".into(),
+            title: "Tour only".into(),
+            overview: "o".into(),
+            pillars: vec![],
+        };
+        std::fs::write(
+            with_tour.join("tour.json"),
+            serde_json::to_string(&tour).unwrap(),
+        )
+        .unwrap();
+
+        // Questions-only bucket should not appear.
+        let questions_only = prs.join("pr-30");
+        std::fs::create_dir_all(&questions_only).unwrap();
+        std::fs::write(questions_only.join("questions.json"), "[]").unwrap();
+
+        let all = list_repo_pr_artifacts_in_dir("acme", "widgets", prs, None, 50);
+        let numbers: Vec<u64> = all.iter().map(|e| e.summary.number).collect();
+        assert!(numbers.contains(&10));
+        assert!(numbers.contains(&20));
+        assert!(!numbers.contains(&1));
+        assert!(!numbers.contains(&30));
+
+        let tours_only = list_repo_pr_artifacts_in_dir(
+            "acme",
+            "widgets",
+            prs,
+            Some(&[SidecarKind::Tour]),
+            50,
+        );
+        assert_eq!(tours_only.len(), 1);
+        assert_eq!(tours_only[0].summary.number, 20);
+        assert_eq!(tours_only[0].kinds, vec!["tour".to_string()]);
     }
 }

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -35,6 +35,10 @@ Uses the authenticated `gh` CLI (same as Easy Review desktop/TUI). Optionally re
 | `prepare_review` | Write shared `diff-tmp`, return `diff_hash` + prompts |
 | `get_artifact_specs` | JSON Schema + examples + prompts for triage/review/tour (no PR needed) |
 | `upload_artifacts` | Validate + write `triage` / `review` / `tour` JSON you produced |
+| `pin_pr` | Pin a PR into Desktop Saved PRs (`projects.json`) |
+| `unpin_pr` | Remove a PR from Desktop Saved |
+| `list_pinned_prs` | List Saved PRs + which sidecars exist |
+| `list_artifacts` | Scan managed storage for uploaded triage/review/tour (marks `pinned`) |
 | `summarize_triage` | Local managed `triage.json` / `review.json` / `tour.json` summary |
 | `open_in_easy_review` | GitHub URL + desktop/TUI open instructions |
 | `tool_ideas` | Catalog of shipped + future tools |
@@ -52,12 +56,15 @@ validates uploads — it does not spawn agent CLIs.
 3. You read `diff_tmp_path`, produce the sidecars (embed that exact `diff_hash`).
 4. `upload_artifacts` — atomic write + schema/`diff_hash` validation.
 5. `summarize_triage` or open the PR in Desktop/TUI — sidecars are shared.
+6. Optionally `pin_pr` so the PR appears in Desktop Saved and `list_pinned_prs`.
 
 ```text
 get_artifact_specs → { "kinds": ["tour"] }
 prepare_review     → { "number": 42, "kinds": ["triage", "tour"] }
 # …you write the JSON per schema…
 upload_artifacts   → { "number": 42, "kind": "tour", "files": { "tour.json": "..." } }
+pin_pr             → { "number": 42 }
+list_artifacts     → { "kinds": ["tour"] }   # discover uploaded sidecars
 summarize_triage   → { "number": 42 }
 ```
 
@@ -143,6 +150,9 @@ compare_prod_size         → { "numbers": [12, 15, 18] }
 prepare_review            → { "number": 42, "kinds": ["tour"] }
 get_artifact_specs        → { "kinds": ["tour", "triage"] }
 upload_artifacts          → { "number": 42, "kind": "tour", "files": { "tour.json": "{...}" } }
+pin_pr                    → { "number": 42 }
+list_pinned_prs           → {}
+list_artifacts            → { "kinds": ["triage", "tour"], "limit": 20 }
 summarize_triage          → { "number": 42 }
 open_in_easy_review       → { "number": 42 }
 ```
@@ -152,6 +162,7 @@ open_in_easy_review       → { "number": 42 }
 - Pure ranking / file classification live in `er-engine` (`review_queue`, `git::file_kind`, `git::diff_stats`, `sidecar_summary`).
 - Client-owned uploads live in `er-engine::sidecar_upload` (prepare kit + validated write).
 - JSON Schema + prompt contracts live in `er-engine::sidecar_specs` (`get_artifact_specs`).
+- Desktop Saved pins live in `er-engine::projects_pins` (Value-preserving `projects.json` writes).
 - `er-mcp` is a thin `rmcp` stdio wrapper over those APIs.
 
 ## Notes

--- a/crates/er-mcp/src/server.rs
+++ b/crates/er-mcp/src/server.rs
@@ -14,9 +14,7 @@ use er_engine::review_queue::{
     ReviewStatus,
 };
 use er_engine::sidecar_specs::{artifact_specs, artifact_specs_for_dir};
-use er_engine::sidecar_summary::{
-    list_repo_pr_artifacts, present_kinds, summarize_pr_sidecars,
-};
+use er_engine::sidecar_summary::{list_repo_pr_artifacts, present_kinds, summarize_pr_sidecars};
 use er_engine::sidecar_upload::{
     prepare_review_kit, upload_pr_artifacts, SidecarKind, UploadArtifactsRequest,
 };
@@ -267,7 +265,10 @@ fn fetch_pr_title(owner: &str, repo: &str, number: u64) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-fn pinned_sidecar_json(entry: &PinnedPr, summary: &er_engine::sidecar_summary::PrSidecarSummary) -> serde_json::Value {
+fn pinned_sidecar_json(
+    entry: &PinnedPr,
+    summary: &er_engine::sidecar_summary::PrSidecarSummary,
+) -> serde_json::Value {
     json!({
         "number": entry.number,
         "title": entry.title,
@@ -967,11 +968,8 @@ impl ErMcp {
         let project_id_arg = args.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
-            let (project_id, project_name) = projects_pins::resolve_project_for_pin(
-                project_id_arg.as_deref(),
-                &owner,
-                &name,
-            )?;
+            let (project_id, project_name) =
+                projects_pins::resolve_project_for_pin(project_id_arg.as_deref(), &owner, &name)?;
             let title = title_arg
                 .filter(|t| !t.trim().is_empty())
                 .or_else(|| fetch_pr_title(&owner, &name, number))
@@ -994,9 +992,7 @@ impl ErMcp {
         }))
     }
 
-    #[tool(
-        description = "Remove a PR from Desktop Saved PRs (unpin)."
-    )]
+    #[tool(description = "Remove a PR from Desktop Saved PRs (unpin).")]
     async fn unpin_pr(
         &self,
         Parameters(args): Parameters<PrNumberArgs>,
@@ -1007,11 +1003,8 @@ impl ErMcp {
         let project_id_arg = args.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
-            let Some((project_id, project_name)) = projects_pins::resolve_project_for_list(
-                project_id_arg.as_deref(),
-                &owner,
-                &name,
-            )?
+            let Some((project_id, project_name)) =
+                projects_pins::resolve_project_for_list(project_id_arg.as_deref(), &owner, &name)?
             else {
                 return Ok((None, None, owner, name, false));
             };
@@ -1044,19 +1037,10 @@ impl ErMcp {
         let project_id_arg = args.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
-            let Some((project_id, project_name)) = projects_pins::resolve_project_for_list(
-                project_id_arg.as_deref(),
-                &owner,
-                &name,
-            )?
+            let Some((project_id, project_name)) =
+                projects_pins::resolve_project_for_list(project_id_arg.as_deref(), &owner, &name)?
             else {
-                return Ok((
-                    None,
-                    None,
-                    owner,
-                    name,
-                    Vec::<serde_json::Value>::new(),
-                ));
+                return Ok((None, None, owner, name, Vec::<serde_json::Value>::new()));
             };
             let pinned = projects_pins::list_pinned(&project_id)?;
             let rows: Vec<_> = pinned
@@ -1066,13 +1050,7 @@ impl ErMcp {
                     pinned_sidecar_json(entry, &summary)
                 })
                 .collect();
-            Ok::<_, anyhow::Error>((
-                Some(project_id),
-                Some(project_name),
-                owner,
-                name,
-                rows,
-            ))
+            Ok::<_, anyhow::Error>((Some(project_id), Some(project_name), owner, name, rows))
         })
         .await
         .map_err(|e| McpError::internal_error(e.to_string(), None))?
@@ -1111,11 +1089,8 @@ impl ErMcp {
         let project_id_arg = args.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
-            let project = projects_pins::resolve_project_for_list(
-                project_id_arg.as_deref(),
-                &owner,
-                &name,
-            )?;
+            let project =
+                projects_pins::resolve_project_for_list(project_id_arg.as_deref(), &owner, &name)?;
             let (project_id, project_name, pinned_set) = match project {
                 Some((id, pname)) => {
                     let set = projects_pins::pinned_numbers(&id);

--- a/crates/er-mcp/src/server.rs
+++ b/crates/er-mcp/src/server.rs
@@ -7,13 +7,16 @@ use er_engine::github::{
     gh_pr_checks_state_remote, gh_pr_list_queue, gh_pr_prod_diff_stats,
     gh_pr_thread_addressing_remote,
 };
+use er_engine::projects_pins::{self, PinnedPr};
 use er_engine::review_queue::{
     filter_blocked, filter_by_status, filter_failing_ci, filter_review_debt, filter_stale,
     open_in_easy_review, rank_low_hanging, rank_priority, score_pr, QueuePr, RankedPr,
     ReviewStatus,
 };
 use er_engine::sidecar_specs::{artifact_specs, artifact_specs_for_dir};
-use er_engine::sidecar_summary::summarize_pr_sidecars;
+use er_engine::sidecar_summary::{
+    list_repo_pr_artifacts, present_kinds, summarize_pr_sidecars,
+};
 use er_engine::sidecar_upload::{
     prepare_review_kit, upload_pr_artifacts, SidecarKind, UploadArtifactsRequest,
 };
@@ -170,6 +173,33 @@ pub struct ArtifactSpecsArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct PinPrArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// PR number to pin into Desktop Saved PRs.
+    pub number: u64,
+    /// Optional title (fetched via `gh` when omitted).
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListArtifactsArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// Optional kind filter (any-of): triage, review, tour.
+    #[serde(default)]
+    pub kinds: Option<Vec<String>>,
+    /// Max PRs to return (default 50, max 50).
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CrossRepoArgs {
     /// Max PRs to return across all projects (default 10).
     #[serde(default)]
@@ -211,6 +241,44 @@ fn text_json(value: &impl Serialize) -> Result<CallToolResult, McpError> {
 
 fn tool_err(msg: impl Into<String>) -> McpError {
     McpError::invalid_params(msg.into(), None)
+}
+
+/// Best-effort PR title via `gh pr view --json title`.
+fn fetch_pr_title(owner: &str, repo: &str, number: u64) -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            &format!("{owner}/{repo}"),
+            "--json",
+            "title",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    value
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn pinned_sidecar_json(entry: &PinnedPr, summary: &er_engine::sidecar_summary::PrSidecarSummary) -> serde_json::Value {
+    json!({
+        "number": entry.number,
+        "title": entry.title,
+        "saved_at_ms": entry.saved_at_ms,
+        "kinds": present_kinds(summary),
+        "bucket_path": summary.bucket_path,
+        "triage": summary.triage,
+        "review": summary.review,
+        "tour": summary.tour,
+        "missing": summary.missing,
+    })
 }
 
 async fn load_queue(
@@ -881,7 +949,212 @@ impl ErMcp {
         text_json(&json!({
             "project": project_name,
             "uploaded": result,
-            "note": "Sidecars are in shared managed storage — open the PR in Desktop/TUI or call summarize_triage.",
+            "note": "Sidecars are in shared managed storage — open the PR in Desktop/TUI, call summarize_triage, or pin_pr to bookmark in Desktop Saved.",
+        }))
+    }
+
+    #[tool(
+        description = "Pin a PR into Desktop Saved PRs (projects.json saved_prs) so you can find agent-reviewed work later. Does not auto-pin on upload — call explicitly after review."
+    )]
+    async fn pin_pr(
+        &self,
+        Parameters(args): Parameters<PinPrArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
+            .map_err(|e| tool_err(e.to_string()))?;
+        let number = args.number;
+        let title_arg = args.title.clone();
+        let project_id_arg = args.project_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let (project_id, project_name) = projects_pins::resolve_project_for_pin(
+                project_id_arg.as_deref(),
+                &owner,
+                &name,
+            )?;
+            let title = title_arg
+                .filter(|t| !t.trim().is_empty())
+                .or_else(|| fetch_pr_title(&owner, &name, number))
+                .unwrap_or_default();
+            let pinned = projects_pins::pin_pr(&project_id, number, &title)?;
+            let summary = summarize_pr_sidecars(&owner, &name, number);
+            Ok::<_, anyhow::Error>((project_id, project_name, owner, name, pinned, summary))
+        })
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        .map_err(|e| tool_err(e.to_string()))?;
+
+        let (project_id, project_name, owner, name, pinned, summary) = result;
+        text_json(&json!({
+            "repo": format!("{owner}/{name}"),
+            "project_id": project_id,
+            "project": project_name,
+            "pinned": pinned_sidecar_json(&pinned, &summary),
+            "note": "Also visible in Desktop sidebar Saved PRs.",
+        }))
+    }
+
+    #[tool(
+        description = "Remove a PR from Desktop Saved PRs (unpin)."
+    )]
+    async fn unpin_pr(
+        &self,
+        Parameters(args): Parameters<PrNumberArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
+            .map_err(|e| tool_err(e.to_string()))?;
+        let number = args.number;
+        let project_id_arg = args.project_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let Some((project_id, project_name)) = projects_pins::resolve_project_for_list(
+                project_id_arg.as_deref(),
+                &owner,
+                &name,
+            )?
+            else {
+                return Ok((None, None, owner, name, false));
+            };
+            let removed = projects_pins::unpin_pr(&project_id, number)?;
+            Ok::<_, anyhow::Error>((Some(project_id), Some(project_name), owner, name, removed))
+        })
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        .map_err(|e| tool_err(e.to_string()))?;
+
+        let (project_id, project_name, owner, name, removed) = result;
+        text_json(&json!({
+            "repo": format!("{owner}/{name}"),
+            "project_id": project_id,
+            "project": project_name,
+            "number": number,
+            "removed": removed,
+        }))
+    }
+
+    #[tool(
+        description = "List Desktop Saved (pinned) PRs for a repo/project, enriched with which triage/review/tour sidecars exist in managed storage."
+    )]
+    async fn list_pinned_prs(
+        &self,
+        Parameters(args): Parameters<RepoArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
+            .map_err(|e| tool_err(e.to_string()))?;
+        let project_id_arg = args.project_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let Some((project_id, project_name)) = projects_pins::resolve_project_for_list(
+                project_id_arg.as_deref(),
+                &owner,
+                &name,
+            )?
+            else {
+                return Ok((
+                    None,
+                    None,
+                    owner,
+                    name,
+                    Vec::<serde_json::Value>::new(),
+                ));
+            };
+            let pinned = projects_pins::list_pinned(&project_id)?;
+            let rows: Vec<_> = pinned
+                .iter()
+                .map(|entry| {
+                    let summary = summarize_pr_sidecars(&owner, &name, entry.number);
+                    pinned_sidecar_json(entry, &summary)
+                })
+                .collect();
+            Ok::<_, anyhow::Error>((
+                Some(project_id),
+                Some(project_name),
+                owner,
+                name,
+                rows,
+            ))
+        })
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        .map_err(|e| tool_err(e.to_string()))?;
+
+        let (project_id, project_name, owner, name, prs) = result;
+        text_json(&json!({
+            "repo": format!("{owner}/{name}"),
+            "project_id": project_id,
+            "project": project_name,
+            "count": prs.len(),
+            "prs": prs,
+        }))
+    }
+
+    #[tool(
+        description = "List PRs in managed storage that have uploaded triage/review/tour artifacts (whether pinned or not). Optional kinds filter. Marks pinned:true when in Desktop Saved."
+    )]
+    async fn list_artifacts(
+        &self,
+        Parameters(args): Parameters<ListArtifactsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
+            .map_err(|e| tool_err(e.to_string()))?;
+        let kinds = match args.kinds {
+            None => None,
+            Some(list) if list.is_empty() => None,
+            Some(list) => Some(
+                list.iter()
+                    .map(|s| parse_kind(s))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(tool_err)?,
+            ),
+        };
+        let limit = clamp_limit(args.limit, 50);
+        let project_id_arg = args.project_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let project = projects_pins::resolve_project_for_list(
+                project_id_arg.as_deref(),
+                &owner,
+                &name,
+            )?;
+            let (project_id, project_name, pinned_set) = match project {
+                Some((id, pname)) => {
+                    let set = projects_pins::pinned_numbers(&id);
+                    (Some(id), Some(pname), set)
+                }
+                None => (None, None, std::collections::HashSet::new()),
+            };
+            let filter = kinds.as_deref();
+            let listed = list_repo_pr_artifacts(&owner, &name, filter, limit);
+            let artifacts: Vec<_> = listed
+                .into_iter()
+                .map(|entry| {
+                    let number = entry.summary.number;
+                    json!({
+                        "number": number,
+                        "kinds": entry.kinds,
+                        "pinned": pinned_set.contains(&number),
+                        "mtime_secs": entry.mtime_secs,
+                        "bucket_path": entry.summary.bucket_path,
+                        "triage": entry.summary.triage,
+                        "review": entry.summary.review,
+                        "tour": entry.summary.tour,
+                        "missing": entry.summary.missing,
+                    })
+                })
+                .collect();
+            Ok::<_, anyhow::Error>((project_id, project_name, owner, name, artifacts))
+        })
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        .map_err(|e| tool_err(e.to_string()))?;
+
+        let (project_id, project_name, owner, name, artifacts) = result;
+        text_json(&json!({
+            "repo": format!("{owner}/{name}"),
+            "project_id": project_id,
+            "project": project_name,
+            "count": artifacts.len(),
+            "artifacts": artifacts,
         }))
     }
 
@@ -953,6 +1226,10 @@ const SHIPPED_TOOLS: &[&str] = &[
     "prepare_review",
     "get_artifact_specs",
     "upload_artifacts",
+    "pin_pr",
+    "unpin_pr",
+    "list_pinned_prs",
+    "list_artifacts",
     "tool_ideas",
 ];
 
@@ -974,6 +1251,7 @@ impl ServerHandler for ErMcp {
              Filters: prs_by_status, prs_stale, prs_blocked, prs_failing_ci, prs_already_addressed. \
              Sizing: pr_diff_stats, diff_hotspots, compare_prod_size. \
              AI sidecars: get_artifact_specs (schemas+prompts) → prepare_review → upload_artifacts → summarize_triage. \
+             Find reviewed work: pin_pr (Desktop Saved) / list_pinned_prs / list_artifacts (scan managed storage). \
              Open: open_in_easy_review.",
             )
     }

--- a/skills/er-review/SKILL.md
+++ b/skills/er-review/SKILL.md
@@ -31,6 +31,7 @@ Treat these as requests to run this skill end-to-end (not just list tools):
 - "triage this PR" / "run triage"
 - "guided tour" / "generate tour" (when they mean Easy Review tour.json)
 - "upload the review" / "push artifacts to Easy Review"
+- "pin this PR" / "show pinned reviews" / "what have I reviewed"
 
 ## Resolve the PR
 
@@ -61,9 +62,17 @@ Treat these as requests to run this skill end-to-end (not just list tools):
    - Triage: `{ "kind": "triage", "files": { "triage.json": "..." } }`
    - Tour: `{ "kind": "tour", "files": { "tour.json": "..." } }`
    - Review: all four — `review.json`, `order.json`, `checklist.json`, `summary.md`
-6. **`summarize_triage`** (optional) and/or **`open_in_easy_review`** so the user can open Desktop/TUI.
+6. **`pin_pr`** (optional but recommended) so the PR lands in Desktop Saved and is easy to find later via `list_pinned_prs`.
+7. **`summarize_triage`** (optional) and/or **`open_in_easy_review`** so the user can open Desktop/TUI.
 
 Do **not** write files under the managed path yourself — always go through `upload_artifacts`.
+Do **not** auto-pin — only call `pin_pr` when the user wants it bookmarked, or after a successful review when they asked to save/pin.
+
+## Finding reviewed work
+
+- **`list_pinned_prs`** — Desktop Saved PRs (explicit pins), with sidecar presence.
+- **`list_artifacts`** — scan managed storage for any uploaded triage/review/tour (pinned or not).
+- **`unpin_pr`** — remove from Desktop Saved.
 
 ## Validation rules
 


### PR DESCRIPTION
## Summary
- Add MCP `pin_pr` / `unpin_pr` / `list_pinned_prs` that write Desktop Saved PRs (`projects.json` `saved_prs`) via Value-preserving `er-engine::projects_pins` helpers.
- Add MCP `list_artifacts` to scan managed `prs/pr-*` buckets for uploaded triage/review/tour sidecars (marks `pinned`).
- Document the find-reviewed-work flow in the er-mcp README and `er-review` skill; release notes under Unreleased.

## Test plan
- [ ] `cargo test -p er-engine projects_pins`
- [ ] `cargo test -p er-engine sidecar_summary`
- [ ] `cargo build -p er-mcp` and restart the MCP server
- [ ] `pin_pr` on a PR → appears in Desktop sidebar Saved and in `list_pinned_prs`
- [ ] `unpin_pr` removes it
- [ ] `list_artifacts` returns PRs with uploaded sidecars; `pinned` matches Saved
- [ ] Confirm `projects.json` unrelated fields (tracked_prs, auto_triage, …) survive a pin write


Made with [Cursor](https://cursor.com)