### PR TITLE
fix: preflight desktop build scripts for missing toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ A graphical front end for the same review engine — split diffs, an embedded te
 
 As of **v0.4.0**, prebuilt Apple Silicon `.dmg` bundles are published on the [Releases page](https://github.com/VilfredSikker/easy-review/releases). Download it, open it, and drag **Easy Review** into Applications (right-click → **Open** the first time to bypass Gatekeeper, since the bundle isn't code-signed yet).
 
-Intel Macs, Linux, and Windows aren't packaged yet — build from source instead:
+Intel Macs, Linux, and Windows aren't packaged yet — build from source instead.
+
+**Prerequisites:** [Rust 1.85+](https://rustup.rs), the Tauri CLI (`cargo install tauri-cli --locked`), and [bun](https://bun.sh) for the frontend. On Linux you'll also need the [WebKitGTK build dependencies](https://v2.tauri.app/start/prerequisites/#linux). The scripts below check for these and `bun install` the frontend on first run.
 
 ```bash
 git clone https://github.com/VilfredSikker/easy-review.git

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+# Easy Review (Unreleased)
+
+## In plain terms
+
+- **What changed.** Building the desktop app from a fresh clone used to fail with a cryptic `error: no such command: tauri` (and, later, missing frontend deps), because the setup steps weren't documented and the scripts didn't check for them. Now `tauri-dev.sh` / `tauri-build.sh` verify the toolchain up front and print exactly what to install, and the README lists the prerequisites.
+- **Why it matters.** New contributors get an actionable message instead of a dead end, and the frontend deps install themselves on first run.
+- **TL;DR.** Desktop build-from-source onboarding: preflight checks + documented prerequisites.
+
+## What's Changed
+
+### Fixes
+- Desktop dev/build scripts preflight-check for the Rust toolchain, Tauri CLI, and bun, printing an actionable install command instead of failing cryptically; frontend deps `bun install` on first run (`scripts/preflight-desktop.sh`).
+- README documents desktop build-from-source prerequisites (Rust 1.85+, `tauri-cli`, bun, Linux WebKitGTK deps).
+
+---
+
 # Easy Review v0.4.4
 
 ## In plain terms

--- a/scripts/preflight-desktop.sh
+++ b/scripts/preflight-desktop.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Shared preflight for the desktop dev/build scripts.
+# Verifies the toolchain a fresh clone needs (tauri-cli + bun) and installs the
+# frontend deps on first run, so a missing prerequisite prints an actionable fix
+# up front instead of failing cryptically inside `cargo tauri` / Vite later.
+# Sourced by tauri-dev.sh and tauri-build.sh; returns non-zero on the first
+# missing prerequisite (callers run under `set -e`, so that aborts the script).
+
+preflight_desktop() {
+  local root="$1"
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+error: cargo (Rust toolchain) is not installed (or not on PATH).
+
+The desktop app is built with Rust. Install it once:
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+open a new shell so cargo is on PATH, then re-run this script.
+EOF
+    return 1
+  fi
+
+  if ! cargo tauri --version >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+error: the Tauri CLI (cargo-tauri) is not installed.
+
+The desktop app builds with Tauri, which provides the `cargo tauri` subcommand.
+Install it once:
+
+    cargo install tauri-cli --locked
+
+then re-run this script.
+EOF
+    return 1
+  fi
+
+  if ! command -v bun >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+error: bun is not installed (or not on PATH).
+
+The desktop frontend (desktop-ui) builds with bun. Install it once:
+
+    curl -fsSL https://bun.sh/install | bash      # or: brew install oven-sh/bun/bun
+
+open a new shell so bun is on PATH, then re-run this script.
+EOF
+    return 1
+  fi
+
+  # Frontend deps aren't vendored, and Tauri's beforeDev/beforeBuild command runs
+  # `bun run dev` / `bun run build`, which needs node_modules present. Install on
+  # first run so a fresh clone doesn't hit an opaque Vite "cannot find module".
+  if [[ ! -d "$root/desktop-ui/node_modules" ]]; then
+    echo "preflight: installing desktop-ui dependencies (bun install)…" >&2
+    (cd "$root/desktop-ui" && bun install)
+  fi
+}

--- a/scripts/tauri-build.sh
+++ b/scripts/tauri-build.sh
@@ -2,6 +2,8 @@
 # Release desktop bundle (.app install by default; DMG/open are opt-in).
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT/scripts/preflight-desktop.sh"
+preflight_desktop "$ROOT"
 export CARGO_TARGET_DIR="$ROOT/target/desktop"
 CONF="$ROOT/crates/er-desktop/tauri.conf.json"
 BUNDLE_ROOT="$CARGO_TARGET_DIR/release/bundle"

--- a/scripts/tauri-dev.sh
+++ b/scripts/tauri-dev.sh
@@ -3,6 +3,8 @@
 # Equivalent: ER_LOG=arena cargo tauri dev  (from crates/er-desktop)
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT/scripts/preflight-desktop.sh"
+preflight_desktop "$ROOT"
 LOGS=""
 ARGS=()
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## The Problem

Building the desktop app from a fresh clone dies with a cryptic `error: no such command: tauri` — the `tauri-dev.sh` / `tauri-build.sh` scripts run `cargo tauri`, but the README's build-from-source path never says to install the Tauri CLI, and the scripts don't check. It's not a lone wall either: even after installing `tauri-cli`, the next fresh clone hits missing `bun` and un-installed frontend deps (`beforeDevCommand` runs `bun run dev`, deps aren't vendored).

## How we fix

- New `scripts/preflight-desktop.sh`, sourced by both `tauri-dev.sh` and `tauri-build.sh`. Before either runs `cargo tauri`, it checks the fresh-clone prerequisites in dependency order and fails with an actionable message instead of an opaque one:
  - `cargo` (Rust) → rustup install command
  - `cargo tauri` (Tauri CLI) → `cargo install tauri-cli --locked`
  - `bun` → bun install command
  - `desktop-ui/node_modules` absent → auto-runs `bun install`
- README gains a **Prerequisites** line in the desktop build-from-source section (Rust 1.85+, `tauri-cli`, bun, Linux WebKitGTK deps).

## How to manually test

1. In a shell without the Tauri CLI (`cargo uninstall tauri-cli` or drop it from PATH), run `./scripts/tauri-dev.sh` → you get the `cargo install tauri-cli --locked` message and a clean exit 1, **not** `error: no such command: tauri`.
2. With `tauri-cli` + `bun` present, `./scripts/tauri-dev.sh` proceeds to `cargo tauri dev` as before (installs `desktop-ui` deps first if `node_modules` is missing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local desktop build/dev scripts and documentation; no runtime, auth, or review-engine behavior.
> 
> **Overview**
> Fresh clones building the desktop app no longer fail with opaque errors like **`no such command: tauri`** or missing frontend modules. **`scripts/preflight-desktop.sh`** is sourced by **`tauri-dev.sh`** and **`tauri-build.sh`** before **`cargo tauri`** runs.
> 
> Preflight checks **`cargo`**, the **Tauri CLI** (`cargo tauri`), and **`bun`**, and prints install commands when something is missing. If **`desktop-ui/node_modules`** is absent, it runs **`bun install`** automatically.
> 
> The README **desktop build-from-source** section now lists prerequisites (Rust 1.85+, `tauri-cli`, bun, Linux WebKitGTK). Unreleased release notes document the onboarding fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9854bcb15400e524eced3008a7439e2644e6556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->