### PR TITLE
Add just sign alias for signed desktop releases

### DIFF
--- a/.env.signing.example
+++ b/.env.signing.example
@@ -5,8 +5,8 @@
 #   # fill in the values below (never commit .env.signing)
 #
 # Build:
-#   ./scripts/tauri-sign-release.sh
-#   # or: cargo desktop-sign-release / just sign-release-desktop
+#   just sign
+#   # or: just sign-release-desktop / ./scripts/tauri-sign-release.sh
 #
 # Full guide: docs/DEVELOPMENT.md → "macOS signed release"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ scripts/aliases below, so either form works.
 | Install ER agent skill | `npx skills add VilfredSikker/easy-review -s er-review -g` — see `skills/er-review/` |
 | Desktop dev | `./scripts/tauri-dev.sh` |
 | Desktop release (local/ad-hoc) | `./scripts/tauri-build.sh` or `cargo desktop-release` |
-| Desktop signed release | `./scripts/tauri-sign-release.sh` or `cargo desktop-sign-release` — guide: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#macos-signed-release-developer-id--notarization) (`.env.signing`) |
+| Desktop signed release | `just sign` (or `just sign-release-desktop`) — guide: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#macos-signed-release-developer-id--notarization) (`.env.signing`) |
 | Frontend checks | `cd desktop-ui && bun run check && bun test src` |
 | Test full workspace | `cargo test --workspace` (slow — builds Tauri) |
 | Reclaim `target/` disk | `./scripts/cargo-gc.sh` (also runs from dev scripts) |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/VilfredSikker/easy-review.git
 cd easy-review
 ./scripts/tauri-dev.sh           # dev shell with hot reload
 ./scripts/tauri-build.sh         # local release bundle (ad-hoc sign)
-./scripts/tauri-sign-release.sh  # Developer ID + notarized .dmg (see docs/DEVELOPMENT.md)
+just sign                        # Developer ID + notarized .dmg (see docs/DEVELOPMENT.md)
 ```
 
 See [Installation](https://vilfredsikker.github.io/easy-review/guide/installation.html#desktop-app) for install details, and [DEVELOPMENT.md — macOS signed release](docs/DEVELOPMENT.md#macos-signed-release-developer-id--notarization) for signing/notarization.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -176,9 +176,9 @@ Use this when shipping a desktop `.dmg` others can open without right-click → 
 ### Build a signed + notarized release
 
 ```bash
-./scripts/tauri-sign-release.sh
-# or: cargo desktop-sign-release
+just sign
 # or: just sign-release-desktop
+# or: ./scripts/tauri-sign-release.sh / cargo desktop-sign-release
 ```
 
 Output:

--- a/justfile
+++ b/justfile
@@ -27,6 +27,7 @@ alias b := build
 alias t := test
 alias f := fmt
 alias l := lint
+alias sign := sign-release-desktop
 
 # Bare `just` lists every recipe. The `_` prefix hides this entry from the list itself.
 _default:
@@ -106,8 +107,7 @@ install-desktop *ARGS:
 release-desktop *ARGS:
     ER_SKIP_DMG=0 ./scripts/tauri-build.sh {{ARGS}}
 
-# Developer ID signed + notarized .app + .dmg (for GitHub Releases / direct download).
-# Credentials: repo-root `.env.signing` (see `.env.signing.example`) or APPLE_* env vars.
+# Developer ID signed + notarized .app/.dmg (needs `.env.signing`).
 [group('prod/desktop')]
 sign-release-desktop *ARGS:
     ./scripts/tauri-sign-release.sh {{ARGS}}


### PR DESCRIPTION
## Summary
- Add `just sign` as a short alias for `sign-release-desktop` (Developer ID + notarized `.app`/`.dmg`).
- Point README, AGENTS, DEVELOPMENT, and `.env.signing.example` at the alias.

## Test plan
- [ ] `just --list` shows `sign-release-desktop` with `[alias: sign]`
- [ ] `just sign --help` / dry-run path resolves to `./scripts/tauri-sign-release.sh` (or recipe runs when `.env.signing` is present)


Made with [Cursor](https://cursor.com)