### PR TITLE
Add uninstall for TUI, Desktop, and install.sh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,26 @@
+# Easy Review — unreleased (feat/first-time-experience)
+
+## In plain terms
+
+- **What this is.** Easy Review (`er`) is a fast diff reviewer for people who work with AI coding tools — a terminal UI and a desktop app that share the same review engine.
+- **What changed.** First-time setup and uninstall: welcome-screen access to settings/uninstall, and a shared uninstall path for TUI, Desktop, and `install.sh`.
+- **Why it matters.** New users can finish setup and leave cleanly without hunting for config or leftover review data.
+- **TL;DR.** `er uninstall`, Desktop Settings → Uninstall, and `install.sh --uninstall` remove config, managed data, cache, and apps.
+
+## Highlights
+
+- **Uninstall.** Shared `er-engine::uninstall` plans and removes config, managed review storage, legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal).
+- **TUI.** `er uninstall [--yes|--dry-run|--keep-data|--keep-config|--keep-apps]`.
+- **Desktop.** Settings → General → Uninstall (preview + type-to-confirm); welcome empty state can jump to uninstall.
+- **install.sh.** `install.sh --uninstall` mirrors the CLI options.
+
+## What's Changed
+
+### Features
+- Uninstall support: shared engine module, TUI subcommand, Desktop Settings/welcome UI, and `install.sh --uninstall`.
+
+---
+
 # Easy Review v0.4.5
 
 ## In plain terms

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,7 @@
 
 ## Highlights
 
-- **Uninstall.** Shared `er-engine::uninstall` plans and removes config, managed review storage, legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal with PID + start-time checks).
+- **Uninstall.** Shared `er-engine::uninstall` plans and removes config, managed review storage (including Tauri bundle data dirs), legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal with PID + start-time checks).
 - **TUI.** `er uninstall [--yes|--dry-run|--keep-data|--keep-config|--keep-apps]`.
 - **Desktop.** Settings → General → Uninstall (preview + type-to-confirm); welcome empty state can jump to uninstall.
 - **install.sh.** `install.sh --uninstall` forwards the same keep/dry-run/yes flags to `er uninstall`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,16 +3,16 @@
 ## In plain terms
 
 - **What this is.** Easy Review (`er`) is a fast diff reviewer for people who work with AI coding tools — a terminal UI and a desktop app that share the same review engine.
-- **What changed.** First-time setup and uninstall: welcome-screen access to settings/uninstall, and a shared uninstall path for TUI, Desktop, and `install.sh`.
-- **Why it matters.** New users can finish setup and leave cleanly without hunting for config or leftover review data.
+- **What changed.** Uninstall support across TUI, Desktop, and `install.sh`, with welcome/settings entry points.
+- **Why it matters.** You can leave cleanly without hunting for config or leftover review data.
 - **TL;DR.** `er uninstall`, Desktop Settings → Uninstall, and `install.sh --uninstall` remove config, managed data, cache, and apps.
 
 ## Highlights
 
-- **Uninstall.** Shared `er-engine::uninstall` plans and removes config, managed review storage, legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal).
+- **Uninstall.** Shared `er-engine::uninstall` plans and removes config, managed review storage, legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal with PID + start-time checks).
 - **TUI.** `er uninstall [--yes|--dry-run|--keep-data|--keep-config|--keep-apps]`.
 - **Desktop.** Settings → General → Uninstall (preview + type-to-confirm); welcome empty state can jump to uninstall.
-- **install.sh.** `install.sh --uninstall` mirrors the CLI options.
+- **install.sh.** `install.sh --uninstall` forwards the same keep/dry-run/yes flags to `er uninstall`.
 
 ## What's Changed
 

--- a/crates/er-desktop/permissions/app-commands.toml
+++ b/crates/er-desktop/permissions/app-commands.toml
@@ -68,6 +68,8 @@ commands.allow = [
   "get_config_hub",
   "apply_config_patch",
   "save_config_global_cmd",
+  "preview_uninstall",
+  "run_uninstall",
   "set_ai_effort",
   "promote_to_comment",
   "promote_to_note",

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -162,25 +162,6 @@ pub fn save_config_global_cmd(state: State<AppState>) -> Result<AppSnapshot, Str
 
 // ── Uninstall ───────────────────────────────────────────────────────────────
 
-#[derive(serde::Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct UninstallRequest {
-    #[serde(default = "default_true")]
-    pub remove_config: bool,
-    #[serde(default = "default_true")]
-    pub remove_data: bool,
-    #[serde(default = "default_true")]
-    pub remove_cache: bool,
-    #[serde(default = "default_true")]
-    pub remove_binaries: bool,
-    #[serde(default = "default_true")]
-    pub remove_desktop_app: bool,
-}
-
-fn default_true() -> bool {
-    true
-}
-
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UninstallTargetDto {
@@ -208,91 +189,89 @@ pub struct UninstallResult {
     pub should_quit: bool,
 }
 
-fn options_from_request(req: &UninstallRequest) -> er_engine::uninstall::UninstallOptions {
-    er_engine::uninstall::UninstallOptions {
-        remove_config: req.remove_config,
-        remove_data: req.remove_data,
-        remove_cache: req.remove_cache,
-        remove_binaries: req.remove_binaries,
-        remove_desktop_app: req.remove_desktop_app,
-    }
-}
-
 #[tauri::command]
-pub fn preview_uninstall(request: Option<UninstallRequest>) -> Result<UninstallPreview, String> {
-    let req = request.unwrap_or_default();
-    let opts = options_from_request(&req);
-    let targets = er_engine::uninstall::plan(&opts);
-    let existing_count = targets.iter().filter(|t| t.exists).count();
-    Ok(UninstallPreview {
-        targets: targets
-            .into_iter()
-            .map(|t| UninstallTargetDto {
-                kind: t.kind.label().to_string(),
-                path: t.path.display().to_string(),
-                exists: t.exists,
-                description: t.description(),
-            })
-            .collect(),
-        existing_count,
+pub async fn preview_uninstall(
+    request: Option<er_engine::uninstall::UninstallOptions>,
+) -> Result<UninstallPreview, String> {
+    crate::commands::run_blocking(move || {
+        let opts = request.unwrap_or_default();
+        let targets = er_engine::uninstall::plan(&opts);
+        let existing_count = targets.iter().filter(|t| t.exists).count();
+        Ok(UninstallPreview {
+            targets: targets
+                .into_iter()
+                .map(|t| UninstallTargetDto {
+                    kind: t.kind.label().to_string(),
+                    path: t.path.display().to_string(),
+                    exists: t.exists,
+                    description: t.description(),
+                })
+                .collect(),
+            existing_count,
+        })
     })
+    .await
 }
 
 #[tauri::command]
-pub fn run_uninstall(
+pub async fn run_uninstall(
     app_handle: tauri::AppHandle,
-    request: Option<UninstallRequest>,
+    request: Option<er_engine::uninstall::UninstallOptions>,
 ) -> Result<UninstallResult, String> {
-    let req = request.unwrap_or_default();
-    let opts = options_from_request(&req);
-    let existing = er_engine::uninstall::existing_targets(&opts);
-    if existing.is_empty() {
-        return Ok(UninstallResult {
-            removed: vec![],
-            deferred: vec![],
-            missing: vec![],
-            failed: vec![],
-            should_quit: false,
-        });
-    }
+    let result = crate::commands::run_blocking(move || {
+        let opts = request.unwrap_or_default();
+        let existing = er_engine::uninstall::existing_targets(&opts);
+        if existing.is_empty() {
+            return Ok(UninstallResult {
+                removed: vec![],
+                deferred: vec![],
+                missing: vec![],
+                failed: vec![],
+                should_quit: false,
+            });
+        }
 
-    let report = er_engine::uninstall::execute(&existing);
-    if !report.deferred.is_empty() {
-        er_engine::uninstall::schedule_deferred_removal(&report.deferred)
-            .map_err(|e| format!("Could not schedule removal of in-use paths: {e}"))?;
-    }
+        let report = er_engine::uninstall::execute(&existing);
+        if !report.deferred.is_empty() {
+            if let Err(e) = er_engine::uninstall::schedule_deferred_removal(&report.deferred) {
+                let msg = format!("Could not schedule removal of in-use paths: {e}");
+                log::error!("run_uninstall: {msg}");
+                return Err(msg);
+            }
+        }
 
-    let result = UninstallResult {
-        removed: report
-            .removed
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect(),
-        deferred: report
-            .deferred
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect(),
-        missing: report
-            .missing
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect(),
-        failed: report
-            .failed
-            .iter()
-            .map(|(p, e)| format!("{}: {e}", p.display()))
-            .collect(),
-        // Must quit whenever deferred deletes were scheduled — otherwise the
-        // waiter never sees this PID exit.
-        should_quit: report.is_success() || !report.deferred.is_empty(),
-    };
+        Ok(UninstallResult {
+            removed: report
+                .removed
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            deferred: report
+                .deferred
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            missing: report
+                .missing
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            failed: report
+                .failed
+                .iter()
+                .map(|(p, e)| format!("{}: {e}", p.display()))
+                .collect(),
+            // Must quit whenever deferred deletes were scheduled — otherwise the
+            // waiter never sees this PID exit.
+            should_quit: report.is_success() || !report.deferred.is_empty(),
+        })
+    })
+    .await?;
 
-    if !report.is_success() && !result.should_quit {
-        return Err(format!(
-            "Uninstall failed:\n{}",
-            result.failed.join("\n")
-        ));
+    if !result.failed.is_empty() && !result.should_quit {
+        let msg = format!("Uninstall failed:\n{}", result.failed.join("\n"));
+        log::error!("run_uninstall: {msg}");
+        return Err(msg);
     }
 
     if result.should_quit {
@@ -303,11 +282,13 @@ pub fn run_uninstall(
         });
     }
 
-    if !report.is_success() {
-        return Err(format!(
+    if !result.failed.is_empty() {
+        let msg = format!(
             "Uninstall partially failed (quitting so in-use paths can be removed):\n{}",
             result.failed.join("\n")
-        ));
+        );
+        log::error!("run_uninstall: {msg}");
+        return Err(msg);
     }
 
     Ok(result)

--- a/crates/er-desktop/src/config_commands.rs
+++ b/crates/er-desktop/src/config_commands.rs
@@ -159,3 +159,156 @@ pub fn save_config_global_cmd(state: State<AppState>) -> Result<AppSnapshot, Str
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     Ok(snap_from(&app, &state))
 }
+
+// ── Uninstall ───────────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallRequest {
+    #[serde(default = "default_true")]
+    pub remove_config: bool,
+    #[serde(default = "default_true")]
+    pub remove_data: bool,
+    #[serde(default = "default_true")]
+    pub remove_cache: bool,
+    #[serde(default = "default_true")]
+    pub remove_binaries: bool,
+    #[serde(default = "default_true")]
+    pub remove_desktop_app: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallTargetDto {
+    pub kind: String,
+    pub path: String,
+    pub exists: bool,
+    pub description: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallPreview {
+    pub targets: Vec<UninstallTargetDto>,
+    pub existing_count: usize,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallResult {
+    pub removed: Vec<String>,
+    pub deferred: Vec<String>,
+    pub missing: Vec<String>,
+    pub failed: Vec<String>,
+    /// Frontend should quit the app after a successful uninstall.
+    pub should_quit: bool,
+}
+
+fn options_from_request(req: &UninstallRequest) -> er_engine::uninstall::UninstallOptions {
+    er_engine::uninstall::UninstallOptions {
+        remove_config: req.remove_config,
+        remove_data: req.remove_data,
+        remove_cache: req.remove_cache,
+        remove_binaries: req.remove_binaries,
+        remove_desktop_app: req.remove_desktop_app,
+    }
+}
+
+#[tauri::command]
+pub fn preview_uninstall(request: Option<UninstallRequest>) -> Result<UninstallPreview, String> {
+    let req = request.unwrap_or_default();
+    let opts = options_from_request(&req);
+    let targets = er_engine::uninstall::plan(&opts);
+    let existing_count = targets.iter().filter(|t| t.exists).count();
+    Ok(UninstallPreview {
+        targets: targets
+            .into_iter()
+            .map(|t| UninstallTargetDto {
+                kind: t.kind.label().to_string(),
+                path: t.path.display().to_string(),
+                exists: t.exists,
+                description: t.description(),
+            })
+            .collect(),
+        existing_count,
+    })
+}
+
+#[tauri::command]
+pub fn run_uninstall(
+    app_handle: tauri::AppHandle,
+    request: Option<UninstallRequest>,
+) -> Result<UninstallResult, String> {
+    let req = request.unwrap_or_default();
+    let opts = options_from_request(&req);
+    let existing = er_engine::uninstall::existing_targets(&opts);
+    if existing.is_empty() {
+        return Ok(UninstallResult {
+            removed: vec![],
+            deferred: vec![],
+            missing: vec![],
+            failed: vec![],
+            should_quit: false,
+        });
+    }
+
+    let report = er_engine::uninstall::execute(&existing);
+    if !report.deferred.is_empty() {
+        er_engine::uninstall::schedule_deferred_removal(&report.deferred)
+            .map_err(|e| format!("Could not schedule removal of in-use paths: {e}"))?;
+    }
+
+    let result = UninstallResult {
+        removed: report
+            .removed
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect(),
+        deferred: report
+            .deferred
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect(),
+        missing: report
+            .missing
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect(),
+        failed: report
+            .failed
+            .iter()
+            .map(|(p, e)| format!("{}: {e}", p.display()))
+            .collect(),
+        // Must quit whenever deferred deletes were scheduled — otherwise the
+        // waiter never sees this PID exit.
+        should_quit: report.is_success() || !report.deferred.is_empty(),
+    };
+
+    if !report.is_success() && !result.should_quit {
+        return Err(format!(
+            "Uninstall failed:\n{}",
+            result.failed.join("\n")
+        ));
+    }
+
+    if result.should_quit {
+        let handle = app_handle.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(400));
+            handle.exit(0);
+        });
+    }
+
+    if !report.is_success() {
+        return Err(format!(
+            "Uninstall partially failed (quitting so in-use paths can be removed):\n{}",
+            result.failed.join("\n")
+        ));
+    }
+
+    Ok(result)
+}

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -1862,6 +1862,8 @@ fn main() {
             config_commands::get_config_hub,
             config_commands::apply_config_patch,
             config_commands::save_config_global_cmd,
+            config_commands::preview_uninstall,
+            config_commands::run_uninstall,
             commands::set_ai_effort,
             commands::promote_to_comment,
             commands::promote_to_note,

--- a/crates/er-engine/src/CLAUDE.md
+++ b/crates/er-engine/src/CLAUDE.md
@@ -17,6 +17,7 @@ to the consuming crates.
 | `sync.rs` | Pure sync core (no `App` dependency): comment merge + anchor resolution, remote diff fetch | — |
 | `config.rs` | `ErConfig`, feature flags, settings items, TOML load/save | — |
 | `storage.rs` | Managed review storage paths (repo/branch/view-bucket slugs) | — |
+| `uninstall.rs` | Plan/execute uninstall of config, managed data, cache, binaries, apps | — |
 | `highlight.rs` | Syntect highlighter core (TUI wraps this; desktop uses Shiki) | — |
 | `agent_slots.rs` | Process-wide counting semaphore for agent subprocess spawns | — |
 | `dev_log.rs` | Opt-in debug log groups (`ER_LOG`) | — |

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -909,19 +909,31 @@ pub fn split_shell_args(s: &str) -> Vec<String> {
     args
 }
 
+/// Global config directory (`$XDG_CONFIG_HOME/er`, else `~/.config/er`, else
+/// the platform config dir). Shared by load/save and uninstall planning.
+pub fn global_config_dir() -> Option<std::path::PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(std::path::PathBuf::from(xdg).join("er"));
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return Some(std::path::PathBuf::from(home).join(".config").join("er"));
+        }
+    }
+    dirs::config_dir().map(|d| d.join("er"))
+}
+
 /// Load the global config (~/.config/er/config.toml).
 pub fn load_global_config() -> ErConfig {
-    let global_path = std::env::var("XDG_CONFIG_HOME")
-        .ok()
-        .map(|xdg| format!("{xdg}/er/config.toml"))
+    let global_path = global_config_dir()
+        .map(|d| d.join("config.toml"))
+        .filter(|p| p.exists())
         .or_else(|| {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| format!("{h}/.config/er/config.toml"))
-        })
-        .filter(|p| std::path::Path::new(p).exists())
-        .or_else(|| {
-            dirs::config_dir().map(|d| d.join("er/config.toml").to_string_lossy().to_string())
+            dirs::config_dir()
+                .map(|d| d.join("er").join("config.toml"))
+                .filter(|p| p.exists())
         });
 
     let global_table = global_path
@@ -938,17 +950,8 @@ pub fn load_global_config() -> ErConfig {
 
 /// Save config to the global config dir (~/.config/er/config.toml).
 pub fn save_config(config: &ErConfig) -> Result<()> {
-    let dir = std::env::var("XDG_CONFIG_HOME")
-        .map(|xdg| std::path::PathBuf::from(format!("{xdg}/er")))
-        .or_else(|_| {
-            std::env::var("HOME").map(|h| std::path::PathBuf::from(format!("{h}/.config/er")))
-        })
-        .or_else(|_| {
-            dirs::config_dir()
-                .map(|d| d.join("er"))
-                .ok_or(std::env::VarError::NotPresent)
-        })
-        .map_err(|_| anyhow::anyhow!("Could not determine config directory"))?;
+    let dir = global_config_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine config directory"))?;
     std::fs::create_dir_all(&dir)?;
     let path = dir.join("config.toml");
     let tmp_path = dir.join("config.toml.tmp");

--- a/crates/er-engine/src/lib.rs
+++ b/crates/er-engine/src/lib.rs
@@ -26,6 +26,7 @@ pub mod sidecar_summary;
 pub mod sidecar_upload;
 pub mod storage;
 pub mod sync;
+pub mod uninstall;
 #[cfg(feature = "watch")]
 pub mod watch;
 

--- a/crates/er-engine/src/uninstall.rs
+++ b/crates/er-engine/src/uninstall.rs
@@ -122,11 +122,6 @@ pub fn config_dirs() -> Vec<PathBuf> {
     out
 }
 
-/// Managed review storage root (`…/easy-review`).
-pub fn data_dir() -> PathBuf {
-    storage::storage_root()
-}
-
 /// Extra app-data dirs Tauri may create under the bundle identifier.
 pub fn bundle_data_dirs() -> Vec<PathBuf> {
     let mut out = Vec::new();
@@ -163,7 +158,7 @@ pub fn plan(opts: &UninstallOptions) -> Vec<UninstallTarget> {
         }
     }
     if opts.remove_data {
-        push_unique(&mut targets, UninstallKind::Data, data_dir());
+        push_unique(&mut targets, UninstallKind::Data, storage::storage_root());
         for dir in bundle_data_dirs() {
             push_unique(&mut targets, UninstallKind::Data, dir);
         }

--- a/crates/er-engine/src/uninstall.rs
+++ b/crates/er-engine/src/uninstall.rs
@@ -1,0 +1,574 @@
+//! Uninstall Easy Review user data and (optionally) installed apps.
+//!
+//! Shared by the TUI (`er uninstall`) and Desktop settings. Removes config,
+//! managed review storage, legacy cache, and discovered binaries / app bundles.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::storage;
+
+/// What kind of artifact an uninstall target represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UninstallKind {
+    Config,
+    Data,
+    Cache,
+    Binary,
+    DesktopApp,
+}
+
+impl UninstallKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Config => "Config",
+            Self::Data => "Review data",
+            Self::Cache => "Legacy cache",
+            Self::Binary => "Terminal binary",
+            Self::DesktopApp => "Desktop app",
+        }
+    }
+}
+
+/// One path that uninstall may remove.
+#[derive(Debug, Clone)]
+pub struct UninstallTarget {
+    pub kind: UninstallKind,
+    pub path: PathBuf,
+    pub exists: bool,
+}
+
+impl UninstallTarget {
+    pub fn description(&self) -> String {
+        format!("{} — {}", self.kind.label(), self.path.display())
+    }
+}
+
+/// Options controlling which uninstall categories are included.
+#[derive(Debug, Clone)]
+pub struct UninstallOptions {
+    pub remove_config: bool,
+    pub remove_data: bool,
+    pub remove_cache: bool,
+    pub remove_binaries: bool,
+    pub remove_desktop_app: bool,
+}
+
+impl Default for UninstallOptions {
+    fn default() -> Self {
+        Self::full()
+    }
+}
+
+impl UninstallOptions {
+    /// Remove config, review data, cache, binaries, and desktop app when found.
+    pub fn full() -> Self {
+        Self {
+            remove_config: true,
+            remove_data: true,
+            remove_cache: true,
+            remove_binaries: true,
+            remove_desktop_app: true,
+        }
+    }
+}
+
+/// Result of executing an uninstall plan.
+#[derive(Debug, Clone, Default)]
+pub struct UninstallReport {
+    pub removed: Vec<PathBuf>,
+    pub failed: Vec<(PathBuf, String)>,
+    pub deferred: Vec<PathBuf>,
+    pub missing: Vec<PathBuf>,
+}
+
+impl UninstallReport {
+    pub fn is_success(&self) -> bool {
+        self.failed.is_empty()
+    }
+
+    pub fn summary_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for p in &self.removed {
+            lines.push(format!("removed  {}", p.display()));
+        }
+        for p in &self.deferred {
+            lines.push(format!("deferred {}", p.display()));
+        }
+        for p in &self.missing {
+            lines.push(format!("missing  {}", p.display()));
+        }
+        for (p, err) in &self.failed {
+            lines.push(format!("failed   {}: {err}", p.display()));
+        }
+        lines
+    }
+}
+
+/// Global config directory (`~/.config/er` or platform equivalent).
+pub fn config_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("er"));
+        }
+    }
+    dirs::config_dir().map(|d| d.join("er"))
+}
+
+/// All known config directory locations (platform dir + legacy `~/.config/er`).
+pub fn config_dirs() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(dir) = config_dir() {
+        out.push(dir);
+    }
+    if let Some(home) = dirs::home_dir() {
+        let legacy = home.join(".config").join("er");
+        if !out.iter().any(|d| paths_same(d, &legacy)) {
+            out.push(legacy);
+        }
+    }
+    out
+}
+
+/// Managed review storage root (`…/easy-review`).
+pub fn data_dir() -> PathBuf {
+    storage::storage_root()
+}
+
+/// Extra app-data dirs Tauri may create under the bundle identifier.
+pub fn bundle_data_dirs() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(data) = dirs::data_dir() {
+        out.push(data.join("com.reshape.easy-review"));
+        out.push(data.join("Easy Review"));
+    }
+    if let Some(cache) = dirs::cache_dir() {
+        out.push(cache.join("com.reshape.easy-review"));
+        out.push(cache.join("Easy Review"));
+        out.push(cache.join("er"));
+    }
+    out
+}
+
+/// Legacy cache directory (`~/.cache/er`).
+pub fn cache_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("er"));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".cache").join("er"))
+}
+
+/// Build the uninstall plan for the given options (lists expected roots even when
+/// missing so dry-run / UI can show the full picture).
+pub fn plan(opts: &UninstallOptions) -> Vec<UninstallTarget> {
+    let mut targets = Vec::new();
+
+    if opts.remove_config {
+        for dir in config_dirs() {
+            push_unique(&mut targets, UninstallKind::Config, dir);
+        }
+    }
+    if opts.remove_data {
+        push_unique(&mut targets, UninstallKind::Data, data_dir());
+        for dir in bundle_data_dirs() {
+            push_unique(&mut targets, UninstallKind::Data, dir);
+        }
+    }
+    if opts.remove_cache {
+        if let Some(dir) = cache_dir() {
+            push_unique(&mut targets, UninstallKind::Cache, dir);
+        }
+    }
+    if opts.remove_binaries {
+        for path in discover_binaries() {
+            push_unique(&mut targets, UninstallKind::Binary, path);
+        }
+    }
+    if opts.remove_desktop_app {
+        for path in discover_desktop_apps() {
+            push_unique(&mut targets, UninstallKind::DesktopApp, path);
+        }
+    }
+
+    targets
+}
+
+/// Targets that currently exist on disk.
+pub fn existing_targets(opts: &UninstallOptions) -> Vec<UninstallTarget> {
+    plan(opts)
+        .into_iter()
+        .filter(|t| t.exists || t.path.exists())
+        .map(|mut t| {
+            t.exists = true;
+            t
+        })
+        .collect()
+}
+
+fn push_unique(targets: &mut Vec<UninstallTarget>, kind: UninstallKind, path: PathBuf) {
+    if targets.iter().any(|t| paths_same(&t.path, &path)) {
+        return;
+    }
+    let exists = path_exists(&path);
+    targets.push(UninstallTarget { kind, path, exists });
+}
+
+fn path_exists(path: &Path) -> bool {
+    // Use symlink_metadata so a dangling symlink still counts as present.
+    std::fs::symlink_metadata(path).is_ok()
+}
+
+/// Discover installed `er` binaries in common locations (+ current exe when installed).
+pub fn discover_binaries() -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut candidates = Vec::new();
+
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".local/bin/er"));
+        candidates.push(home.join(".cargo/bin/er"));
+        #[cfg(windows)]
+        {
+            candidates.push(home.join(".local/bin/er.exe"));
+            candidates.push(home.join(".cargo/bin/er.exe"));
+        }
+    }
+    candidates.push(PathBuf::from("/usr/local/bin/er"));
+    candidates.push(PathBuf::from("/opt/homebrew/bin/er"));
+
+    if let Ok(exe) = std::env::current_exe() {
+        if looks_like_product_binary(&exe) && is_install_location(&exe) {
+            candidates.push(exe);
+        }
+    }
+
+    for path in candidates {
+        if path_exists(&path) && !found.iter().any(|p: &PathBuf| paths_same(p, &path)) {
+            // Prefer the path as given for removal; canonicalize only for dedupe key.
+            found.push(path);
+        }
+    }
+    found
+}
+
+fn looks_like_product_binary(path: &Path) -> bool {
+    let name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    // Installed product binary is always `er` (see er-tui [[bin]] name).
+    name == "er" || name == "er.exe"
+}
+
+/// True for typical install dirs — not cargo `target/` build outputs.
+fn is_install_location(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    if s.contains("/target/") || s.contains("\\target\\") {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let parent = parent.to_string_lossy();
+    parent.ends_with("/.local/bin")
+        || parent.ends_with("/.cargo/bin")
+        || parent.ends_with("/usr/local/bin")
+        || parent.ends_with("/opt/homebrew/bin")
+        || parent.ends_with("\\.local\\bin")
+        || parent.ends_with("\\.cargo\\bin")
+}
+
+/// Discover desktop app bundles / install directories.
+pub fn discover_desktop_apps() -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut candidates = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        candidates.push(PathBuf::from("/Applications/Easy Review.app"));
+        if let Some(home) = dirs::home_dir() {
+            candidates.push(home.join("Applications/Easy Review.app"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(home) = dirs::home_dir() {
+            candidates.push(home.join(".local/share/applications/easy-review.desktop"));
+            candidates.push(home.join(".local/bin/easy-review"));
+        }
+        candidates.push(PathBuf::from("/usr/local/bin/easy-review"));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(local) = dirs::data_local_dir() {
+            candidates.push(local.join("Easy Review"));
+            candidates.push(local.join("Programs").join("Easy Review"));
+        }
+    }
+
+    // If we're running inside a .app bundle outside cargo target/, include it.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(app) = enclosing_app_bundle(&exe) {
+            let app_s = app.to_string_lossy();
+            if !app_s.contains("/target/") && !app_s.contains("\\target\\") {
+                candidates.push(app);
+            }
+        }
+    }
+
+    for path in candidates {
+        if path_exists(&path) && !found.iter().any(|p: &PathBuf| paths_same(p, &path)) {
+            found.push(path);
+        }
+    }
+    found
+}
+
+fn enclosing_app_bundle(exe: &Path) -> Option<PathBuf> {
+    let mut cur = exe.parent()?;
+    for _ in 0..8 {
+        if cur
+            .file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|n| n.ends_with(".app"))
+        {
+            return Some(cur.to_path_buf());
+        }
+        cur = cur.parent()?;
+    }
+    None
+}
+
+fn canonicalize_best_effort(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn paths_same(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Remove the given targets. Paths that are the currently running executable or its
+/// enclosing `.app` are scheduled for deferred deletion after this process exits.
+pub fn execute(targets: &[UninstallTarget]) -> UninstallReport {
+    let mut report = UninstallReport::default();
+    let mut deferred = Vec::new();
+
+    let current_exe = std::env::current_exe().ok().map(|p| canonicalize_best_effort(&p));
+    let current_app = current_exe
+        .as_ref()
+        .and_then(|p| enclosing_app_bundle(p).map(|a| canonicalize_best_effort(&a)));
+
+    for target in targets {
+        if !path_exists(&target.path) {
+            report.missing.push(target.path.clone());
+            continue;
+        }
+
+        let path = &target.path;
+        let is_self_binary = current_exe
+            .as_ref()
+            .is_some_and(|exe| paths_same(exe, path));
+        let is_self_app = current_app
+            .as_ref()
+            .is_some_and(|app| paths_same(app, path));
+
+        if is_self_binary || is_self_app {
+            deferred.push(path.clone());
+            continue;
+        }
+
+        match remove_path(path) {
+            Ok(()) => report.removed.push(path.clone()),
+            Err(e) => report.failed.push((path.clone(), e.to_string())),
+        }
+    }
+
+    if !deferred.is_empty() {
+        match schedule_deferred_removal(&deferred) {
+            Ok(()) => report.deferred.extend(deferred),
+            Err(e) => {
+                for path in deferred {
+                    report
+                        .failed
+                        .push((path, format!("could not schedule removal: {e}")));
+                }
+            }
+        }
+    }
+
+    report
+}
+
+/// Remove a file, symlink, or directory without following directory symlinks.
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+
+    if meta.file_type().is_symlink() || meta.file_type().is_file() {
+        std::fs::remove_file(path)
+    } else if meta.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        // Fallback for unusual file types (fifo/socket): try unlink.
+        std::fs::remove_file(path)
+    }
+}
+
+/// Schedule path removals after this process exits (PID wait), so a quick relaunch
+/// does not race a fixed-delay `rm`.
+pub fn schedule_deferred_removal(paths: &[PathBuf]) -> std::io::Result<()> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+
+    let pid = std::process::id();
+
+    #[cfg(unix)]
+    {
+        let quoted: Vec<String> = paths
+            .iter()
+            .map(|p| shell_single_quote(&p.to_string_lossy()))
+            .collect();
+        let joined = quoted.join(" ");
+        // Wait until our PID is gone (or 60s), then remove. Avoids deleting a
+        // freshly relaunched app that reused the same bundle path.
+        let script = format!(
+            "pid={pid}; i=0; while kill -0 \"$pid\" 2>/dev/null; do \
+               i=$((i+1)); [ \"$i\" -gt 120 ] && break; sleep 0.5; \
+             done; rm -rf {joined}"
+        );
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("( {script} ) >/dev/null 2>&1 &"))
+            .spawn()?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        let list: Vec<String> = paths
+            .iter()
+            .map(|p| format!("\"{}\"", p.to_string_lossy().replace('"', "")))
+            .collect();
+        let joined = list.join(",");
+        let script = format!(
+            "$pid={pid}; for ($i=0; $i -lt 120; $i++) {{ \
+               try {{ Get-Process -Id $pid -ErrorAction Stop | Out-Null; Start-Sleep -Milliseconds 500 }} \
+               catch {{ break }} \
+             }}; @({joined}) | ForEach-Object {{ if (Test-Path $_) {{ Remove-Item -LiteralPath $_ -Recurse -Force }} }}"
+        );
+        Command::new("powershell")
+            .args(["-NoProfile", "-WindowStyle", "Hidden", "-Command", &script])
+            .spawn()?;
+        Ok(())
+    }
+}
+
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn execute_removes_directories() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("easy-review-data");
+        fs::create_dir_all(dir.join("repos")).unwrap();
+        fs::write(dir.join("repos/marker"), "x").unwrap();
+
+        let targets = vec![UninstallTarget {
+            kind: UninstallKind::Data,
+            path: dir.clone(),
+            exists: true,
+        }];
+        let report = execute(&targets);
+        assert!(report.failed.is_empty(), "{:?}", report.failed);
+        assert!(report.removed.iter().any(|p| p == &dir));
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn execute_reports_missing() {
+        let path = PathBuf::from("/tmp/er-uninstall-definitely-missing-xyz");
+        let targets = vec![UninstallTarget {
+            kind: UninstallKind::Cache,
+            path: path.clone(),
+            exists: false,
+        }];
+        let report = execute(&targets);
+        assert!(report.missing.iter().any(|p| p == &path));
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn remove_path_unlinks_symlink_not_target() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("real-dir");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("keep.txt"), "safe").unwrap();
+        let link = tmp.path().join("link-dir");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            remove_path(&link).unwrap();
+            assert!(!link.exists());
+            assert!(target.join("keep.txt").exists(), "symlink target must survive");
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (target, link);
+        }
+    }
+
+    #[test]
+    fn shell_quote_escapes_apostrophe() {
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn product_binary_name_is_er_only() {
+        assert!(looks_like_product_binary(Path::new("/usr/local/bin/er")));
+        assert!(!looks_like_product_binary(Path::new("/usr/local/bin/er-tui")));
+        // Name check alone accepts cargo outputs; install_location gates those out.
+        assert!(looks_like_product_binary(Path::new("/tmp/target/debug/er")));
+        assert!(!is_install_location(Path::new("/tmp/target/debug/er")));
+    }
+
+    #[test]
+    fn install_location_rejects_cargo_target() {
+        assert!(!is_install_location(Path::new(
+            "/Users/me/proj/target/tui/debug/er"
+        )));
+        assert!(is_install_location(Path::new(
+            "/Users/me/.local/bin/er"
+        )));
+    }
+
+    #[test]
+    fn full_options_default_all_on() {
+        let opts = UninstallOptions::default();
+        assert!(opts.remove_config);
+        assert!(opts.remove_data);
+        assert!(opts.remove_cache);
+        assert!(opts.remove_binaries);
+        assert!(opts.remove_desktop_app);
+    }
+}

--- a/crates/er-engine/src/uninstall.rs
+++ b/crates/er-engine/src/uninstall.rs
@@ -350,7 +350,9 @@ fn paths_same(a: &Path, b: &Path) -> bool {
 pub fn execute(targets: &[UninstallTarget]) -> UninstallReport {
     let mut report = UninstallReport::default();
 
-    let current_exe = std::env::current_exe().ok().map(|p| canonicalize_best_effort(&p));
+    let current_exe = std::env::current_exe()
+        .ok()
+        .map(|p| canonicalize_best_effort(&p));
     let current_app = current_exe
         .as_ref()
         .and_then(|p| enclosing_app_bundle(p).map(|a| canonicalize_best_effort(&a)));
@@ -543,7 +545,10 @@ mod tests {
             std::os::unix::fs::symlink(&target, &link).unwrap();
             remove_path(&link).unwrap();
             assert!(!link.exists());
-            assert!(target.join("keep.txt").exists(), "symlink target must survive");
+            assert!(
+                target.join("keep.txt").exists(),
+                "symlink target must survive"
+            );
         }
         #[cfg(not(unix))]
         {
@@ -559,7 +564,9 @@ mod tests {
     #[test]
     fn product_binary_name_is_er_only() {
         assert!(looks_like_product_binary(Path::new("/usr/local/bin/er")));
-        assert!(!looks_like_product_binary(Path::new("/usr/local/bin/er-tui")));
+        assert!(!looks_like_product_binary(Path::new(
+            "/usr/local/bin/er-tui"
+        )));
         // Name check alone accepts cargo outputs; install_location gates those out.
         assert!(looks_like_product_binary(Path::new("/tmp/target/debug/er")));
         assert!(!is_install_location(Path::new("/tmp/target/debug/er")));
@@ -570,9 +577,7 @@ mod tests {
         assert!(!is_install_location(Path::new(
             "/Users/me/proj/target/tui/debug/er"
         )));
-        assert!(is_install_location(Path::new(
-            "/Users/me/.local/bin/er"
-        )));
+        assert!(is_install_location(Path::new("/Users/me/.local/bin/er")));
     }
 
     #[test]

--- a/crates/er-engine/src/uninstall.rs
+++ b/crates/er-engine/src/uninstall.rs
@@ -45,7 +45,8 @@ impl UninstallTarget {
 }
 
 /// Options controlling which uninstall categories are included.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct UninstallOptions {
     pub remove_config: bool,
     pub remove_data: bool,
@@ -105,26 +106,17 @@ impl UninstallReport {
     }
 }
 
-/// Global config directory (`~/.config/er` or platform equivalent).
-pub fn config_dir() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        if !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join("er"));
-        }
-    }
-    dirs::config_dir().map(|d| d.join("er"))
-}
-
-/// All known config directory locations (platform dir + legacy `~/.config/er`).
+/// All known config directory locations (shared resolver + platform config dir).
 pub fn config_dirs() -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Some(dir) = config_dir() {
+    if let Some(dir) = crate::config::global_config_dir() {
         out.push(dir);
     }
-    if let Some(home) = dirs::home_dir() {
-        let legacy = home.join(".config").join("er");
-        if !out.iter().any(|d| paths_same(d, &legacy)) {
-            out.push(legacy);
+    // Also cover the platform config dir when it differs from XDG/HOME resolution
+    // (e.g. macOS `~/Library/Application Support/er`).
+    if let Some(platform) = dirs::config_dir().map(|d| d.join("er")) {
+        if !out.iter().any(|d| paths_same(d, &platform)) {
+            out.push(platform);
         }
     }
     out
@@ -358,10 +350,10 @@ fn paths_same(a: &Path, b: &Path) -> bool {
 }
 
 /// Remove the given targets. Paths that are the currently running executable or its
-/// enclosing `.app` are scheduled for deferred deletion after this process exits.
+/// enclosing `.app` are returned in [`UninstallReport::deferred`] — callers must
+/// [`schedule_deferred_removal`] then exit so the waiter can finish.
 pub fn execute(targets: &[UninstallTarget]) -> UninstallReport {
     let mut report = UninstallReport::default();
-    let mut deferred = Vec::new();
 
     let current_exe = std::env::current_exe().ok().map(|p| canonicalize_best_effort(&p));
     let current_app = current_exe
@@ -383,26 +375,13 @@ pub fn execute(targets: &[UninstallTarget]) -> UninstallReport {
             .is_some_and(|app| paths_same(app, path));
 
         if is_self_binary || is_self_app {
-            deferred.push(path.clone());
+            report.deferred.push(path.clone());
             continue;
         }
 
         match remove_path(path) {
             Ok(()) => report.removed.push(path.clone()),
             Err(e) => report.failed.push((path.clone(), e.to_string())),
-        }
-    }
-
-    if !deferred.is_empty() {
-        match schedule_deferred_removal(&deferred) {
-            Ok(()) => report.deferred.extend(deferred),
-            Err(e) => {
-                for path in deferred {
-                    report
-                        .failed
-                        .push((path, format!("could not schedule removal: {e}")));
-                }
-            }
         }
     }
 
@@ -427,8 +406,12 @@ fn remove_path(path: &Path) -> std::io::Result<()> {
     }
 }
 
-/// Schedule path removals after this process exits (PID wait), so a quick relaunch
-/// does not race a fixed-delay `rm`.
+/// Schedule path removals after this process exits.
+///
+/// Waits until our PID is gone **or** the process start-time no longer matches
+/// the token captured at schedule time (PID reuse), then `rm -rf`. A timeout
+/// without either condition skips deletion so an unrelated process that reused
+/// the PID is never waited out into a blind delete.
 pub fn schedule_deferred_removal(paths: &[PathBuf]) -> std::io::Result<()> {
     if paths.is_empty() {
         return Ok(());
@@ -438,17 +421,26 @@ pub fn schedule_deferred_removal(paths: &[PathBuf]) -> std::io::Result<()> {
 
     #[cfg(unix)]
     {
+        let start = process_start_token_unix(pid).unwrap_or_default();
+        let start_q = shell_single_quote(&start);
         let quoted: Vec<String> = paths
             .iter()
             .map(|p| shell_single_quote(&p.to_string_lossy()))
             .collect();
         let joined = quoted.join(" ");
-        // Wait until our PID is gone (or 60s), then remove. Avoids deleting a
-        // freshly relaunched app that reused the same bundle path.
+        // Exit the wait loop when: PID gone, start-time mismatch (reuse), or
+        // timeout. Only delete when PID is gone or start-time mismatched —
+        // never after a blind timeout while the original-looking PID still runs.
         let script = format!(
-            "pid={pid}; i=0; while kill -0 \"$pid\" 2>/dev/null; do \
+            "pid={pid}; start={start_q}; i=0; do_rm=0; \
+             while kill -0 \"$pid\" 2>/dev/null; do \
+               cur=$(ps -p \"$pid\" -o lstart= 2>/dev/null || true); \
+               if [ -n \"$start\" ] && [ \"$cur\" != \"$start\" ]; then do_rm=1; break; fi; \
                i=$((i+1)); [ \"$i\" -gt 120 ] && break; sleep 0.5; \
-             done; rm -rf {joined}"
+             done; \
+             if [ \"$do_rm\" -eq 1 ] || ! kill -0 \"$pid\" 2>/dev/null; then \
+               rm -rf {joined}; \
+             fi"
         );
         Command::new("sh")
             .arg("-c")
@@ -465,15 +457,41 @@ pub fn schedule_deferred_removal(paths: &[PathBuf]) -> std::io::Result<()> {
             .collect();
         let joined = list.join(",");
         let script = format!(
-            "$pid={pid}; for ($i=0; $i -lt 120; $i++) {{ \
-               try {{ Get-Process -Id $pid -ErrorAction Stop | Out-Null; Start-Sleep -Milliseconds 500 }} \
-               catch {{ break }} \
-             }}; @({joined}) | ForEach-Object {{ if (Test-Path $_) {{ Remove-Item -LiteralPath $_ -Recurse -Force }} }}"
+            "$pid={pid}; \
+             $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue; \
+             $start = if ($proc) {{ $proc.StartTime }} else {{ $null }}; \
+             $doRm = $false; \
+             for ($i=0; $i -lt 120; $i++) {{ \
+               $p = Get-Process -Id $pid -ErrorAction SilentlyContinue; \
+               if (-not $p) {{ $doRm = $true; break }}; \
+               if ($start -and $p.StartTime -ne $start) {{ $doRm = $true; break }}; \
+               Start-Sleep -Milliseconds 500 \
+             }}; \
+             if ($doRm) {{ \
+               @({joined}) | ForEach-Object {{ if (Test-Path $_) {{ Remove-Item -LiteralPath $_ -Recurse -Force }} }} \
+             }}"
         );
         Command::new("powershell")
             .args(["-NoProfile", "-WindowStyle", "Hidden", "-Command", &script])
             .spawn()?;
         Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn process_start_token_unix(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "lstart="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
     }
 }
 

--- a/crates/er-tui/src/main.rs
+++ b/crates/er-tui/src/main.rs
@@ -83,7 +83,7 @@ fn install_panic_hook() {
 
 fn run_uninstall(yes: bool, dry_run: bool, opts: uninstall::UninstallOptions) -> Result<()> {
     let plan = uninstall::plan(&opts);
-    let existing: Vec<_> = plan.iter().filter(|t| t.exists).cloned().collect();
+    let existing = uninstall::existing_targets(&opts);
 
     println!("Easy Review uninstall");
     println!();

--- a/crates/er-tui/src/main.rs
+++ b/crates/er-tui/src/main.rs
@@ -2,20 +2,21 @@ mod input;
 mod ui;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use crossterm::{
+    cursor::Show,
     event::{self, Event},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use er_engine::app::{self, App, InputMode};
-use er_engine::{github, watch};
+use er_engine::{github, uninstall, watch};
 use input::{
     handle_comment_input, handle_commit_input, handle_confirm_input, handle_filter_input,
     handle_normal_input, handle_overlay_input, handle_remote_url_input, handle_search_input,
 };
 use ratatui::prelude::*;
-use std::io;
+use std::io::{self, Write};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use watch::{FileWatcher, WatchEvent};
@@ -24,6 +25,9 @@ use watch::{FileWatcher, WatchEvent};
 #[derive(Parser)]
 #[command(name = "er", version, about)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
     /// Repository paths to open (defaults to current directory)
     paths: Vec<String>,
 
@@ -44,21 +48,130 @@ struct Cli {
     target: Option<String>,
 }
 
+#[derive(Subcommand)]
+enum Commands {
+    /// Remove Easy Review config, review data, and installed apps from this machine
+    Uninstall {
+        /// Skip the confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Print what would be removed without deleting anything
+        #[arg(long)]
+        dry_run: bool,
+        /// Keep managed review storage (`…/easy-review`)
+        #[arg(long)]
+        keep_data: bool,
+        /// Keep `~/.config/er`
+        #[arg(long)]
+        keep_config: bool,
+        /// Keep the `er` binary and desktop app bundle
+        #[arg(long)]
+        keep_apps: bool,
+    },
+}
+
 /// Restore the terminal before the default panic handler runs, so a panic
 /// inside the event loop doesn't leave the shell in raw mode with no cursor.
 fn install_panic_hook() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show);
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, Show);
         default_hook(info);
     }));
+}
+
+fn run_uninstall(
+    yes: bool,
+    dry_run: bool,
+    keep_data: bool,
+    keep_config: bool,
+    keep_apps: bool,
+) -> Result<()> {
+    let opts = uninstall::UninstallOptions {
+        remove_config: !keep_config,
+        remove_data: !keep_data,
+        remove_cache: true,
+        remove_binaries: !keep_apps,
+        remove_desktop_app: !keep_apps,
+    };
+
+    let plan = uninstall::plan(&opts);
+    let existing: Vec<_> = plan.iter().filter(|t| t.exists).cloned().collect();
+
+    println!("Easy Review uninstall");
+    println!();
+    if plan.is_empty() {
+        println!("Nothing selected to remove.");
+        return Ok(());
+    }
+
+    for t in &plan {
+        let mark = if t.exists { "•" } else { "·" };
+        let status = if t.exists { "" } else { " (not present)" };
+        println!("  {mark} {}{status}", t.description());
+    }
+    println!();
+
+    if existing.is_empty() {
+        println!("Nothing installed to remove.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("Dry run — no changes made.");
+        return Ok(());
+    }
+
+    if !yes {
+        print!("Type uninstall to confirm: ");
+        io::stdout().flush()?;
+        let mut line = String::new();
+        io::stdin().read_line(&mut line)?;
+        if line.trim() != "uninstall" {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let report = uninstall::execute(&existing);
+    if !report.deferred.is_empty() {
+        uninstall::schedule_deferred_removal(&report.deferred)
+            .map_err(|e| anyhow::anyhow!("Could not schedule removal of in-use paths: {e}"))?;
+    }
+    for line in report.summary_lines() {
+        println!("{line}");
+    }
+
+    if !report.deferred.is_empty() {
+        println!();
+        println!("Some paths are in use by this process and will be removed after it exits.");
+    }
+
+    if !report.is_success() {
+        anyhow::bail!("Uninstall completed with errors");
+    }
+
+    println!();
+    println!("Done. Easy Review data and apps have been removed.");
+    Ok(())
 }
 
 fn main() -> Result<()> {
     er_engine::env_path::init_cli_path();
     install_panic_hook();
     let cli = Cli::parse();
+
+    if let Some(Commands::Uninstall {
+        yes,
+        dry_run,
+        keep_data,
+        keep_config,
+        keep_apps,
+    }) = cli.command
+    {
+        return run_uninstall(yes, dry_run, keep_data, keep_config, keep_apps);
+    }
 
     // Reject conflicting --pr and PR URL arguments
     if cli.pr.is_some() && cli.paths.iter().any(|p| github::is_github_pr_url(p)) {

--- a/crates/er-tui/src/main.rs
+++ b/crates/er-tui/src/main.rs
@@ -81,21 +81,7 @@ fn install_panic_hook() {
     }));
 }
 
-fn run_uninstall(
-    yes: bool,
-    dry_run: bool,
-    keep_data: bool,
-    keep_config: bool,
-    keep_apps: bool,
-) -> Result<()> {
-    let opts = uninstall::UninstallOptions {
-        remove_config: !keep_config,
-        remove_data: !keep_data,
-        remove_cache: true,
-        remove_binaries: !keep_apps,
-        remove_desktop_app: !keep_apps,
-    };
-
+fn run_uninstall(yes: bool, dry_run: bool, opts: uninstall::UninstallOptions) -> Result<()> {
     let plan = uninstall::plan(&opts);
     let existing: Vec<_> = plan.iter().filter(|t| t.exists).cloned().collect();
 
@@ -170,7 +156,14 @@ fn main() -> Result<()> {
         keep_apps,
     }) = cli.command
     {
-        return run_uninstall(yes, dry_run, keep_data, keep_config, keep_apps);
+        let opts = uninstall::UninstallOptions {
+            remove_config: !keep_config,
+            remove_data: !keep_data,
+            remove_cache: true,
+            remove_binaries: !keep_apps,
+            remove_desktop_app: !keep_apps,
+        };
+        return run_uninstall(yes, dry_run, opts);
     }
 
     // Reject conflicting --pr and PR URL arguments

--- a/desktop-ui/src/lib/components/EmptyState.svelte
+++ b/desktop-ui/src/lib/components/EmptyState.svelte
@@ -61,7 +61,7 @@
   }
 
   function connectGitHub() {
-    void openExternalUrl("https://cli.github.com/");
+    void openExternalUrl("https://github.com/login");
   }
 
   function openSettings() {
@@ -141,7 +141,7 @@
         class="w-full text-left px-2 py-1.5 rounded-md hover:bg-hover text-sm text-fg-3 flex items-center gap-2"
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-        Install GitHub CLI
+        Connect GitHub
       </button>
       <button
         type="button"
@@ -178,7 +178,7 @@
               </div>
               <div class="font-medium">Open a local repo</div>
             </div>
-            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in app data — nothing is written into your project.</p>
+            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in <span class="mono text-fg-2">.er/</span> alongside your code.</p>
             <div class="mt-3 text-[11px] text-muted mono">⌘O</div>
           </button>
 

--- a/desktop-ui/src/lib/components/EmptyState.svelte
+++ b/desktop-ui/src/lib/components/EmptyState.svelte
@@ -61,7 +61,22 @@
   }
 
   function connectGitHub() {
-    void openExternalUrl("https://github.com/login");
+    void openExternalUrl("https://cli.github.com/");
+  }
+
+  function openSettings() {
+    app.setMainView("settings");
+    app.showEmptyState = false;
+  }
+
+  function openUninstall() {
+    try {
+      localStorage.setItem("er.focusUninstall", "1");
+    } catch {
+      /* ignore */
+    }
+    app.setMainView("settings");
+    app.showEmptyState = false;
   }
 
   function dismiss(e: KeyboardEvent) {
@@ -126,7 +141,23 @@
         class="w-full text-left px-2 py-1.5 rounded-md hover:bg-hover text-sm text-fg-3 flex items-center gap-2"
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-        Connect GitHub
+        Install GitHub CLI
+      </button>
+      <button
+        type="button"
+        onclick={openSettings}
+        class="w-full text-left px-2 py-1.5 rounded-md hover:bg-hover text-sm text-fg-3 flex items-center gap-2"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg>
+        App settings
+      </button>
+      <button
+        type="button"
+        onclick={openUninstall}
+        class="w-full text-left px-2 py-1.5 rounded-md hover:bg-hover text-sm text-fg-3 flex items-center gap-2"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6"/></svg>
+        Uninstall
       </button>
     </aside>
 
@@ -147,7 +178,7 @@
               </div>
               <div class="font-medium">Open a local repo</div>
             </div>
-            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in <span class="mono text-fg-2">.er/</span> alongside your code.</p>
+            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in app data — nothing is written into your project.</p>
             <div class="mt-3 text-[11px] text-muted mono">⌘O</div>
           </button>
 

--- a/desktop-ui/src/lib/components/EmptyState.svelte
+++ b/desktop-ui/src/lib/components/EmptyState.svelte
@@ -178,7 +178,7 @@
               </div>
               <div class="font-medium">Open a local repo</div>
             </div>
-            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in <span class="mono text-fg-2">.er/</span> alongside your code.</p>
+            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in app data — nothing is written into your project.</p>
             <div class="mt-3 text-[11px] text-muted mono">⌘O</div>
           </button>
 

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { app } from "$lib/stores/app.svelte";
   import type {
@@ -40,6 +41,16 @@
   let repoRoot = $state("");
   let addPattern = $state("");
   let textWarnings = $state<Record<string, string | null>>({});
+
+  let uninstallPreview = $state<{
+    targets: { kind: string; path: string; exists: boolean; description: string }[];
+    existingCount: number;
+  } | null>(null);
+  let uninstallLoading = $state(false);
+  let uninstallConfirm = $state(false);
+  let uninstallTyped = $state("");
+  let uninstallBusy = $state(false);
+  let focusUninstall = $state(false);
 
   const fields = $derived(activeTab === "general" ? generalFields : terminalFields);
 
@@ -170,8 +181,61 @@
     }
   }
 
+  async function loadUninstallPreview() {
+    uninstallLoading = true;
+    try {
+      const res = await invoke<{
+        targets: { kind: string; path: string; exists: boolean; description: string }[];
+        existingCount: number;
+      }>("preview_uninstall", { request: null });
+      uninstallPreview = res;
+    } catch (e) {
+      app.showToast("error", `preview_uninstall: ${e}`);
+    } finally {
+      uninstallLoading = false;
+    }
+  }
+
+  async function confirmUninstall() {
+    if (uninstallTyped.trim() !== "uninstall") return;
+    uninstallBusy = true;
+    try {
+      await invoke("run_uninstall", { request: null });
+      app.showToast("success", "Easy Review removed — quitting…");
+    } catch (e) {
+      app.showToast("error", String(e));
+      uninstallBusy = false;
+      await loadUninstallPreview();
+    }
+  }
+
   $effect(() => {
     void reload();
+  });
+
+  onMount(() => {
+    try {
+      if (localStorage.getItem("er.focusUninstall") === "1") {
+        localStorage.removeItem("er.focusUninstall");
+        activeTab = "general";
+        focusUninstall = true;
+      }
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // Scroll + preview after settings finish loading (section missing while loading).
+  $effect(() => {
+    if (!focusUninstall || loading || activeTab !== "general") return;
+    focusUninstall = false;
+    void loadUninstallPreview().then(() => {
+      queueMicrotask(() => {
+        document
+          .getElementById("settings-uninstall")
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    });
   });
 </script>
 
@@ -400,6 +464,78 @@
               </p>
             </div>
           {/if}
+
+          <h2
+            id="settings-uninstall"
+            class="flex items-center gap-2 text-xs uppercase tracking-wider text-muted font-semibold mt-7 mb-2.5 scroll-mt-4"
+          >
+            <span class="w-1 h-3 rounded-full bg-risk-high/70" aria-hidden="true"></span>
+            Uninstall
+          </h2>
+          <div class="bg-card border border-hairline rounded-xl px-4 py-4 space-y-3">
+            <p class="text-sm text-fg-3">
+              Remove Easy Review from this machine: config, review data, legacy cache, and installed
+              apps. Diff review of your repos is unaffected — only Easy Review’s own files are deleted.
+            </p>
+            {#if uninstallPreview}
+              <ul class="space-y-1.5 text-xs font-mono text-fg-3 max-h-40 overflow-y-auto">
+                {#each uninstallPreview.targets as t (t.path)}
+                  <li class="flex gap-2">
+                    <span class={t.exists ? "text-fg-2" : "text-muted"}>{t.exists ? "•" : "·"}</span>
+                    <span class="min-w-0 break-all">{t.description}{t.exists ? "" : " (not present)"}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else if uninstallLoading}
+              <p class="text-xs text-muted">Scanning install locations…</p>
+            {/if}
+            {#if !uninstallConfirm}
+              <div class="flex flex-wrap gap-2 pt-1">
+                <Button variant="ghost" onclick={() => void loadUninstallPreview()}>
+                  {uninstallPreview ? "Refresh list" : "Show what will be removed"}
+                </Button>
+                <Button
+                  variant="danger"
+                  disabled={!uninstallPreview || uninstallPreview.existingCount === 0 || uninstallBusy}
+                  onclick={() => (uninstallConfirm = true)}
+                >
+                  Uninstall…
+                </Button>
+              </div>
+            {:else}
+              <div class="rounded-lg border border-risk-high/40 bg-risk-high/5 px-3 py-3 space-y-2">
+                <p class="text-sm text-fg-1">
+                  Type <span class="font-mono text-risk-high">uninstall</span> to confirm. The app will quit afterward.
+                </p>
+                <input
+                  type="text"
+                  class="w-full bg-ink-850 border border-hairline rounded-md px-2.5 py-1.5 text-sm font-mono outline-none focus:border-risk-high/60"
+                  placeholder="uninstall"
+                  bind:value={uninstallTyped}
+                  disabled={uninstallBusy}
+                />
+                <div class="flex gap-2">
+                  <Button
+                    variant="danger"
+                    disabled={uninstallTyped.trim() !== "uninstall" || uninstallBusy}
+                    onclick={() => void confirmUninstall()}
+                  >
+                    {uninstallBusy ? "Removing…" : "Remove everything"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    disabled={uninstallBusy}
+                    onclick={() => {
+                      uninstallConfirm = false;
+                      uninstallTyped = "";
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            {/if}
+          </div>
         {/if}
       </div>
     </div>

--- a/desktop-ui/src/lib/components/settings/SettingsPage.svelte
+++ b/desktop-ui/src/lib/components/settings/SettingsPage.svelte
@@ -181,13 +181,21 @@
     }
   }
 
+  const fullUninstallRequest = {
+    removeConfig: true,
+    removeData: true,
+    removeCache: true,
+    removeBinaries: true,
+    removeDesktopApp: true,
+  };
+
   async function loadUninstallPreview() {
     uninstallLoading = true;
     try {
       const res = await invoke<{
         targets: { kind: string; path: string; exists: boolean; description: string }[];
         existingCount: number;
-      }>("preview_uninstall", { request: null });
+      }>("preview_uninstall", { request: fullUninstallRequest });
       uninstallPreview = res;
     } catch (e) {
       app.showToast("error", `preview_uninstall: ${e}`);
@@ -200,7 +208,7 @@
     if (uninstallTyped.trim() !== "uninstall") return;
     uninstallBusy = true;
     try {
-      await invoke("run_uninstall", { request: null });
+      await invoke("run_uninstall", { request: fullUninstallRequest });
       app.showToast("success", "Easy Review removed — quitting…");
     } catch (e) {
       app.showToast("error", String(e));

--- a/desktop-ui/src/lib/components/ui/Button.svelte
+++ b/desktop-ui/src/lib/components/ui/Button.svelte
@@ -3,7 +3,7 @@
 
   interface Props {
     children: Snippet;
-    variant?: "primary" | "secondary" | "ghost";
+    variant?: "primary" | "secondary" | "ghost" | "danger";
     size?: "sm" | "md";
     type?: "button" | "submit" | "reset";
     disabled?: boolean;
@@ -32,7 +32,9 @@
       ? "bg-accent text-on-accent hover:bg-accent-hover"
       : variant === "ghost"
         ? "text-fg-3 hover:bg-hover"
-        : "border border-border text-fg-2 hover:bg-hover"
+        : variant === "danger"
+          ? "bg-risk-high/15 text-risk-high border border-risk-high/40 hover:bg-risk-high/25 disabled:opacity-40"
+          : "border border-border text-fg-2 hover:bg-hover"
   );
 
   const sizeClass = $derived(size === "md" ? "px-3 py-2 text-xs" : "px-3 py-1.5 text-xs");

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -111,9 +111,10 @@ cd easy-review
 er uninstall --yes        <span class="cmt"># no prompt</span>
 er uninstall --dry-run    <span class="cmt"># list paths only</span>
 er uninstall --keep-data  <span class="cmt"># leave review storage</span>
+er uninstall --keep-config <span class="cmt"># leave ~/.config/er</span>
 er uninstall --keep-apps  <span class="cmt"># leave binaries / .app</span></code></pre>
     <p>
-      Or re-run the install script with <code>--uninstall</code>:
+      Or re-run the install script with <code>--uninstall</code> (same keep/dry-run flags are forwarded):
     </p>
     <pre><code>curl -fsSL https://raw.githubusercontent.com/VilfredSikker/easy-review/main/install.sh | bash -s -- --uninstall</code></pre>
 
@@ -133,9 +134,9 @@ er uninstall --keep-apps  <span class="cmt"># leave binaries / .app</span></code
 
     <h2 id="mcp-server">MCP server (<code>er-mcp</code>)</h2>
     <p>
-      Optional local MCP server for Claude Code, Cursor, Codex, and OpenCode — PR triage queues and AI sidecar upload into
+      Optional local MCP server for Claude Code, Cursor, and Codex — PR triage queues and AI sidecar upload into
       shared managed storage. Full setup (one-line <code>claude mcp add</code> / <code>codex mcp add</code>, plus
-      <code>mcp.json</code> for Cursor and <code>opencode.json</code> for OpenCode): <a href="mcp.html">MCP Server Setup</a>.
+      <code>mcp.json</code> for Cursor): <a href="mcp.html">MCP Server Setup</a>.
     </p>
     <pre><code>cargo install --path crates/er-mcp</code></pre>
   </main>

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -127,7 +127,7 @@ er uninstall --keep-apps  <span class="cmt"># leave binaries / .app</span></code
     <p>What gets removed by default:</p>
     <ul>
       <li><code>~/.config/er/</code> (and the platform config dir) — config, projects, tabs, caches</li>
-      <li>Managed review storage under <code>…/easy-review/</code> (see <a href="storage.html">Review Storage</a>)</li>
+      <li>Managed review storage under <code>…/easy-review/</code> (see <a href="storage.html">Review Storage</a>), plus Tauri bundle data dirs when present</li>
       <li>Legacy <code>~/.cache/er/</code></li>
       <li>The <code>er</code> binary (common install locations) and <code>Easy Review.app</code> when found</li>
     </ul>

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -103,15 +103,39 @@ cd easy-review
     </ul>
 
     <h2>Uninstalling</h2>
-    <p>Delete the <code>er</code> binary from your install directory (e.g. <code>rm ~/.local/bin/er</code>). Review
-    data lives separately in managed storage — see <a href="storage.html">Review Storage</a> for those paths if you
-    want to remove it too.</p>
+    <p>
+      Remove config, managed review storage, legacy cache, and installed apps from either surface:
+    </p>
+    <h3>Terminal</h3>
+    <pre><code>er uninstall              <span class="cmt"># interactive confirm</span>
+er uninstall --yes        <span class="cmt"># no prompt</span>
+er uninstall --dry-run    <span class="cmt"># list paths only</span>
+er uninstall --keep-data  <span class="cmt"># leave review storage</span>
+er uninstall --keep-apps  <span class="cmt"># leave binaries / .app</span></code></pre>
+    <p>
+      Or re-run the install script with <code>--uninstall</code>:
+    </p>
+    <pre><code>curl -fsSL https://raw.githubusercontent.com/VilfredSikker/easy-review/main/install.sh | bash -s -- --uninstall</code></pre>
+
+    <h3>Desktop</h3>
+    <p>
+      Open <strong>Settings → General → Uninstall</strong> (also linked from the welcome screen). Confirm by typing
+      <code>uninstall</code>; the app quits after removal. Paths in use by the running process are deleted after it exits.
+    </p>
+
+    <p>What gets removed by default:</p>
+    <ul>
+      <li><code>~/.config/er/</code> (and the platform config dir) — config, projects, tabs, caches</li>
+      <li>Managed review storage under <code>…/easy-review/</code> (see <a href="storage.html">Review Storage</a>)</li>
+      <li>Legacy <code>~/.cache/er/</code></li>
+      <li>The <code>er</code> binary (common install locations) and <code>Easy Review.app</code> when found</li>
+    </ul>
 
     <h2 id="mcp-server">MCP server (<code>er-mcp</code>)</h2>
     <p>
-      Optional local MCP server for Claude Code, Cursor, and Codex — PR triage queues and AI sidecar upload into
+      Optional local MCP server for Claude Code, Cursor, Codex, and OpenCode — PR triage queues and AI sidecar upload into
       shared managed storage. Full setup (one-line <code>claude mcp add</code> / <code>codex mcp add</code>, plus
-      <code>mcp.json</code> for Cursor): <a href="mcp.html">MCP Server Setup</a>.
+      <code>mcp.json</code> for Cursor and <code>opencode.json</code> for OpenCode): <a href="mcp.html">MCP Server Setup</a>.
     </p>
     <pre><code>cargo install --path crates/er-mcp</code></pre>
   </main>

--- a/docs/guide/storage.html
+++ b/docs/guide/storage.html
@@ -111,6 +111,11 @@
     repository also ships helper scripts:</p>
     <pre><code>scripts/er-cleanup-reviews.sh     <span class="cmt"># remove review.json, checklist, summary, …</span>
 scripts/er-cleanup-questions.sh   <span class="cmt"># remove questions.json</span></code></pre>
+    <p>
+      To remove <em>all</em> Easy Review data and apps from the machine, use
+      <code>er uninstall</code> or Desktop <strong>Settings → Uninstall</strong> — see
+      <a href="installation.html">Installation → Uninstalling</a>.
+    </p>
   </main>
   <script src="assets/docs.js"></script>
 </body>

--- a/install.sh
+++ b/install.sh
@@ -13,21 +13,57 @@ usage() {
     echo "Options:"
     echo "  --version VERSION   Install a specific version (e.g., v0.1.0)"
     echo "  --dir DIR           Install directory (default: ~/.local/bin)"
+    echo "  --uninstall         Remove er binary, config, and review data"
+    echo "  --yes               Skip uninstall confirmation"
     echo "  --help              Show this help"
     echo ""
     echo "Examples:"
     echo "  curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh | bash"
     echo "  curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh | bash -s -- --version v0.1.0"
+    echo "  curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh | bash -s -- --uninstall"
 }
+
+UNINSTALL=0
+YES=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version) VERSION="$2"; shift 2 ;;
         --dir) INSTALL_DIR="$2"; shift 2 ;;
+        --uninstall) UNINSTALL=1; shift ;;
+        --yes|-y) YES=1; shift ;;
         --help) usage; exit 0 ;;
         *) echo "Unknown option: $1"; usage; exit 1 ;;
     esac
 done
+
+if [[ "$UNINSTALL" -eq 1 ]]; then
+    if command -v er >/dev/null 2>&1; then
+        if [[ "$YES" -eq 1 ]]; then
+            exec er uninstall --yes
+        else
+            exec er uninstall
+        fi
+    fi
+    echo "er is not on PATH — removing common locations manually…"
+    rm -f "${INSTALL_DIR}/er" "$HOME/.local/bin/er" "$HOME/.cargo/bin/er" 2>/dev/null || true
+    rm -rf "$HOME/.config/er" 2>/dev/null || true
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        rm -rf "$HOME/Library/Application Support/er" \
+               "$HOME/Library/Application Support/easy-review" \
+               "$HOME/Library/Application Support/com.reshape.easy-review" \
+               "$HOME/Library/Application Support/Easy Review" \
+               "$HOME/Library/Caches/com.reshape.easy-review" \
+               "$HOME/Library/Caches/Easy Review" 2>/dev/null || true
+    fi
+    rm -rf "$HOME/.local/share/easy-review" \
+           "$HOME/.local/share/com.reshape.easy-review" \
+           "$HOME/.cache/er" \
+           "/Applications/Easy Review.app" \
+           "$HOME/Applications/Easy Review.app" 2>/dev/null || true
+    echo "Done."
+    exit 0
+fi
 
 # Detect OS and architecture
 OS="$(uname -s)"

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,10 @@ usage() {
     echo "  --dir DIR           Install directory (default: ~/.local/bin)"
     echo "  --uninstall         Remove er binary, config, and review data"
     echo "  --yes               Skip uninstall confirmation"
+    echo "  --dry-run           List uninstall paths without deleting"
+    echo "  --keep-data         Keep managed review storage"
+    echo "  --keep-config       Keep ~/.config/er"
+    echo "  --keep-apps         Keep the er binary and desktop app"
     echo "  --help              Show this help"
     echo ""
     echo "Examples:"
@@ -25,6 +29,10 @@ usage() {
 
 UNINSTALL=0
 YES=0
+DRY_RUN=0
+KEEP_DATA=0
+KEEP_CONFIG=0
+KEEP_APPS=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -32,6 +40,10 @@ while [[ $# -gt 0 ]]; do
         --dir) INSTALL_DIR="$2"; shift 2 ;;
         --uninstall) UNINSTALL=1; shift ;;
         --yes|-y) YES=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --keep-data) KEEP_DATA=1; shift ;;
+        --keep-config) KEEP_CONFIG=1; shift ;;
+        --keep-apps) KEEP_APPS=1; shift ;;
         --help) usage; exit 0 ;;
         *) echo "Unknown option: $1"; usage; exit 1 ;;
     esac
@@ -39,28 +51,72 @@ done
 
 if [[ "$UNINSTALL" -eq 1 ]]; then
     if command -v er >/dev/null 2>&1; then
-        if [[ "$YES" -eq 1 ]]; then
-            exec er uninstall --yes
-        else
-            exec er uninstall
+        args=(uninstall)
+        [[ "$YES" -eq 1 ]] && args+=(--yes)
+        [[ "$DRY_RUN" -eq 1 ]] && args+=(--dry-run)
+        [[ "$KEEP_DATA" -eq 1 ]] && args+=(--keep-data)
+        [[ "$KEEP_CONFIG" -eq 1 ]] && args+=(--keep-config)
+        [[ "$KEEP_APPS" -eq 1 ]] && args+=(--keep-apps)
+        exec er "${args[@]}"
+    fi
+
+    echo "er is not on PATH — removing common locations manually…"
+    echo "(best-effort path list; prefer installing er and re-running for the canonical plan)"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "(dry-run) would remove:"
+        [[ "$KEEP_APPS" -eq 0 ]] && echo "  ${INSTALL_DIR}/er" && echo "  $HOME/.local/bin/er" && echo "  $HOME/.cargo/bin/er"
+        [[ "$KEEP_CONFIG" -eq 0 ]] && echo "  $HOME/.config/er"
+        if [[ "$KEEP_DATA" -eq 0 ]]; then
+            if [[ "$(uname -s)" == "Darwin" ]]; then
+                echo "  $HOME/Library/Application Support/easy-review"
+                echo "  $HOME/Library/Application Support/com.reshape.easy-review"
+                echo "  $HOME/Library/Application Support/Easy Review"
+                echo "  $HOME/Library/Caches/com.reshape.easy-review"
+                echo "  $HOME/Library/Caches/Easy Review"
+            fi
+            echo "  $HOME/.local/share/easy-review"
+            echo "  $HOME/.local/share/com.reshape.easy-review"
+            echo "  $HOME/.cache/er"
+        fi
+        if [[ "$KEEP_APPS" -eq 0 ]]; then
+            echo "  /Applications/Easy Review.app"
+            echo "  $HOME/Applications/Easy Review.app"
+        fi
+        exit 0
+    fi
+
+    if [[ "$YES" -ne 1 ]]; then
+        printf "Type uninstall to confirm: "
+        read -r confirm
+        if [[ "$confirm" != "uninstall" ]]; then
+            echo "Cancelled."
+            exit 0
         fi
     fi
-    echo "er is not on PATH — removing common locations manually…"
-    rm -f "${INSTALL_DIR}/er" "$HOME/.local/bin/er" "$HOME/.cargo/bin/er" 2>/dev/null || true
-    rm -rf "$HOME/.config/er" 2>/dev/null || true
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        rm -rf "$HOME/Library/Application Support/er" \
-               "$HOME/Library/Application Support/easy-review" \
-               "$HOME/Library/Application Support/com.reshape.easy-review" \
-               "$HOME/Library/Application Support/Easy Review" \
-               "$HOME/Library/Caches/com.reshape.easy-review" \
-               "$HOME/Library/Caches/Easy Review" 2>/dev/null || true
+
+    if [[ "$KEEP_APPS" -eq 0 ]]; then
+        rm -f "${INSTALL_DIR}/er" "$HOME/.local/bin/er" "$HOME/.cargo/bin/er" 2>/dev/null || true
     fi
-    rm -rf "$HOME/.local/share/easy-review" \
-           "$HOME/.local/share/com.reshape.easy-review" \
-           "$HOME/.cache/er" \
-           "/Applications/Easy Review.app" \
-           "$HOME/Applications/Easy Review.app" 2>/dev/null || true
+    if [[ "$KEEP_CONFIG" -eq 0 ]]; then
+        rm -rf "$HOME/.config/er" 2>/dev/null || true
+    fi
+    if [[ "$KEEP_DATA" -eq 0 ]]; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            rm -rf "$HOME/Library/Application Support/er" \
+                   "$HOME/Library/Application Support/easy-review" \
+                   "$HOME/Library/Application Support/com.reshape.easy-review" \
+                   "$HOME/Library/Application Support/Easy Review" \
+                   "$HOME/Library/Caches/com.reshape.easy-review" \
+                   "$HOME/Library/Caches/Easy Review" 2>/dev/null || true
+        fi
+        rm -rf "$HOME/.local/share/easy-review" \
+               "$HOME/.local/share/com.reshape.easy-review" \
+               "$HOME/.cache/er" 2>/dev/null || true
+    fi
+    if [[ "$KEEP_APPS" -eq 0 ]]; then
+        rm -rf "/Applications/Easy Review.app" \
+               "$HOME/Applications/Easy Review.app" 2>/dev/null || true
+    fi
     echo "Done."
     exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -61,27 +61,71 @@ if [[ "$UNINSTALL" -eq 1 ]]; then
     fi
 
     echo "er is not on PATH — removing common locations manually…"
-    echo "(best-effort path list; prefer installing er and re-running for the canonical plan)"
+    echo "(best-effort path list aligned with er-engine::uninstall categories; prefer re-running with er on PATH)"
+
+    # Mirror dirs::{ / XDG resolution used by er-engine (config / data / cache).
+    config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+    cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+    os="$(uname -s)"
+
+    # Collect paths in the same categories as er-engine::uninstall::plan.
+    paths=()
+    if [[ "$KEEP_CONFIG" -eq 0 ]]; then
+        paths+=("$config_home/er")
+        # Platform config dir when it differs from XDG (macOS Application Support).
+        if [[ "$os" == "Darwin" ]]; then
+            paths+=("$HOME/Library/Application Support/er")
+        fi
+    fi
+    if [[ "$KEEP_DATA" -eq 0 ]]; then
+        paths+=("$data_home/easy-review")
+        paths+=("$data_home/com.reshape.easy-review")
+        paths+=("$data_home/Easy Review")
+        paths+=("$cache_home/com.reshape.easy-review")
+        paths+=("$cache_home/Easy Review")
+        paths+=("$cache_home/er")
+        if [[ "$os" == "Darwin" ]]; then
+            paths+=("$HOME/Library/Application Support/easy-review")
+            paths+=("$HOME/Library/Application Support/com.reshape.easy-review")
+            paths+=("$HOME/Library/Application Support/Easy Review")
+            paths+=("$HOME/Library/Caches/com.reshape.easy-review")
+            paths+=("$HOME/Library/Caches/Easy Review")
+            paths+=("$HOME/Library/Caches/er")
+        fi
+    fi
+    # Engine always removes legacy ~/.cache/er (remove_cache stays true with --keep-data).
+    paths+=("$HOME/.cache/er")
+    if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+        paths+=("$XDG_CACHE_HOME/er")
+    fi
+    if [[ "$KEEP_APPS" -eq 0 ]]; then
+        paths+=("${INSTALL_DIR}/er" "$HOME/.local/bin/er" "$HOME/.cargo/bin/er")
+        paths+=("/usr/local/bin/er" "/opt/homebrew/bin/er")
+        if [[ "$os" == "Darwin" ]]; then
+            paths+=("/Applications/Easy Review.app" "$HOME/Applications/Easy Review.app")
+        elif [[ "$os" == "Linux" ]]; then
+            paths+=("$HOME/.local/share/applications/easy-review.desktop")
+            paths+=("$HOME/.local/bin/easy-review" "/usr/local/bin/easy-review")
+        fi
+    fi
+
+    # Deduplicate while preserving order.
+    deduped=()
+    for p in "${paths[@]}"; do
+        skip=0
+        for d in "${deduped[@]+"${deduped[@]}"}"; do
+            [[ "$d" == "$p" ]] && skip=1 && break
+        done
+        [[ "$skip" -eq 0 ]] && deduped+=("$p")
+    done
+    paths=("${deduped[@]}")
+
     if [[ "$DRY_RUN" -eq 1 ]]; then
         echo "(dry-run) would remove:"
-        [[ "$KEEP_APPS" -eq 0 ]] && echo "  ${INSTALL_DIR}/er" && echo "  $HOME/.local/bin/er" && echo "  $HOME/.cargo/bin/er"
-        [[ "$KEEP_CONFIG" -eq 0 ]] && echo "  $HOME/.config/er"
-        if [[ "$KEEP_DATA" -eq 0 ]]; then
-            if [[ "$(uname -s)" == "Darwin" ]]; then
-                echo "  $HOME/Library/Application Support/easy-review"
-                echo "  $HOME/Library/Application Support/com.reshape.easy-review"
-                echo "  $HOME/Library/Application Support/Easy Review"
-                echo "  $HOME/Library/Caches/com.reshape.easy-review"
-                echo "  $HOME/Library/Caches/Easy Review"
-            fi
-            echo "  $HOME/.local/share/easy-review"
-            echo "  $HOME/.local/share/com.reshape.easy-review"
-            echo "  $HOME/.cache/er"
-        fi
-        if [[ "$KEEP_APPS" -eq 0 ]]; then
-            echo "  /Applications/Easy Review.app"
-            echo "  $HOME/Applications/Easy Review.app"
-        fi
+        for p in "${paths[@]}"; do
+            echo "  $p"
+        done
         exit 0
     fi
 
@@ -94,29 +138,11 @@ if [[ "$UNINSTALL" -eq 1 ]]; then
         fi
     fi
 
-    if [[ "$KEEP_APPS" -eq 0 ]]; then
-        rm -f "${INSTALL_DIR}/er" "$HOME/.local/bin/er" "$HOME/.cargo/bin/er" 2>/dev/null || true
-    fi
-    if [[ "$KEEP_CONFIG" -eq 0 ]]; then
-        rm -rf "$HOME/.config/er" 2>/dev/null || true
-    fi
-    if [[ "$KEEP_DATA" -eq 0 ]]; then
-        if [[ "$(uname -s)" == "Darwin" ]]; then
-            rm -rf "$HOME/Library/Application Support/er" \
-                   "$HOME/Library/Application Support/easy-review" \
-                   "$HOME/Library/Application Support/com.reshape.easy-review" \
-                   "$HOME/Library/Application Support/Easy Review" \
-                   "$HOME/Library/Caches/com.reshape.easy-review" \
-                   "$HOME/Library/Caches/Easy Review" 2>/dev/null || true
+    for p in "${paths[@]}"; do
+        if [[ -e "$p" || -L "$p" ]]; then
+            rm -rf "$p" 2>/dev/null || true
         fi
-        rm -rf "$HOME/.local/share/easy-review" \
-               "$HOME/.local/share/com.reshape.easy-review" \
-               "$HOME/.cache/er" 2>/dev/null || true
-    fi
-    if [[ "$KEEP_APPS" -eq 0 ]]; then
-        rm -rf "/Applications/Easy Review.app" \
-               "$HOME/Applications/Easy Review.app" 2>/dev/null || true
-    fi
+    done
     echo "Done."
     exit 0
 fi


### PR DESCRIPTION
## Summary
- Shared `er-engine::uninstall` plans and removes config, managed review storage, legacy cache, `er` binaries, and `Easy Review.app` (symlink-safe; defers in-use binary/.app removal).
- TUI: `er uninstall [--yes|--dry-run|--keep-data|--keep-config|--keep-apps]`; `install.sh --uninstall` mirrors the same options.
- Desktop: Settings → General → Uninstall (preview + type-to-confirm) and welcome empty-state entry that jumps to uninstall.

## Test plan
- [ ] `./scripts/er-tui.sh test -p er-engine -- uninstall` (engine unit tests)
- [ ] `er uninstall --dry-run` lists expected paths only
- [ ] `er uninstall --yes --keep-apps` removes data/config but leaves binaries
- [ ] Desktop Settings → Uninstall: preview loads, confirm requires typing `uninstall`, then app quits
- [ ] Welcome empty state → Uninstall opens Settings scrolled to the uninstall section
- [ ] `install.sh --uninstall` invokes `er uninstall` (with `--yes` when passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uninstall recursively deletes user config, review data, and install artifacts; deferred removal uses background shell scripts, so incorrect path discovery could cause data loss beyond Easy Review.
> 
> **Overview**
> Adds **end-to-end uninstall** so users can remove Easy Review config, managed review data, legacy cache, `er` binaries, and the desktop app from one flow.
> 
> A new **`er-engine::uninstall`** module plans targets (config dirs via shared `global_config_dir()`, storage roots, Tauri bundle data, cache, discovered binaries/apps), removes symlink-safe paths, and **defers** deletion of the running binary or `.app` with a post-exit shell/PowerShell waiter (PID + start-time checks to avoid PID reuse).
> 
> **TUI:** `er uninstall` subcommand with `--yes`, `--dry-run`, and `--keep-data` / `--keep-config` / `--keep-apps`.
> 
> **Desktop:** Tauri `preview_uninstall` / `run_uninstall` commands; Settings → General shows a preview, type-to-confirm, then quits when needed; welcome empty state links to settings/uninstall. UI adds a **danger** button variant.
> 
> **`install.sh`:** `--uninstall` forwards flags to `er uninstall`, with a manual fallback when `er` is not on PATH.
> 
> Docs and release notes document the surfaces; welcome copy clarifies reviews live in app data, not in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6f4c8cabb7e26ea5d1daca1de03456fa18c16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->