### PR TITLE
fix(desktop): show file risks when review has no line findings

### DIFF
--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -896,6 +896,17 @@ pub struct FlatFinding {
     pub responses: Vec<FindingResponseSnapshot>,
 }
 
+/// Per-file risk assessment from `review.json` (`ErFileReview`), distinct from
+/// line-anchored findings. Shown in the AI Review card as assessment metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileRiskSnapshot {
+    pub path: String,
+    /// "high" | "med" | "low"
+    pub risk: String,
+    pub risk_reason: String,
+    pub summary: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AiSnapshot {
     pub fresh: bool,
@@ -914,6 +925,9 @@ pub struct AiSnapshot {
     pub unpushed: usize,
     pub threads: Vec<ThreadSnapshot>,
     pub findings: Vec<FlatFinding>,
+    /// Per-file risk assessments from review.json (not counted as findings).
+    #[serde(default)]
+    pub file_risks: Vec<FileRiskSnapshot>,
     /// Whether `{er_dir}/review.json` exists (batch validate target).
     pub has_review_json: bool,
     /// Top-level GitHub comments eligible for batch validate (!resolved, !outdated).
@@ -1025,6 +1039,33 @@ fn severity_str(r: &RiskLevel) -> &'static str {
         RiskLevel::Medium => "med",
         RiskLevel::Low | RiskLevel::Info => "low",
     }
+}
+
+fn risk_sort_ord(r: &RiskLevel) -> u8 {
+    match r {
+        RiskLevel::High => 0,
+        RiskLevel::Medium => 1,
+        RiskLevel::Low => 2,
+        RiskLevel::Info => 3,
+    }
+}
+
+fn build_file_risks(review: &er_engine::ai::ErReview) -> Vec<FileRiskSnapshot> {
+    let mut entries: Vec<_> = review.files.iter().collect();
+    entries.sort_by(|(pa, fa), (pb, fb)| {
+        risk_sort_ord(&fa.risk)
+            .cmp(&risk_sort_ord(&fb.risk))
+            .then_with(|| pa.cmp(pb))
+    });
+    entries
+        .into_iter()
+        .map(|(path, fr)| FileRiskSnapshot {
+            path: path.clone(),
+            risk: severity_str(&fr.risk).to_string(),
+            risk_reason: fr.risk_reason.clone(),
+            summary: fr.summary.clone(),
+        })
+        .collect()
 }
 
 fn comment_ref_to_thread(
@@ -2238,6 +2279,7 @@ fn empty_ai_snapshot() -> AiSnapshot {
         unpushed: 0,
         threads: Vec::new(),
         findings: Vec::new(),
+        file_risks: Vec::new(),
         has_review_json: false,
         eligible_comment_count: 0,
         triage: None,
@@ -3415,6 +3457,12 @@ fn build_ai_snapshot(tab: &TabState, pending: Option<&PendingAiReplies>) -> AiSn
         vec![]
     };
 
+    let file_risks: Vec<FileRiskSnapshot> = ai
+        .review
+        .as_ref()
+        .map(build_file_risks)
+        .unwrap_or_default();
+
     let er_dir = tab.er_dir();
     let has_review_json = std::path::Path::new(&er_dir).join("review.json").exists();
     let eligible_comment_count = ai
@@ -3463,6 +3511,7 @@ fn build_ai_snapshot(tab: &TabState, pending: Option<&PendingAiReplies>) -> AiSn
         unpushed,
         threads,
         findings,
+        file_risks,
         has_review_json,
         eligible_comment_count,
         triage,
@@ -3743,6 +3792,66 @@ mod tests {
 
         assert_eq!(snapshot.threads.len(), 1);
         assert!(snapshot.threads[0].stale);
+    }
+
+    #[test]
+    fn ai_snapshot_includes_sorted_file_risks_without_findings() {
+        use er_engine::ai::{ErFileReview, ErReview, RiskLevel};
+        use std::collections::HashMap;
+
+        let mut files = HashMap::new();
+        files.insert(
+            "z_low.rs".to_string(),
+            ErFileReview {
+                risk: RiskLevel::Low,
+                risk_reason: "minor".into(),
+                summary: "low file".into(),
+                findings: vec![],
+            },
+        );
+        files.insert(
+            "a_high.rs".to_string(),
+            ErFileReview {
+                risk: RiskLevel::High,
+                risk_reason: "critical path".into(),
+                summary: "high file".into(),
+                findings: vec![],
+            },
+        );
+        files.insert(
+            "m_med.rs".to_string(),
+            ErFileReview {
+                risk: RiskLevel::Medium,
+                risk_reason: "touches API".into(),
+                summary: "med file".into(),
+                findings: vec![],
+            },
+        );
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.ai.review = Some(ErReview {
+            version: 1,
+            diff_hash: "abc".into(),
+            created_at: String::new(),
+            base_branch: String::new(),
+            head_branch: String::new(),
+            files,
+            file_hashes: HashMap::new(),
+        });
+        tab.ai.summary = Some("No line findings.".into());
+
+        let snapshot = build_ai_snapshot(&tab, None);
+
+        assert!(snapshot.findings.is_empty());
+        assert_eq!(snapshot.high + snapshot.med + snapshot.low, 0);
+        assert_eq!(snapshot.file_risks.len(), 3);
+        assert_eq!(snapshot.file_risks[0].path, "a_high.rs");
+        assert_eq!(snapshot.file_risks[0].risk, "high");
+        assert_eq!(snapshot.file_risks[1].path, "m_med.rs");
+        assert_eq!(snapshot.file_risks[1].risk, "med");
+        assert_eq!(snapshot.file_risks[2].path, "z_low.rs");
+        assert_eq!(snapshot.file_risks[2].risk, "low");
+        assert_eq!(snapshot.summary_markdown.as_deref(), Some("No line findings."));
     }
 
     #[test]

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -67,7 +67,7 @@ fn annotate_diff_command(input: &str, output: &str) -> String {
 /// Canonical review rules block (aligned with `skills/REVIEW_RULES.md`).
 ///
 /// When `prepared_diff` is false, pass `git_diff_capture` as the full step-1 shell command
-/// (e.g. `git diff main --unified=20 ... > .er/diff-tmp && shasum ...`).
+/// (e.g. `git diff main --unified=20 ... > {output_dir}/diff-tmp && shasum ...`).
 pub fn review_rules_preamble(
     output_dir: &str,
     prepared_diff: bool,
@@ -85,9 +85,10 @@ pub fn review_rules_preamble(
             "1. Run: `(sha256sum {safe_output_dir}/diff-tmp 2>/dev/null || shasum -a 256 {safe_output_dir}/diff-tmp)`\n   - Save the SHA-256 hash as `diff_hash` (do **not** run `git diff` — the diff is already prepared)"
         )
     } else {
-        let capture = git_diff_capture.unwrap_or(
-            "git diff <base> --unified=20 --no-color --no-ext-diff > .er/diff-tmp && (sha256sum .er/diff-tmp 2>/dev/null || shasum -a 256 .er/diff-tmp)",
+        let default_capture = format!(
+            "git diff <base> --unified=20 --no-color --no-ext-diff > {safe_output_dir}/diff-tmp && (sha256sum {safe_output_dir}/diff-tmp 2>/dev/null || shasum -a 256 {safe_output_dir}/diff-tmp)"
         );
+        let capture = git_diff_capture.unwrap_or(default_capture.as_str());
         format!(
             "1. Run: `{capture}`\n   - Use a **two-dot** diff (`git diff <base>`), never three-dot (`main...HEAD`)\n   - Always `--unified=20 --no-color --no-ext-diff`\n   - Save the SHA-256 hash as `diff_hash`"
         )
@@ -1775,7 +1776,7 @@ mod tests {
 
     #[test]
     fn review_rules_preamble_no_style_category() {
-        let preamble = review_rules_preamble(".er", false, FindingCaps::general(), None);
+        let preamble = review_rules_preamble("/tmp/managed", false, FindingCaps::general(), None);
         assert!(!preamble.contains(
             "Categories: security, logic, performance, correctness, error-handling, style, testing"
         ));
@@ -1785,9 +1786,17 @@ mod tests {
     }
 
     #[test]
+    fn review_rules_preamble_default_capture_uses_output_dir_not_repo_er() {
+        let preamble = review_rules_preamble("/tmp/managed-er", false, FindingCaps::general(), None);
+        assert!(preamble.contains("'/tmp/managed-er'/diff-tmp"));
+        assert!(!preamble.contains("> .er/diff-tmp"));
+        assert!(!preamble.contains("sha256sum .er/diff-tmp"));
+    }
+
+    #[test]
     fn review_rules_preamble_expert_caps_stricter() {
-        let expert = review_rules_preamble(".er", true, FindingCaps::expert(), None);
-        let general = review_rules_preamble(".er", true, FindingCaps::general(), None);
+        let expert = review_rules_preamble("/tmp/managed", true, FindingCaps::expert(), None);
+        let general = review_rules_preamble("/tmp/managed", true, FindingCaps::general(), None);
         assert!(expert.contains("Max 2 findings per file, max 10 total"));
         assert!(general.contains("Max 4 findings per file, max 15 total"));
     }

--- a/desktop-ui/src/lib/aiReviewAgents.test.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.test.ts
@@ -221,7 +221,7 @@ describe("resolveAgentSummary", () => {
     expect(r.text).toBe("No line findings. 1 file assessed.");
   });
 
-  it("keeps inspect-folder message only when truly empty", () => {
+  it("keeps generic empty message only when truly empty", () => {
     const r = resolveAgentSummary(
       { summary_markdown: null, agent_summaries: {} },
       ALL_REVIEWERS,
@@ -231,7 +231,8 @@ describe("resolveAgentSummary", () => {
       0,
     );
     expect(r.text).toContain("No findings written");
-    expect(r.text).toContain(".er/");
+    expect(r.text).toContain("Reveal review files");
+    expect(r.text).not.toContain(".er/");
   });
 });
 

--- a/desktop-ui/src/lib/aiReviewAgents.test.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.test.ts
@@ -179,6 +179,60 @@ describe("resolveAgentSummary", () => {
     expect(r.markdown).toBe(false);
     expect(r.text).toBe("1 finding from Security");
   });
+
+  it("prefers summary_markdown when findings are empty", () => {
+    const r = resolveAgentSummary(
+      {
+        summary_markdown: "No correctness issues on changed lines.",
+        agent_summaries: {},
+      },
+      ALL_REVIEWERS,
+      { high: 0, med: 0, low: 0 },
+      0,
+      true,
+      15,
+    );
+    expect(r.markdown).toBe(true);
+    expect(r.text).toBe("No correctness issues on changed lines.");
+  });
+
+  it("mentions file assessments when empty findings and no summary", () => {
+    const r = resolveAgentSummary(
+      { summary_markdown: null, agent_summaries: {} },
+      ALL_REVIEWERS,
+      { high: 0, med: 0, low: 0 },
+      0,
+      true,
+      15,
+    );
+    expect(r.markdown).toBe(false);
+    expect(r.text).toBe("No line findings. 15 files assessed.");
+  });
+
+  it("uses singular file wording for one assessment", () => {
+    const r = resolveAgentSummary(
+      { summary_markdown: null, agent_summaries: {} },
+      ALL_REVIEWERS,
+      { high: 0, med: 0, low: 0 },
+      0,
+      true,
+      1,
+    );
+    expect(r.text).toBe("No line findings. 1 file assessed.");
+  });
+
+  it("keeps inspect-folder message only when truly empty", () => {
+    const r = resolveAgentSummary(
+      { summary_markdown: null, agent_summaries: {} },
+      ALL_REVIEWERS,
+      { high: 0, med: 0, low: 0 },
+      0,
+      true,
+      0,
+    );
+    expect(r.text).toContain("No findings written");
+    expect(r.text).toContain(".er/");
+  });
 });
 
 describe("agentScopedSummaryLine", () => {

--- a/desktop-ui/src/lib/aiReviewAgents.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.ts
@@ -126,30 +126,41 @@ export function resolveAgentSummary(
   counts: { high: number; med: number; low: number },
   fileCount: number,
   isEmpty: boolean,
+  fileRiskCount = 0,
 ): ResolvedSummary {
-  if (isEmpty) {
-    return {
-      text: "No findings written. Inspect the `.er/` folder to see raw review output, or re-run the review skill.",
-      markdown: false,
-    };
-  }
-
   if (useAgentScopedSummary(agentFilter)) {
     const scoped = ai.agent_summaries?.[agentFilter]?.trim();
     if (scoped) return { text: scoped, markdown: true };
-    return {
-      text: agentScopedSummaryLine(agentFilter, counts),
-      markdown: false,
-    };
+    if (!isEmpty) {
+      return {
+        text: agentScopedSummaryLine(agentFilter, counts),
+        markdown: false,
+      };
+    }
   }
 
   if (ai.summary_markdown?.trim()) {
     return { text: ai.summary_markdown.trim(), markdown: true };
   }
 
-  const total = counts.high + counts.med + counts.low;
+  if (!isEmpty) {
+    const total = counts.high + counts.med + counts.low;
+    return {
+      text: `${total} findings across ${fileCount} files.`,
+      markdown: false,
+    };
+  }
+
+  if (fileRiskCount > 0) {
+    const plural = fileRiskCount === 1 ? "file" : "files";
+    return {
+      text: `No line findings. ${fileRiskCount} ${plural} assessed.`,
+      markdown: false,
+    };
+  }
+
   return {
-    text: `${total} findings across ${fileCount} files.`,
+    text: "No findings written. Inspect the `.er/` folder to see raw review output, or re-run the review skill.",
     markdown: false,
   };
 }

--- a/desktop-ui/src/lib/aiReviewAgents.ts
+++ b/desktop-ui/src/lib/aiReviewAgents.ts
@@ -160,7 +160,7 @@ export function resolveAgentSummary(
   }
 
   return {
-    text: "No findings written. Inspect the `.er/` folder to see raw review output, or re-run the review skill.",
+    text: "No findings written. Use Reveal review files to inspect raw output, or re-run the review.",
     markdown: false,
   };
 }

--- a/desktop-ui/src/lib/components/AiReviewCard.svelte
+++ b/desktop-ui/src/lib/components/AiReviewCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import type { AiSnapshot } from "$lib/types";
+  import type { AiSnapshot, FileRiskSnapshot } from "$lib/types";
   import { invoke } from "@tauri-apps/api/core";
+  import { tick } from "svelte";
   import { app } from "$lib/stores/app.svelte";
   import Card from "$lib/components/ui/Card.svelte";
   import SectionLabel from "$lib/components/ui/SectionLabel.svelte";
@@ -31,12 +32,22 @@
   const { ai }: Props = $props();
 
   let open = $state(false);
+  /** User collapsed the auto-open list (findings-empty reviews). */
+  let fileRisksUserCollapsed = $state(false);
+  /** User expanded the list when findings also exist. */
+  let fileRisksUserExpanded = $state(false);
   let summaryOpen = $state(false);
   let staleHelpOpen = $state(false);
   let filter = $state<"all" | "high" | "med" | "low">("all");
 
   const agentLabels = $derived(
     uniqueAgentLabels(ai.findings, Object.keys(ai.agent_summaries ?? {})),
+  );
+
+  const fileRisks = $derived(ai.file_risks ?? []);
+  const fileRisksOpen = $derived(
+    fileRisks.length > 0 &&
+      (ai.findings.length === 0 ? !fileRisksUserCollapsed : fileRisksUserExpanded),
   );
 
   $effect(() => {
@@ -57,6 +68,24 @@
     navigateToFinding(finding);
   }
 
+  async function jumpToFileRisk(risk: FileRiskSnapshot) {
+    const snap = app.snapshot;
+    if (!snap) return;
+    const f = snap.files.find((file) => file.path === risk.path);
+    if (f) {
+      await app.cmd("select_file", { idx: f.source_index });
+      await tick();
+    }
+  }
+
+  function toggleFileRisks() {
+    if (ai.findings.length === 0) {
+      fileRisksUserCollapsed = !fileRisksUserCollapsed;
+    } else {
+      fileRisksUserExpanded = !fileRisksUserExpanded;
+    }
+  }
+
   const agentScopedFindings = $derived(
     filterByAgent(ai.findings, aiReviewFilter.filter),
   );
@@ -75,7 +104,10 @@
   );
 
   const hasReviewContent = $derived(
-    !isEmpty || !!ai.summary_markdown || ai.has_review_json,
+    !isEmpty ||
+      !!ai.summary_markdown ||
+      ai.has_review_json ||
+      fileRisks.length > 0,
   );
 
   const resolvedSummary = $derived(
@@ -85,6 +117,7 @@
       scopedCounts,
       new Set(agentScopedFindings.map((f) => f.file)).size,
       isEmpty,
+      fileRisks.length,
     ),
   );
   const summary = $derived(resolvedSummary.text);
@@ -99,6 +132,12 @@
   const filtered = $derived(
     agentScopedFindings.filter((f) => filter === "all" || f.severity === filter)
   );
+
+  function riskDotClass(risk: string): string {
+    if (risk === "high") return "bg-risk-high";
+    if (risk === "med") return "bg-risk-med";
+    return "bg-risk-low";
+  }
 
   function revealErFolder() {
     invoke("reveal_er_folder").catch(() => {});
@@ -374,6 +413,45 @@
       </svg>
       <span>{open ? "Hide findings" : "View findings"}</span>
     </Button>
+  {/if}
+
+  {#if fileRisks.length > 0}
+    <div class="mt-3 pt-3 border-t border-hairline">
+      <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-info">
+        File risks ({fileRisks.length})
+      </p>
+      {#if fileRisksOpen}
+        <div class="findings-list space-y-1.5 mb-2">
+          {#each fileRisks as risk (risk.path)}
+            <button
+              type="button"
+              onclick={() => jumpToFileRisk(risk)}
+              class="w-full text-left p-2 rounded-md hover:bg-bg border border-transparent hover:border-border block"
+            >
+              <div class="flex items-start gap-2">
+                <span class="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0 {riskDotClass(risk.risk)}"></span>
+                <div class="flex-1 min-w-0">
+                  <div class="text-[11px] font-mono text-muted mb-0.5">{basename(risk.path)}</div>
+                  <div class="text-[13px] text-fg-2 leading-snug">
+                    {risk.risk_reason || risk.summary || `${risk.risk} risk`}
+                  </div>
+                </div>
+              </div>
+            </button>
+          {/each}
+        </div>
+      {/if}
+      <Button
+        variant="secondary"
+        onclick={toggleFileRisks}
+        class="w-full flex items-center justify-center gap-2 normal-case"
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="transition-transform {fileRisksOpen ? 'rotate-180' : ''}">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+        <span>{fileRisksOpen ? "Hide file risks" : "View file risks"}</span>
+      </Button>
+    </div>
   {/if}
 
   <div class="mt-2 flex flex-col gap-1">

--- a/desktop-ui/src/lib/components/CommandPalette.svelte
+++ b/desktop-ui/src/lib/components/CommandPalette.svelte
@@ -79,7 +79,7 @@
       {
         id: "export-review-file",
         label: "Export review to file",
-        description: "Write markdown to .er/export.md",
+        description: "Write markdown export of the current review",
         group: "Actions",
         run: () => { close(); app.cmd("export_to_agent"); },
       },

--- a/desktop-ui/src/lib/components/EmptyState.svelte
+++ b/desktop-ui/src/lib/components/EmptyState.svelte
@@ -147,7 +147,7 @@
               </div>
               <div class="font-medium">Open a local repo</div>
             </div>
-            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in <span class="mono text-fg-2">.er/</span> alongside your code.</p>
+            <p class="text-sm text-fg-3">Pick any git repo. Reviews are stored in shared Easy Review storage, not in the repo.</p>
             <div class="mt-3 text-[11px] text-muted mono">⌘O</div>
           </button>
 

--- a/desktop-ui/src/lib/diffRenderModel.test.ts
+++ b/desktop-ui/src/lib/diffRenderModel.test.ts
@@ -128,6 +128,7 @@ function emptyAi(threads: ThreadSnapshot[] = [], findings: FlatFinding[] = []): 
     unpushed: 0,
     threads,
     findings,
+    file_risks: [],
     has_review_json: false,
     eligible_comment_count: 0,
     triage: null,

--- a/desktop-ui/src/lib/prUrl.test.ts
+++ b/desktop-ui/src/lib/prUrl.test.ts
@@ -29,6 +29,7 @@ function minimalSnapshot(overrides: Partial<AppSnapshot>): AppSnapshot {
       unpushed: 0,
       threads: [],
       findings: [],
+      file_risks: [],
       has_review_json: false,
       eligible_comment_count: 0,
       triage: null,

--- a/desktop-ui/src/lib/resolveTabRoot.test.ts
+++ b/desktop-ui/src/lib/resolveTabRoot.test.ts
@@ -41,6 +41,7 @@ function minimalSnapshot(overrides: Partial<AppSnapshot>): AppSnapshot {
       unpushed: 0,
       threads: [],
       findings: [],
+      file_risks: [],
       has_review_json: false,
       eligible_comment_count: 0,
       triage: null,

--- a/desktop-ui/src/lib/stores/arena.svelte.ts
+++ b/desktop-ui/src/lib/stores/arena.svelte.ts
@@ -239,7 +239,7 @@ class ArenaStore {
     }
   }
 
-  /** Import a completed single review into `.er/review.json` and focus the Review tab filter. */
+  /** Import a completed single review into managed review.json and focus the Review tab filter. */
   private async importSingleReviewToTab(runId: string, snap: ArenaRunSnapshot) {
     const label = agentLabelFromSnapshot(snap);
     try {

--- a/desktop-ui/src/lib/stories/AiReviewCard.stories.ts
+++ b/desktop-ui/src/lib/stories/AiReviewCard.stories.ts
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/svelte";
 import AiReviewCard from "$lib/components/AiReviewCard.svelte";
-import { aiWithFindings, aiEmpty, aiProfessorOnly, aiMultiAgent } from "./fixtures";
+import {
+  aiWithFindings,
+  aiEmpty,
+  aiProfessorOnly,
+  aiMultiAgent,
+  aiFileRisksOnly,
+} from "./fixtures";
 
 const meta = {
   title: "RightPanel/AiReviewCard",
@@ -14,6 +20,7 @@ type Story = StoryObj<typeof meta>;
 export const Fresh: Story = { args: { ai: aiWithFindings } };
 export const Stale: Story = { args: { ai: { ...aiWithFindings, fresh: false } } };
 export const NoFindings: Story = { args: { ai: aiEmpty } };
+export const FileRisksOnly: Story = { args: { ai: aiFileRisksOnly } };
 export const LongSummaryCollapsed: Story = {
   args: {
     ai: {

--- a/desktop-ui/src/lib/stories/BrowserView.stories.ts
+++ b/desktop-ui/src/lib/stories/BrowserView.stories.ts
@@ -63,6 +63,7 @@ function setupAnnotations(items: UiAnnotation[], annotateMode = false) {
       unpushed: 0,
       threads: [],
       findings: [],
+      file_risks: [],
       has_review_json: false,
       eligible_comment_count: 0,
       triage: null,

--- a/desktop-ui/src/lib/stories/fixtures.ts
+++ b/desktop-ui/src/lib/stories/fixtures.ts
@@ -288,6 +288,7 @@ export const aiWithFindings: AiSnapshot = {
       agent_label: "General",
     },
   ],
+  file_risks: [],
   has_review_json: true,
   eligible_comment_count: 0,
   triage: null,
@@ -309,7 +310,60 @@ export const aiEmpty: AiSnapshot = {
   unpushed: 0,
   threads: [],
   findings: [],
+  file_risks: [],
   has_review_json: false,
+  eligible_comment_count: 0,
+  triage: null,
+};
+
+/** Completed review with file risk assessments but no line findings. */
+export const aiFileRisksOnly: AiSnapshot = {
+  fresh: true,
+  stale_reason: null,
+  summary_markdown:
+    "No correctness, security, or reliability findings were identified on changed lines. The checklist records the key manual verification points.",
+  agent_summaries: {},
+  high: 0,
+  med: 0,
+  low: 0,
+  local_comment_count: 0,
+  github_comment_count: 0,
+  comments: 0,
+  questions: 0,
+  notes: 0,
+  unpushed: 0,
+  threads: [],
+  findings: [],
+  file_risks: [
+    {
+      path: "packages/discovery-platform/src/lib/components/editor/embeddable/buildEmbedRef.ts",
+      risk: "high",
+      risk_reason:
+        "Defines the persisted embed wire format and validates hrefs before they reach rendered links.",
+      summary: "Adds safe relative source metadata to embed serialization and parsing.",
+    },
+    {
+      path: "packages/discovery-platform/src/lib/components/editor/extensions/ReportEmbed.svelte.ts",
+      risk: "high",
+      risk_reason:
+        "Replaces the report node view and adds editor transactions for persisted title changes.",
+      summary: "Uses the report card node view, persists titles, and handles input/link events.",
+    },
+    {
+      path: "packages/discovery-platform/src/lib/components/editor/ReportEmbedCard.svelte",
+      risk: "med",
+      risk_reason:
+        "Introduces persisted title editing and source-link rendering in the report node UI.",
+      summary: "Renders report embeds in a card with fallback titles and a source link.",
+    },
+    {
+      path: "packages/discovery-platform/src/lib/components/editor/ReportEmbedCard.test.ts",
+      risk: "low",
+      risk_reason: "Adds focused component coverage for the new card interactions.",
+      summary: "Tests source visibility, title editing, and renderer errors.",
+    },
+  ],
+  has_review_json: true,
   eligible_comment_count: 0,
   triage: null,
 };
@@ -362,6 +416,7 @@ export const aiProfessorOnly: AiSnapshot = {
       severity: "med",
     },
   ],
+  file_risks: [],
   has_review_json: true,
   eligible_comment_count: 0,
   triage: null,

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -173,6 +173,14 @@ export interface FlatFinding {
   responses?: FindingResponseSnapshot[];
 }
 
+/** Per-file risk assessment from review.json — distinct from line findings. */
+export interface FileRiskSnapshot {
+  path: string;
+  risk: "high" | "med" | "low";
+  risk_reason: string;
+  summary: string;
+}
+
 export interface TriagePriorityFileSnapshot {
   path: string;
   reason: string;
@@ -209,6 +217,8 @@ export interface AiSnapshot {
   unpushed: number;
   threads: ThreadSnapshot[];
   findings: FlatFinding[];
+  /** Per-file risk assessments from review.json (not counted as findings). */
+  file_risks: FileRiskSnapshot[];
   /** Whether `{er_dir}/review.json` exists (batch validate target). */
   has_review_json: boolean;
   /** Top-level GitHub comments eligible for batch validate (!resolved, !outdated). */

--- a/skills/REVIEW_RULES.md
+++ b/skills/REVIEW_RULES.md
@@ -9,7 +9,7 @@ See also: [`REVIEW_PHILOSOPHY.md`](REVIEW_PHILOSOPHY.md) for severity model and 
 - **Two-dot diff only:** `git diff <base>` — never `main...HEAD` (staleness mismatch with `er`)
 - Always **`--unified=20 --no-color --no-ext-diff`** (matches desktop engine)
 - **Prepared-diff path (desktop):** hash `{output_dir}/diff-tmp`; agent must **not** re-run `git diff`
-- **TUI / skill path:** `git diff … > .er/diff-tmp` (or `{output_dir}/diff-tmp`), then hash that file
+- **Agent capture path:** `git diff … > {output_dir}/diff-tmp`, then hash that file — always the managed review bucket, never a repo-local `.er/`
 
 ## Annotate and anchor
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a review finishes with empty `findings[]` arrays (but populated per-file `risk` / `risk_reason` / `summary` plus `summary.md`), the AI Review card showed “No findings written…” and 0/0/0 — hiding the completed review.

This keeps HIGH/MED/LOW as **findings-only**, and:

- Prefers `summary.md` over a generic empty message when findings are empty
- Falls back to `No line findings. N files assessed.` when there is no summary but file risks exist
- Adds a separate **File risks** section in `AiReviewCard` (auto-expanded when findings are empty; toggle when mixed)
- Removes repo-local `.er/` fallbacks from empty-state/onboarding copy and agent prompt defaults — writes target managed shared storage (`er_dir()` / `{output_dir}`)

## Test plan

- [x] `bun test src/lib/aiReviewAgents.test.ts` (incl. empty-summary + no-`.er/` assertion)
- [x] `bun test src` (594 pass)
- [x] `bun run check` (0 errors)
- [x] `cargo test -p er-desktop --lib ai_snapshot_includes_sorted_file_risks`
- [x] `./scripts/er-tui.sh test -p er-engine review_rules_preamble`
- [ ] Manually: open a PR review whose `review.json` has file risks and empty findings — confirm summary shows and File risks list is usable; HIGH/MED/LOW stay 0; Reveal review files opens managed storage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ff56464-afad-491b-9fd4-c3ff2ec896f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ff56464-afad-491b-9fd4-c3ff2ec896f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

