### PR TITLE
fix(desktop): align composer width with inline threads

### DIFF
--- a/desktop-ui/src/lib/components/DiffComposer.svelte
+++ b/desktop-ui/src/lib/components/DiffComposer.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
   import { app } from "$lib/stores/app.svelte";
   import { diffSel } from "$lib/stores/diffSelection.svelte";
-  import type { DiffViewMode } from "$lib/stores/app.svelte";
 
   interface Props {
     /** Absolute top position in px. When set, renders absolute (flat mode); otherwise sticky. */
     topPx?: number;
-    viewMode?: DiffViewMode;
+    /** Left inset for Guide pillar rail — keep composer aligned with the diff column. */
+    offsetLeftPx?: number;
   }
-  const { topPx, viewMode = "unified" }: Props = $props();
-
-  const gutterInsetPx = $derived(viewMode === "split" ? 80 : 40);
+  const { topPx, offsetLeftPx = 0 }: Props = $props();
 
   const canSubmit = $derived(diffSel.text.trim().length > 0);
   let composerEl: HTMLTextAreaElement | null = $state(null);
@@ -96,9 +94,9 @@
   tabindex="-1"
   onkeydown={() => {}}
   style={topPx !== undefined
-    ? `position:absolute;top:${topPx}px;left:calc(${gutterInsetPx}px + 0.75rem);right:1rem;z-index:20`
+    ? `position:absolute;top:${topPx}px;left:${offsetLeftPx}px;right:0;z-index:20`
     : undefined}
-  class="{topPx === undefined ? 'sticky bottom-0 left-0 right-0 mx-4 mb-4 mt-2' : 'mb-4 mt-2'} rounded-lg overflow-hidden font-sans shadow-[0_20px_40px_-8px_rgba(0,0,0,0.7),0_0_0_1px_color-mix(in_srgb,var(--color-fg)_4%,transparent)]
+  class="{topPx === undefined ? 'sticky bottom-0 left-0 right-0 mb-4 mt-2' : 'mb-4 mt-2'} rounded-lg overflow-hidden font-sans shadow-[0_20px_40px_-8px_rgba(0,0,0,0.7),0_0_0_1px_color-mix(in_srgb,var(--color-fg)_4%,transparent)]
          {diffSel.kind === 'question' || diffSel.kind === 'note'
            ? 'border border-question/40 bg-card'
            : 'border border-action/40 bg-card'}"

--- a/desktop-ui/src/lib/components/FlatDiffView.svelte
+++ b/desktop-ui/src/lib/components/FlatDiffView.svelte
@@ -2209,7 +2209,7 @@
       </div>
 
       {#if diffSel.composerOpen}
-        <DiffComposer topPx={composerTopPx} {viewMode} />
+        <DiffComposer topPx={composerTopPx} offsetLeftPx={tourActive ? RAIL_W : 0} />
       {/if}
     {/if}
   </div>

--- a/desktop-ui/src/lib/components/InlineFinding.svelte
+++ b/desktop-ui/src/lib/components/InlineFinding.svelte
@@ -200,7 +200,7 @@
 
 <div
   id="finding-{finding.id}"
-  class="mx-4 my-3 border rounded-lg overflow-hidden font-sans scroll-mt-16 min-w-0 max-w-full"
+  class="my-3 border rounded-lg overflow-hidden font-sans scroll-mt-16 min-w-0 max-w-full"
   style="border-color: color-mix(in srgb, {severityColor} 30%, transparent); background: color-mix(in srgb, {severityColor} 4%, transparent);"
 >
   <!-- Header -->

--- a/desktop-ui/src/lib/components/InlineThread.svelte
+++ b/desktop-ui/src/lib/components/InlineThread.svelte
@@ -195,7 +195,7 @@
 
 <div
   id={thread.id}
-  class="{variant === 'panel' ? '' : 'mx-4 my-3'} rounded-lg overflow-hidden font-sans border scroll-mt-16 min-w-0 max-w-full {thread.stale ? 'opacity-60' : ''} {isLocal ? 'bg-question-surface border-question-border' : 'bg-card border-border'}"
+  class="{variant === 'panel' ? '' : 'my-3'} rounded-lg overflow-hidden font-sans border scroll-mt-16 min-w-0 max-w-full {thread.stale ? 'opacity-60' : ''} {isLocal ? 'bg-question-surface border-question-border' : 'bg-card border-border'}"
 >
   <!-- Header -->
   <div class="px-3 py-2 border-b border-hairline flex items-center gap-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The comment/question/note composer was inset past the line gutter (`left: gutter + 0.75rem`), so it didn't match the width of saved inline threads and findings.

## Changes
- DiffComposer spans the full diff column (`left`/`right` edge-aligned), with a Guide-rail offset when the pillar rail is open
- Inline threads and findings drop the extra `mx-4` inset so writing and saved cards share the same width as the diff view

## Test plan
- [ ] Open a diff, select lines, open the question/comment/note composer — width should match the code band
- [ ] Save a question/comment/note — the inline card should match the composer width
- [ ] Confirm AI findings cards also span the same width
- [ ] In Guide mode, composer stays in the diff column (not over the pillar rail)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e81bea7b-510f-4527-bd58-0efd4a4b3c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e81bea7b-510f-4527-bd58-0efd4a4b3c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

