### PR TITLE
fix(ai): keep review agents in the repo and stop truncating their log

### DIFF
--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -129,6 +129,11 @@ pub fn review_rules_preamble(
 - `confidence`: `confirmed` | `informational` | `tentative` (with `verification_plan`)
 - `evidence`: cite files/ranges read; budget ~10 reads per finding (no global session cap)
 
+### Scope
+- Investigate only within the repository checkout you were started in and the artifacts in the output directory. Do **not** run filesystem-wide searches (`find /`, scanning unrelated project directories) and do **not** `git clone` this or any other repository to a new location.
+- If you were given a prepared PR diff and this working tree does not contain the PR's commits, fetch the ref once — `git fetch origin pull/<N>/head:refs/er/pr-<N>` — then read with `git show refs/er/pr-<N>:<path>` and `git grep <pattern> refs/er/pr-<N>`. **Never** `git checkout` / `git switch`: the user is working in this tree.
+- If you are not inside a repository checkout at all, the prepared diff plus `gh` (`gh pr view`, `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>`) is your only evidence. Do not go looking for a copy of the repo on disk — mark the finding `tentative` with a `verification_plan` instead.
+
 ### Finding caps
 - Max {per_file} findings per file, max {total} total
 - {categories}
@@ -1177,7 +1182,7 @@ pub fn build_review_prompt_remote(
     format!(
         r#"You are a code reviewer. Perform a thorough review of the GitHub PR diff and write results to `{safe_output_dir}/`.
 
-Note: `gh pr diff` returns less context than local `git diff` — agentic verification matters more.
+Note: `gh pr diff` returns less context than local `git diff`, so verification matters more — do it from the checkout you were started in (fetch the PR ref, see Scope) or via `gh`, never by searching the filesystem for a local copy. When you cannot verify, mark the finding `tentative`.
 
 {preamble}
 
@@ -1784,6 +1789,38 @@ mod tests {
         assert!(preamble.contains("**no `style`**"));
         assert!(preamble.contains("P0"));
         assert!(preamble.contains("two-dot"));
+    }
+
+    #[test]
+    fn review_rules_preamble_bounds_investigation_scope() {
+        let preamble = review_rules_preamble(".er", false, FindingCaps::general(), None);
+        assert!(preamble.contains("### Scope"));
+        assert!(preamble.contains("find /"));
+        assert!(preamble.contains("`git clone`"));
+        assert!(preamble.contains("git fetch origin pull/<N>/head:refs/er/pr-<N>"));
+        assert!(preamble.contains("git show refs/er/pr-<N>:<path>"));
+        // `git worktree add` would materialize a second checkout at an agent-chosen path —
+        // the very behaviour the Scope section exists to prevent.
+        assert!(!preamble.contains("git worktree"));
+    }
+
+    #[test]
+    fn scope_rules_reach_every_review_prompt_family() {
+        let local = build_review_prompt_local_managed("main", "branch", "/tmp/er-test");
+        let prepared = build_review_prompt_prepared_diff("branch", "/tmp/out", "main", "feat/x");
+        let remote = build_review_prompt_remote("owner", "repo", 42, "/tmp/cache");
+        let expert = build_expert_review_prompt_prepared_diff("branch", "/tmp/out", "security");
+        for prompt in [&local, &prepared, &remote, &expert] {
+            assert!(prompt.contains("### Scope"), "missing Scope: {prompt}");
+        }
+    }
+
+    #[test]
+    fn remote_prompt_points_verification_at_checkout_not_filesystem() {
+        let prompt = build_review_prompt_remote("owner", "repo", 42, "/tmp/cache");
+        assert!(!prompt.contains("agentic verification matters more"));
+        assert!(prompt.contains("never by searching the filesystem for a local copy"));
+        assert!(prompt.contains("mark the finding `tentative`"));
     }
 
     #[test]

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// Review agents never need a second checkout: they run inside the repo (or, for a remote PR
+/// whose repo is not checked out locally, work from the prepared diff plus `gh`). Cloning has
+/// only ever produced stray copies under `/tmp` that later runs then read stale code out of.
+/// A speed bump rather than a wall — `gh repo clone` and `cd x && git clone` slip past it.
+const CLONE_DENY_RULE: &str = "Bash(git clone*)";
+
 impl App {
     // ── Comment System ──
 
@@ -2222,6 +2228,7 @@ impl App {
         let repo_root = self.tab().repo_root.clone();
         let er_dir_path = self.tab().er_dir();
         let is_remote = self.tab().is_remote();
+        let remote_repo = self.tab().remote_repo.clone();
         let selection = if let Some(selection) = self.pending_ai_selection_override.clone() {
             selection
         } else {
@@ -2377,6 +2384,11 @@ impl App {
                         "Bash(rg *)",
                         "Bash(git grep*)",
                         "Bash(git diff*)",
+                        "Bash(git show*)",
+                        // Narrow on purpose: a bare `git fetch*` would also permit
+                        // `git fetch origin +refs/heads/*:refs/heads/*`, which can
+                        // clobber the user's local branches.
+                        "Bash(git fetch origin pull/*)",
                         "Bash(shasum*)",
                         "Bash(sha256sum*)",
                         "Bash(mkdir*)",
@@ -2386,11 +2398,28 @@ impl App {
                         agent_args.insert(0, rule.to_string());
                         agent_args.insert(0, "--allowedTools".to_string());
                     }
+                    agent_args.insert(0, CLONE_DENY_RULE.to_string());
+                    agent_args.insert(0, "--disallowedTools".to_string());
                 }
 
-                // In remote mode, run from the cache dir so relative paths resolve there.
-                // The agent fetches the diff via `gh` — no local repo access needed.
-                let work_dir = if is_remote { &er_dir_path } else { &repo_root };
+                // Remote mode has no repo around it, which is what sends the agent hunting
+                // the filesystem for a copy of the code. When the local checkout *is* the
+                // PR's repo, run there so verification reads hit real files; otherwise fall
+                // back to the artifact dir. Output dirs are absolute either way.
+                let remote_checkout = if is_remote {
+                    remote_repo
+                        .as_deref()
+                        .and_then(|slug| crate::github::local_checkout_for_repo(&repo_root, slug))
+                } else {
+                    None
+                };
+                let work_dir = if let Some(checkout) = &remote_checkout {
+                    checkout
+                } else if is_remote {
+                    &er_dir_path
+                } else {
+                    &repo_root
+                };
                 let mut cmd = std::process::Command::new(&agent_cmd);
                 cmd.args(&agent_args)
                     .current_dir(work_dir)
@@ -2422,7 +2451,7 @@ impl App {
                             let display = if is_stream_json {
                                 parse_stream_json_line(&line)
                             } else {
-                                Some(truncate_str(line.trim(), 120))
+                                Some(line.trim().to_string())
                             };
                             if let Some(text) = display.filter(|text| !text.is_empty()) {
                                 let _ = log_tx_out.send(AgentLogEntry {
@@ -2787,6 +2816,7 @@ impl App {
         let task_id = task.id.clone();
         let er_dir = target.er_dir.clone();
         let repo_root = target.repo_root.clone();
+        let remote_repo = target.remote_repo.clone();
         let is_remote = target.remote_repo.is_some();
         let managed_local = target.managed_local;
         // For local-branch views (cache-dir er_dir) treat like remote — cwd is
@@ -2843,6 +2873,8 @@ impl App {
                             "Bash(grep *)",
                             "Bash(rg *)",
                             "Bash(git grep*)",
+                            "Bash(git show*)",
+                            "Bash(git fetch origin pull/*)",
                             "Bash(cp .er/*)",
                             "Bash(shasum*)",
                             "Bash(sha256sum*)",
@@ -2857,6 +2889,9 @@ impl App {
                             "Bash(gh pr *)",
                             "Bash(cp .er/*)",
                             "Bash(git diff*)",
+                            "Bash(git grep*)",
+                            "Bash(git show*)",
+                            "Bash(git fetch origin pull/*)",
                             "Bash(shasum*)",
                             "Bash(sha256sum*)",
                             "Bash(mkdir*)",
@@ -2866,11 +2901,24 @@ impl App {
                         agent_args.insert(0, rule.to_string());
                         agent_args.insert(0, "--allowedTools".to_string());
                     }
+                    agent_args.insert(0, CLONE_DENY_RULE.to_string());
+                    agent_args.insert(0, "--disallowedTools".to_string());
                 }
 
                 // managed_local: er_dir is outside repo_root but git must run from repo_root.
                 // is_remote / is_cache_er_dir without managed_local: cwd = er_dir (cache-dir or remote).
-                let work_dir = if managed_local || (!is_remote && !is_cache_er_dir) {
+                // A remote PR whose repo *is* the local checkout runs there instead, so the
+                // agent can verify against real code rather than hunting the filesystem.
+                let remote_checkout = if is_remote {
+                    remote_repo
+                        .as_deref()
+                        .and_then(|slug| crate::github::local_checkout_for_repo(&repo_root, slug))
+                } else {
+                    None
+                };
+                let work_dir = if let Some(checkout) = &remote_checkout {
+                    checkout
+                } else if managed_local || (!is_remote && !is_cache_er_dir) {
                     &repo_root
                 } else {
                     &er_dir
@@ -2901,7 +2949,7 @@ impl App {
                             let display = if is_stream_json {
                                 parse_stream_json_line(&line)
                             } else {
-                                Some(truncate_str(line.trim(), 120))
+                                Some(line.trim().to_string())
                             };
                             if let Some(text) = display.filter(|t| !t.is_empty()) {
                                 let _ = log_tx_out.send(AgentLogEntry {

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -7224,7 +7224,7 @@ fn parse_stream_json_line(line: &str) -> Option<String> {
                         };
                         let trimmed = text.trim();
                         if !trimmed.is_empty() {
-                            parts.push(truncate_str(trimmed, 120));
+                            parts.push(trimmed.to_string());
                         }
                     }
                     "tool_use" => {
@@ -7247,12 +7247,12 @@ fn parse_stream_json_line(line: &str) -> Option<String> {
                             "Bash" => input
                                 .and_then(|i| i.get("command"))
                                 .and_then(|c| c.as_str())
-                                .map(|c| truncate_str(c, 60))
+                                .map(|c| c.to_string())
                                 .unwrap_or_default(),
                             "Glob" | "Grep" => input
                                 .and_then(|i| i.get("pattern"))
                                 .and_then(|p| p.as_str())
-                                .map(|p| truncate_str(p, 40))
+                                .map(|p| p.to_string())
                                 .unwrap_or_default(),
                             _ => String::new(),
                         };
@@ -7300,15 +7300,6 @@ fn shorten_path(path: &str) -> String {
         format!("{}/{}", parts[1], parts[0])
     } else {
         parts[0].to_string()
-    }
-}
-
-fn truncate_str(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let boundary = s.char_indices().nth(max).map(|(i, _)| i).unwrap_or(s.len());
-        format!("{}…", &s[..boundary])
     }
 }
 
@@ -9793,46 +9784,6 @@ mod tests {
         assert!(tab.ai.github_comments.is_none());
     }
 
-    // ── truncate_str (multi-byte UTF-8 regression) ──
-
-    #[test]
-    fn truncate_str_emoji_does_not_panic() {
-        // Emoji are multi-byte (4 bytes each). Slicing at byte offset would panic.
-        let s = "hello 🎉🎊🎈 world";
-        let result = truncate_str(s, 8);
-        // Should get 8 chars + ellipsis, no panic
-        assert_eq!(result, "hello 🎉🎊…");
-    }
-
-    #[test]
-    fn truncate_str_cjk_chars() {
-        let s = "你好世界测试";
-        let result = truncate_str(s, 4);
-        assert_eq!(result, "你好世界…");
-    }
-
-    #[test]
-    fn truncate_str_mixed_ascii_and_multibyte() {
-        let s = "café résumé";
-        let result = truncate_str(s, 5);
-        assert_eq!(result, "café …");
-    }
-
-    #[test]
-    fn truncate_str_exact_multibyte_boundary() {
-        let s = "🎉🎊"; // 2 emoji, each 4 bytes
-        let result = truncate_str(s, 2);
-        // Exactly at limit, no truncation needed
-        assert_eq!(result, "🎉🎊");
-    }
-
-    #[test]
-    fn truncate_str_single_emoji_within_limit() {
-        let s = "🎉";
-        let result = truncate_str(s, 5);
-        assert_eq!(result, "🎉");
-    }
-
     // ── parse_stream_json_line ──
 
     #[test]
@@ -9939,6 +9890,50 @@ mod tests {
     fn parse_stream_json_unknown_type_returns_none() {
         let line = r#"{"type":"unknown_event","data":"something"}"#;
         assert_eq!(parse_stream_json_line(line), None);
+    }
+
+    // ── no truncation: the log is the user's audit trail of what the agent ran ──
+
+    #[test]
+    fn parse_stream_json_long_bash_command_not_truncated() {
+        // 60-char cap used to cut this mid-flag, hiding what the agent actually ran.
+        let cmd = r#"find / -maxdepth 6 -iname "discovery-api" -type d 2>/dev/null | head -20"#;
+        assert!(cmd.chars().count() > 60);
+        let line = format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","name":"Bash","input":{{"command":{}}}}}]}}}}"#,
+            serde_json::to_string(cmd).unwrap()
+        );
+        let result = parse_stream_json_line(&line).expect("bash event should render");
+        assert_eq!(result, format!("→ Bash {cmd}"));
+        assert!(!result.contains('…'), "result = {result}");
+    }
+
+    #[test]
+    fn parse_stream_json_long_grep_pattern_not_truncated() {
+        let pattern = "timelapse|stitching|compilation|ffmpeg|segmentation|playback_offset";
+        assert!(pattern.chars().count() > 40);
+        let line = format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","name":"Grep","input":{{"pattern":{}}}}}]}}}}"#,
+            serde_json::to_string(pattern).unwrap()
+        );
+        let result = parse_stream_json_line(&line).expect("grep event should render");
+        assert_eq!(result, format!("→ Grep {pattern}"));
+        assert!(!result.contains('…'), "result = {result}");
+    }
+
+    #[test]
+    fn parse_stream_json_long_assistant_text_not_truncated() {
+        let text = "Now writing the review artifacts based on confirmed backend evidence \
+                    gathered from the stitching service, the compilation service and the \
+                    ffmpeg helpers referenced by the diff.";
+        assert!(text.chars().count() > 120);
+        let line = format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":{}}}]}}}}"#,
+            serde_json::to_string(text).unwrap()
+        );
+        let result = parse_stream_json_line(&line).expect("text event should render");
+        assert_eq!(result, text);
+        assert!(!result.contains('…'), "result = {result}");
     }
 
     // ── shorten_path ──

--- a/crates/er-engine/src/github.rs
+++ b/crates/er-engine/src/github.rs
@@ -2610,15 +2610,35 @@ mod tests {
 
     #[test]
     fn slug_match_is_case_insensitive() {
-        assert!(owner_repo_matches_slug("Acme", "Discovery", "acme/discovery"));
-        assert!(owner_repo_matches_slug("acme", "discovery", "Acme/Discovery"));
-        assert!(owner_repo_matches_slug("acme", "discovery", "acme/discovery.git"));
+        assert!(owner_repo_matches_slug(
+            "Acme",
+            "Discovery",
+            "acme/discovery"
+        ));
+        assert!(owner_repo_matches_slug(
+            "acme",
+            "discovery",
+            "Acme/Discovery"
+        ));
+        assert!(owner_repo_matches_slug(
+            "acme",
+            "discovery",
+            "acme/discovery.git"
+        ));
     }
 
     #[test]
     fn slug_match_rejects_other_repos_and_malformed_slugs() {
-        assert!(!owner_repo_matches_slug("acme", "discovery", "acme/discovery-api"));
-        assert!(!owner_repo_matches_slug("acme", "discovery", "other/discovery"));
+        assert!(!owner_repo_matches_slug(
+            "acme",
+            "discovery",
+            "acme/discovery-api"
+        ));
+        assert!(!owner_repo_matches_slug(
+            "acme",
+            "discovery",
+            "other/discovery"
+        ));
         assert!(!owner_repo_matches_slug("acme", "discovery", "discovery"));
         assert!(!owner_repo_matches_slug("acme", "discovery", ""));
     }

--- a/crates/er-engine/src/github.rs
+++ b/crates/er-engine/src/github.rs
@@ -647,6 +647,33 @@ pub fn get_repo_info(repo_root: &str) -> Result<(String, String)> {
     parse_owner_repo_from_remote(&remote)
 }
 
+/// True when `owner`/`repo` name the same GitHub repository as the `"owner/repo"` slug.
+/// GitHub treats owner and repo names case-insensitively.
+fn owner_repo_matches_slug(owner: &str, repo: &str, slug: &str) -> bool {
+    let (slug_owner, slug_repo) = match slug.split_once('/') {
+        Some(parts) => parts,
+        None => return false,
+    };
+    let repo = repo.strip_suffix(".git").unwrap_or(repo);
+    let slug_repo = slug_repo.strip_suffix(".git").unwrap_or(slug_repo);
+    owner.eq_ignore_ascii_case(slug_owner) && repo.eq_ignore_ascii_case(slug_repo)
+}
+
+/// The local checkout to run a remote PR review in, when `repo_root`'s `origin` is the same
+/// GitHub repository the PR belongs to (`remote_repo` is an `"owner/repo"` slug).
+///
+/// Remote reviews otherwise run from the managed artifact directory with no repository
+/// around them, which pushes the agent into hunting the filesystem for a copy of the code.
+/// Returns `None` whenever the match cannot be established — no origin, unparseable remote,
+/// or a different repository — so the caller keeps the artifact-dir behaviour.
+pub fn local_checkout_for_repo(repo_root: &str, remote_repo: &str) -> Option<String> {
+    if repo_root.is_empty() || remote_repo.is_empty() {
+        return None;
+    }
+    let (owner, repo) = get_repo_info(repo_root).ok()?;
+    owner_repo_matches_slug(&owner, &repo, remote_repo).then(|| repo_root.to_string())
+}
+
 /// Fetch all review comments for a PR
 pub fn gh_pr_comments(
     owner: &str,
@@ -2566,6 +2593,41 @@ pub fn owner_repo_storage_slug(owner: &str, repo: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── local checkout matching (remote PR reviews) ──
+
+    #[test]
+    fn ssh_and_https_origins_resolve_to_the_same_slug() {
+        for remote in [
+            "git@github.com:Acme/discovery.git",
+            "https://github.com/Acme/discovery.git",
+            "https://github.com/Acme/discovery",
+        ] {
+            let (owner, repo) = parse_owner_repo_from_remote(remote).unwrap();
+            assert_eq!((owner.as_str(), repo.as_str()), ("Acme", "discovery"));
+        }
+    }
+
+    #[test]
+    fn slug_match_is_case_insensitive() {
+        assert!(owner_repo_matches_slug("Acme", "Discovery", "acme/discovery"));
+        assert!(owner_repo_matches_slug("acme", "discovery", "Acme/Discovery"));
+        assert!(owner_repo_matches_slug("acme", "discovery", "acme/discovery.git"));
+    }
+
+    #[test]
+    fn slug_match_rejects_other_repos_and_malformed_slugs() {
+        assert!(!owner_repo_matches_slug("acme", "discovery", "acme/discovery-api"));
+        assert!(!owner_repo_matches_slug("acme", "discovery", "other/discovery"));
+        assert!(!owner_repo_matches_slug("acme", "discovery", "discovery"));
+        assert!(!owner_repo_matches_slug("acme", "discovery", ""));
+    }
+
+    #[test]
+    fn local_checkout_for_repo_needs_both_inputs() {
+        assert_eq!(local_checkout_for_repo("", "acme/discovery"), None);
+        assert_eq!(local_checkout_for_repo("/tmp/some-repo", ""), None);
+    }
 
     #[test]
     fn parse_standard_url() {

--- a/crates/er-tui/src/ui/panel.rs
+++ b/crates/er-tui/src/ui/panel.rs
@@ -149,7 +149,10 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
     // the wrapped line count is known. Only borders LEFT + horizontal padding, so the inner
     // height is the full area height.
     let scroll = if content == PanelContent::AgentLog && tab.agent_log_auto_scroll {
-        lines.len().saturating_sub(area.height as usize).min(u16::MAX as usize) as u16
+        lines
+            .len()
+            .saturating_sub(area.height as usize)
+            .min(u16::MAX as usize) as u16
     } else {
         tab.panel_scroll
     };

--- a/crates/er-tui/src/ui/panel.rs
+++ b/crates/er-tui/src/ui/panel.rs
@@ -144,9 +144,17 @@ fn render_panel(f: &mut Frame, area: Rect, app: &App, content: PanelContent) {
         .style(Style::default().bg(styles::SURFACE()))
         .padding(Padding::new(0, 1, 0, 0));
 
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .scroll((tab.panel_scroll, 0));
+    // `drain_agent_log` tracks auto-scroll in *entries*, but each entry word-wraps into one
+    // or more lines — so the stored offset under-shoots the bottom. Recompute here, where
+    // the wrapped line count is known. Only borders LEFT + horizontal padding, so the inner
+    // height is the full area height.
+    let scroll = if content == PanelContent::AgentLog && tab.agent_log_auto_scroll {
+        lines.len().saturating_sub(area.height as usize).min(u16::MAX as usize) as u16
+    } else {
+        tab.panel_scroll
+    };
+
+    let paragraph = Paragraph::new(lines).block(block).scroll((scroll, 0));
 
     f.render_widget(paragraph, area);
 }


### PR DESCRIPTION
## The Problem

Two defects, found while reviewing a PR through the AI Hub.

**The Agent Output log hid what the agent ran.** Bash commands were cut at 60 characters, Glob/Grep patterns at 40, assistant text at 120 (plus 120 on the non-stream-json fallback). Both frontends already handle long lines without clipping — the TUI word-wraps and chunks unbroken tokens, the desktop rows use `break-all` — so the caps only removed the audit trail.

**Remote PR reviews had no repo to work in, so the agent went looking for one.** `work_dir = if is_remote { er_dir } else { repo_root }` means a remote review (TUI *and* desktop, which sets `managed_local: !is_remote`) starts in the managed artifact dir with no repository around it. The prompt then told it *"`gh pr diff` returns less context than local `git diff` — agentic verification matters more"* while giving it nowhere legitimate to look, and nothing ruled anything out (`--allowedTools` is additive in Claude Code — it grants, it never restricts).

The result in one real review: `find / -maxdepth 6 -iname "discovery-api"`, then a run of greps against `/private/tmp/discovery-pr-1410-src` — **a leftover checkout from an earlier review of a different PR**. Part of that review's evidence was read out of a stale tree. The 60-char cap is why it went unnoticed.

## How we fix

**Log fidelity.** Removed all five truncation call sites and deleted `truncate_str` (it would otherwise be dead code and fail CI's `-D warnings`). `shorten_path` is untouched — it shortens Read/Write/Edit paths for readability and adds no `…`.

The TUI Log panel's auto-scroll tracked *entries* (`agent_log.len()`) while rendering *wrapped lines*, so it already under-shot the bottom; longer entries would have made "scroll to bottom" land mid-log. It now computes the offset at render time from the wrapped line count.

**Scope.** New `github::local_checkout_for_repo` (built on the existing `get_repo_info` / `parse_owner_repo_from_remote`): a remote review now runs from the local checkout when its `origin` is the PR's repo, and falls back to the artifact dir otherwise. A new `### Scope` section in `review_rules_preamble()` — the single preamble behind general, expert, professor and triage reviews — rules out `find /` and `git clone`, and gives the agent the right way to read a PR's version of a file without a second checkout: `git fetch origin pull/<N>/head:refs/er/pr-<N>` then `git show`/`git grep` against that ref. The remote note now points verification at the checkout or `gh`, and at `tentative` when neither works.

## Design Choices and considerations

- **`git worktree add` is deliberately not offered.** It materializes a second working copy at a path the agent picks — the exact behaviour being banned — and leaves `.git/worktrees/` entries behind. `git show <ref>:<path>` covers the real need.
- **The Scope text is conditional, not declarative.** The same preamble ships to local branch/unstaged/staged reviews where the working tree *is* the subject; a flat "the checkout is not the PR's branch" would be wrong there and would send those agents fetching refs that don't exist.
- **`diff_hash` is unchanged.** The fetched ref is for reading code only — the hash still comes from `gh pr diff` / the prepared `diff-tmp`, which is what `er` itself hashes, so sidecars don't go stale.
- **The narrow fetch grant is on purpose.** `Bash(git fetch origin pull/*)` rather than `Bash(git fetch*)`, which would also permit `git fetch origin +refs/heads/*:refs/heads/*` and could clobber local branches. Fetched refs land under `refs/er/*` and never touch the user's branches or working tree.
- **`--disallowedTools "Bash(git clone*)"` is a speed bump, not a wall** — `gh repo clone` and `cd x && git clone` slip past it. `find /` is not blocked: `find /` vs `find .` doesn't pattern-match reliably.

## Tests

Added: three in `state/mod.rs` proving no truncation of a >60-char Bash command (the literal `find /` line from the transcript), a >40-char Grep pattern and >120-char assistant text — each asserts exact equality *and* absence of `…`. Three in `prompts.rs`: Scope present / `git worktree` absent, Scope reaching all four prompt families, and the reworded remote note. Four in `github.rs` for SSH+HTTPS origin parsing, case-insensitive slug matching, rejecting `acme/discovery-api` vs `acme/discovery`, and empty-input guards.

Removed: the five `truncate_str_*` tests, with the function they covered.

Red→green: temporarily reinstating a 60-char cap fails with `left: "→ Bash find / … 2>/dev/nul…"` vs `right: "… | head -20"` — the exact `…` reported.

## How to manually test

1. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` (1196 pass).
2. Run an AI review from the desktop AI Hub and from the TUI. A long Bash command renders in full — wrapped, no trailing `…` — in `AgentOutputCard` / `AgentOutputView` / `RunningAgentPanel` and the TUI Log panel, and the TUI panel stays pinned to the newest entry while the agent runs.
3. Run a remote PR review for a repo you have checked out locally. The log should show `git fetch origin pull/<N>/head:refs/er/pr-<N>` and `git show`/`git grep` against that ref with cwd in the real checkout — no `find /`, no `git clone`, no `/private/tmp/...-src` paths. Confirm `review.json` still loads non-stale.
4. Negative case: open a remote PR for a repo that is *not* your local origin. cwd stays the artifact dir and the agent should use `gh api` + `tentative` rather than hunting.

Both permission patterns were verified against the real `claude` binary rather than assumed: passing the same pattern as both `--allowedTools` and `--disallowedTools`, `Bash(git clone*)` blocked a real `git clone` and `Bash(git fetch origin pull/*)` blocked the real refspec command — so both match the commands the prompt instructs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how review agents are spawned (cwd, allowed/disallowed tools) and what they are instructed to do; incorrect checkout matching could still mis-route verification, but scope is review tooling rather than production auth or data paths.
> 
> **Overview**
> **Review agents** now run from the **local checkout** when a remote PR targets the same repo as `origin`, instead of only the artifact directory—so verification uses real files instead of filesystem hunts and stale `/tmp` checkouts.
> 
> Prompts gain a shared **`### Scope`** block (no `find /` or `git clone`, PR ref via `git fetch origin pull/...` + `git show`/`git grep`, `tentative` when there is no checkout). Remote review text is updated accordingly. Spawn paths add **`--disallowedTools`** for `git clone*`, allow **`git show`** and **narrow `git fetch origin pull/*`**, and pick **`work_dir`** via `github::local_checkout_for_repo`.
> 
> **Agent logs** stop truncating Bash/Grep/text ( **`truncate_str` removed** ); the TUI log panel **auto-scroll** uses wrapped line count so long commands stay visible and pinned to the bottom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd6884eb5e28ea0390e39ab554ff5963e26f7dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->