### PR TITLE
fix(desktop): sequence compacted-file expand commands

### DIFF
--- a/desktop-ui/src/lib/components/diff-rows/CompactedStubRow.svelte
+++ b/desktop-ui/src/lib/components/diff-rows/CompactedStubRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { app } from "$lib/stores/app.svelte";
   import type { CrossFileFlatRow } from "$lib/diffRenderModel";
 
@@ -7,9 +8,10 @@
   }
   const { row }: Props = $props();
 
-  function expand() {
-    app.cmd("select_file", { idx: row.sourceIndex });
-    app.cmd("toggle_compacted");
+  async function expand() {
+    await app.cmd("select_file", { idx: row.sourceIndex });
+    await tick();
+    await app.cmd("toggle_compacted");
   }
 </script>
 
@@ -19,7 +21,7 @@
   class="px-4 py-3 text-muted text-sm italic cursor-pointer hover:bg-hover"
   style="height:{row.height}px;display:flex;align-items:center"
   data-row-identity={row.identity}
-  onclick={expand}
+  onclick={() => void expand()}
 >
   File compacted — click or press Enter to expand
 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicking "File compacted — click or press Enter to expand" did nothing when the compacted file was not already selected.

`CompactedStubRow` fired `select_file` and `toggle_compacted` without awaiting. Because `select_file` is async (`spawn_blocking`) while `toggle_compacted` is sync, the toggle often ran on the previously selected file before selection updated.

## Fix

Sequence the commands the same way as `navigateToThread` / `navigateToFinding` in `dom.ts`:

1. `await select_file` (using `row.sourceIndex`)
2. `await tick()`
3. `await toggle_compacted`

## Test plan

- [ ] Open a diff with an auto-compacted large file
- [ ] Select a different file
- [ ] Click the compacted stub
- [ ] Confirm hunks load for the clicked file
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c501c38-2385-4737-9c6d-e56e4e33e6a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c501c38-2385-4737-9c6d-e56e4e33e6a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

