### PR TITLE
feat(mcp): upgrade er-mcp to MCP 2026-07-28 via rmcp 3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME#v}"
-          for dir in npm/er-mcp npm/platforms/darwin-arm64 npm/platforms/darwin-x64 npm/platforms/linux-x64; do
+          for dir in npm/er-mcp npm/skills npm/platforms/darwin-arm64 npm/platforms/darwin-x64 npm/platforms/linux-x64; do
             PKG=$(node -p "require('./$dir/package.json').version")
             if [ "$TAG" != "$PKG" ]; then
               echo "Version mismatch in $dir: $PKG != tag $TAG"
@@ -151,5 +151,10 @@ jobs:
 
       - name: Publish launcher
         run: cd npm/er-mcp && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish skills installer
+        run: cd npm/skills && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ scripts/aliases below, so either form works.
 ## Environment Gotchas
 
 - **`target/` bloat**: `cargo test` / `cargo build` without `-p` compile **er-desktop** (Tauri) into shared `target/`, which can grow to tens of GB. Use `./scripts/er-tui.sh` for TUI work (`target/tui`), `./scripts/tauri-dev.sh` for desktop (`target/desktop`). Run `./scripts/cargo-gc.sh` to prune.
-- **Rust toolchain**: needs Rust **1.85+** (`edition2024`). The cloud install hook [`scripts/cloud-agent-install.sh`](scripts/cloud-agent-install.sh) runs `rustup update stable` **only when** `rustc` is missing or < 1.85 — unconditional `rustup update` fails on overlayfs (EXDEV) when updating a baked system toolchain.
+- **Rust toolchain**: needs Rust **1.88+** (`rmcp` 3 / MCP 2026-07-28). The cloud install hook [`scripts/cloud-agent-install.sh`](scripts/cloud-agent-install.sh) runs `rustup update stable` **only when** `rustc` is missing or < 1.88 — unconditional `rustup update` fails on overlayfs (EXDEV) when updating a baked system toolchain.
 - **TUI requires a terminal**: `er` renders via crossterm/ratatui, so it must run inside a real terminal (e.g. a tmux session), not a headless pipe.
 - **No external services**: no databases, Docker, or network services. The only runtime dependency is `git` (and optionally `gh` for GitHub PR features).
 - **Review sidecars**: AI sidecar files live in managed app data by default (see "Managed review storage" in `CLAUDE.md`). Set `ER_REPO_LOCAL=1` to use repo-local `.er/` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ scripts/aliases below, so either form works.
 | Test desktop backend | `cargo test -p er-desktop` |
 | Build Easy Review MCP | `cargo build -p er-mcp` (stdio server; setup: `docs/guide/mcp.html`) |
 | npm MCP launcher | `npm/er-mcp` — `npx -y easy-review-mcp` (downloads release binary) |
-| Install ER agent skill | `npx skills add VilfredSikker/easy-review -s er-review -g` — see `skills/er-review/` |
+| Install ER agent skills | `bunx @easy-review/skills` or `npx @easy-review/skills` — see `npm/skills/` |
 | Desktop dev | `./scripts/tauri-dev.sh` |
 | Desktop release (local/ad-hoc) | `./scripts/tauri-build.sh` or `cargo desktop-release` |
 | Desktop signed release | `just sign` (or `just sign-release-desktop`) — guide: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#macos-signed-release-developer-id--notarization) (`.env.signing`) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,12 +4199,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "futures",
  "pastey",
@@ -4211,13 +4217,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["crates/er-engine", "crates/er-tui", "crates/er-desktop", "crates/er-
 [workspace.package]
 version = "0.4.8"
 edition = "2021"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/VilfredSikker/easy-review"
 

--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ low-hanging fruit, production-only diff line counts, and client-owned AI sidecar
 (also in-repo: [`docs/guide/mcp.html`](docs/guide/mcp.html)) — `claude mcp add` / `codex mcp add`, Cursor `mcp.json`, and OpenCode `opencode.json`.
 
 ```bash
+# Agent skills — installs all ER skills globally
+bunx @easy-review/skills
+# or: npx @easy-review/skills -s er-review
+
 # MCP via npm
 npx -y easy-review-mcp
-
-# Agent skill ("ER review") — same as: npx skills add github/gh-stack
-npx skills add VilfredSikker/easy-review -s er-review -g
 
 # Or build MCP from source
 cargo install --path crates/er-mcp
 ```
 
 Tool reference: [`crates/er-mcp/README.md`](crates/er-mcp/README.md).
-npm launcher: [`npm/er-mcp`](npm/er-mcp).
-Skill: [`skills/er-review/SKILL.md`](skills/er-review/SKILL.md).
+Skills: [`skills/er-review/`](skills/er-review/) and [`skills/_shared/`](skills/_shared/).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cd easy-review
 cargo install --path crates/er-tui
 ```
 
-Requires Rust 1.85+.
+Requires Rust 1.88+.
 
 ## Desktop app
 
@@ -39,7 +39,7 @@ As of **v0.4.0**, prebuilt Apple Silicon `.dmg` bundles are published on the [Re
 
 Intel Macs, Linux, and Windows aren't packaged yet — build from source instead.
 
-**Prerequisites:** [Rust 1.85+](https://rustup.rs), the Tauri CLI (`cargo install tauri-cli --locked`), and [bun](https://bun.sh) for the frontend. On Linux you'll also need the [WebKitGTK build dependencies](https://v2.tauri.app/start/prerequisites/#linux). The scripts below check for these and `bun install` the frontend on first run.
+**Prerequisites:** [Rust 1.88+](https://rustup.rs), the Tauri CLI (`cargo install tauri-cli --locked`), and [bun](https://bun.sh) for the frontend. On Linux you'll also need the [WebKitGTK build dependencies](https://v2.tauri.app/start/prerequisites/#linux). The scripts below check for these and `bun install` the frontend on first run.
 
 ```bash
 git clone https://github.com/VilfredSikker/easy-review.git

--- a/crates/er-desktop/Cargo.toml
+++ b/crates/er-desktop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "er-desktop"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 default-run = "er-desktop"
 

--- a/crates/er-engine/Cargo.toml
+++ b/crates/er-engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "er-engine"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "UI-agnostic engine for easy-review (git diffs, watching, AI sidecars, GitHub)"
 

--- a/crates/er-engine/src/git/mod.rs
+++ b/crates/er-engine/src/git/mod.rs
@@ -34,10 +34,10 @@ pub use diff_stats::{DiffKindStats, FileDiffStat, ProdDiffStats};
 pub use file_kind::{classify_path, FileKind};
 pub use status::{
     detect_base_branch_in, diff_shortstat, diff_watched_file_snapshot, discover_watched_files,
-    get_current_branch_in, get_repo_root, get_repo_root_in, git_commit, git_diff_against_branch,
-    git_diff_checkout_against_base, git_diff_commit, git_diff_conflicts, git_diff_raw,
-    git_diff_raw_file, git_diff_raw_range, git_log_branch, git_log_head, git_log_range, git_push,
-    git_stage_all, git_stage_file, git_unstage_file, gitignored_paths, is_merge_in_progress,
-    list_worktrees, read_watched_file_content, save_snapshot, unmerged_files, CommitInfo,
-    FileStatus, WatchedFile, Worktree,
+    get_current_branch_in, get_repo_root, get_repo_root_at, get_repo_root_in, git_commit,
+    git_diff_against_branch, git_diff_checkout_against_base, git_diff_commit, git_diff_conflicts,
+    git_diff_raw, git_diff_raw_file, git_diff_raw_range, git_log_branch, git_log_head,
+    git_log_range, git_push, git_stage_all, git_stage_file, git_unstage_file, gitignored_paths,
+    is_merge_in_progress, list_worktrees, read_watched_file_content, save_snapshot, unmerged_files,
+    CommitInfo, FileStatus, WatchedFile, Worktree,
 };

--- a/crates/er-engine/src/git/status.rs
+++ b/crates/er-engine/src/git/status.rs
@@ -84,6 +84,20 @@ pub fn get_repo_root_in(dir: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Get the repository root for a path inside a worktree (file or directory).
+pub fn get_repo_root_at(path: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["-C", path, "rev-parse", "--show-toplevel"])
+        .output()
+        .context(format!("Failed to run git at '{}'", path))?;
+
+    if !output.status.success() {
+        anyhow::bail!("Not a git repository: {}", path);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 /// Get the current branch name
 #[allow(dead_code)]
 pub fn get_current_branch() -> Result<String> {

--- a/crates/er-engine/src/github.rs
+++ b/crates/er-engine/src/github.rs
@@ -565,6 +565,64 @@ pub fn gh_pr_for_current_branch(repo_root: &str) -> Option<(u64, String)> {
     Some((number, base.to_string()))
 }
 
+/// Open PR number whose head branch matches `head` on `owner/repo` (first non-draft).
+pub fn gh_open_pr_number_for_head(owner: &str, repo: &str, head: &str) -> Result<Option<u64>> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            &format!("{owner}/{repo}"),
+            "--head",
+            head,
+            "--state",
+            "open",
+            "--limit",
+            "10",
+            "--json",
+            "number,isDraft",
+        ])
+        .output()
+        .map_err(gh_spawn_context)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh pr list --head failed: {}", stderr.trim());
+    }
+
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).context("invalid gh pr list JSON")?;
+    let number = rows
+        .iter()
+        .find(|row| row.get("isDraft").and_then(|v| v.as_bool()) != Some(true))
+        .and_then(|row| row.get("number").and_then(|v| v.as_u64()));
+    Ok(number)
+}
+
+/// PR title via `gh pr view --repo` (returns `None` when `gh` fails).
+pub fn gh_pr_title(owner: &str, repo: &str, number: u64) -> Option<String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            &format!("{owner}/{repo}"),
+            "--json",
+            "title",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    value
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 /// Check if a string looks like a GitHub PR URL
 pub fn is_github_pr_url(s: &str) -> bool {
     parse_github_pr_url(s).is_some()

--- a/crates/er-engine/src/lib.rs
+++ b/crates/er-engine/src/lib.rs
@@ -22,6 +22,8 @@ pub mod github;
 pub mod highlight;
 pub mod model_discovery;
 pub mod paths;
+pub mod pr_resolve;
+pub mod pr_review_feedback;
 pub mod projects_pins;
 pub mod review_queue;
 pub mod sidecar_specs;

--- a/crates/er-engine/src/pr_resolve.rs
+++ b/crates/er-engine/src/pr_resolve.rs
@@ -1,0 +1,420 @@
+//! Resolve a user-facing PR `ref` (URL, worktree path, owner/repo, branch, number)
+//! into owner/repo/number for MCP and skills.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::git::get_repo_root_at;
+use crate::github::{
+    get_pr_info, gh_open_pr_number_for_head, owner_repo_storage_slug, parse_github_pr_url,
+    parse_remote_url,
+};
+use crate::storage;
+
+/// Easy Review project entry used when resolving `owner/repo` or active project.
+#[derive(Debug, Clone)]
+pub struct ProjectHint {
+    pub id: String,
+    pub name: String,
+    pub root_path: String,
+    pub remote: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedPrRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub pr_url: String,
+    pub bucket_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    pub resolved_via: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvePrRefInput<'a> {
+    /// Catch-all user ref (URL, path, owner/repo, branch, number).
+    pub ref_str: Option<&'a str>,
+    pub pr_url: Option<&'a str>,
+    pub repo: Option<&'a str>,
+    pub project_id: Option<&'a str>,
+    pub number: Option<u64>,
+    pub projects: &'a [ProjectHint],
+    /// Easy Review `projects.json` `active_id` (preferred over first project).
+    pub active_project_id: Option<&'a str>,
+}
+
+/// Resolve a PR target from explicit fields and/or a single `ref` string.
+pub fn resolve_pr_ref(input: &ResolvePrRefInput<'_>) -> Result<ResolvedPrRef> {
+    if let Some(url) = input.pr_url.map(str::trim).filter(|s| !s.is_empty()) {
+        return resolve_from_pr_url(url, None, "pr_url");
+    }
+
+    if let Some(raw) = input.ref_str.map(str::trim).filter(|s| !s.is_empty()) {
+        return resolve_ref_string(raw, input);
+    }
+
+    let number = input
+        .number
+        .context("pass ref, pr_url, or number (with repo or Easy Review project)")?;
+    let (owner, repo, project_name) = resolve_repo_context(
+        input.repo,
+        input.project_id,
+        input.projects,
+        input.active_project_id,
+    )?;
+    finish(&owner, &repo, number, project_name, None, "repo_and_number")
+}
+
+fn resolve_ref_string(raw: &str, input: &ResolvePrRefInput<'_>) -> Result<ResolvedPrRef> {
+    if parse_github_pr_url(raw).is_some() {
+        return resolve_from_pr_url(raw, None, "ref_pr_url");
+    }
+
+    if let Some(path) = expand_path(raw) {
+        if path.is_dir() || path.is_file() {
+            if let Some(path_str) = path.to_str() {
+                if let Ok(repo_root) = get_repo_root_at(path_str) {
+                    return resolve_from_worktree(&repo_root, None, "ref_worktree");
+                }
+            }
+        }
+    }
+
+    if let Some((owner, repo, number)) = parse_repo_number(raw) {
+        return finish(&owner, &repo, number, None, None, "ref_repo_number");
+    }
+
+    if let Some((owner, repo)) = parse_repo_slug_pair(raw) {
+        if let Some(project) = find_project_for_slug(input.projects, &owner, &repo) {
+            let repo_root = project.root_path.clone();
+            let project_name = Some(project.name.clone());
+            return resolve_from_worktree(&repo_root, project_name, "ref_project_slug");
+        }
+        // `feature/auth` is a branch, not owner/repo — try branch lookup before failing.
+        if let Ok((gh_owner, gh_repo, project_name, _repo_root)) = resolve_repo_with_root(
+            input.repo,
+            input.project_id,
+            input.projects,
+            input.active_project_id,
+        ) {
+            if let Some(number) = gh_open_pr_number_for_head(&gh_owner, &gh_repo, raw)? {
+                return finish(
+                    &gh_owner,
+                    &gh_repo,
+                    number,
+                    project_name,
+                    Some(raw.to_string()),
+                    "ref_branch_head",
+                );
+            }
+        }
+        bail!(
+            "ref '{raw}' looks like owner/repo but no Easy Review project matches — \
+             use owner/repo#N, a worktree path, or configure the project in Desktop"
+        );
+    }
+
+    if raw.chars().all(|c| c.is_ascii_digit()) {
+        let number: u64 = raw.parse().context("invalid PR number")?;
+        let (owner, repo, project_name) = resolve_repo_context(
+            input.repo,
+            input.project_id,
+            input.projects,
+            input.active_project_id,
+        )?;
+        return finish(&owner, &repo, number, project_name, None, "ref_number");
+    }
+
+    // Branch name — repo from explicit repo, active project, or cwd.
+    let (owner, repo, project_name, repo_root) = resolve_repo_with_root(
+        input.repo,
+        input.project_id,
+        input.projects,
+        input.active_project_id,
+    )?;
+    if let Some(number) = gh_open_pr_number_for_head(&owner, &repo, raw)? {
+        return finish(
+            &owner,
+            &repo,
+            number,
+            project_name,
+            Some(raw.to_string()),
+            "ref_branch_head",
+        );
+    }
+    if let Ok((o, r, n)) = get_pr_info(&repo_root) {
+        return finish(
+            &o,
+            &r,
+            n,
+            project_name,
+            Some(raw.to_string()),
+            "ref_branch_worktree",
+        );
+    }
+
+    bail!(
+        "no open PR found for branch '{raw}' in {owner}/{repo} — pass a PR URL, owner/repo#N, or a worktree path"
+    )
+}
+
+fn resolve_from_pr_url(
+    url: &str,
+    project_name: Option<String>,
+    via: &str,
+) -> Result<ResolvedPrRef> {
+    let pr = parse_github_pr_url(url).with_context(|| format!("invalid GitHub PR URL: {url}"))?;
+    finish(&pr.owner, &pr.repo, pr.number, project_name, None, via)
+}
+
+fn resolve_from_worktree(
+    repo_root: &str,
+    project_name: Option<String>,
+    via: &str,
+) -> Result<ResolvedPrRef> {
+    let (owner, repo, number) = get_pr_info(repo_root).with_context(|| {
+        format!("no open PR for current branch in {repo_root} — checkout the PR branch or pass a PR URL")
+    })?;
+    finish(&owner, &repo, number, project_name, None, via)
+}
+
+fn finish(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    project_name: Option<String>,
+    branch: Option<String>,
+    resolved_via: &str,
+) -> Result<ResolvedPrRef> {
+    let pr_url = format!("https://github.com/{owner}/{repo}/pull/{number}");
+    let bucket_path = storage::pr_bucket_dir(&owner_repo_storage_slug(owner, repo), number)
+        .to_string_lossy()
+        .into_owned();
+    Ok(ResolvedPrRef {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+        pr_url,
+        bucket_path,
+        branch,
+        project_name,
+        resolved_via: resolved_via.to_string(),
+    })
+}
+
+fn resolve_repo_context(
+    repo: Option<&str>,
+    project_id: Option<&str>,
+    projects: &[ProjectHint],
+    active_project_id: Option<&str>,
+) -> Result<(String, String, Option<String>)> {
+    if let Some(slug) = repo.map(str::trim).filter(|s| !s.is_empty()) {
+        let (o, r) = parse_remote_url(slug)
+            .or_else(|| parse_repo_slug_pair(slug))
+            .with_context(|| format!("invalid repo slug: {slug}"))?;
+        return Ok((o, r, None));
+    }
+    let project = select_project(project_id, active_project_id, projects)?;
+    let remote = project
+        .remote
+        .as_deref()
+        .context("project has no remote; pass repo=owner/repo")?;
+    let (o, r) =
+        parse_remote_url(remote).with_context(|| format!("invalid project remote: {remote}"))?;
+    Ok((o, r, Some(project.name.clone())))
+}
+
+fn resolve_repo_with_root(
+    repo: Option<&str>,
+    project_id: Option<&str>,
+    projects: &[ProjectHint],
+    active_project_id: Option<&str>,
+) -> Result<(String, String, Option<String>, String)> {
+    if let Some(slug) = repo.map(str::trim).filter(|s| !s.is_empty()) {
+        let (o, r) = parse_remote_url(slug)
+            .or_else(|| parse_repo_slug_pair(slug))
+            .with_context(|| format!("invalid repo slug: {slug}"))?;
+        if let Some(project) = find_project_for_slug(projects, &o, &r) {
+            return Ok((o, r, Some(project.name.clone()), project.root_path.clone()));
+        }
+        bail!("no Easy Review project for {o}/{r} — pass a worktree path in ref");
+    }
+    let project = select_project(project_id, active_project_id, projects)?;
+    let remote = project
+        .remote
+        .as_deref()
+        .context("project has no remote; pass repo=owner/repo")?;
+    let (o, r) =
+        parse_remote_url(remote).with_context(|| format!("invalid project remote: {remote}"))?;
+    Ok((o, r, Some(project.name.clone()), project.root_path.clone()))
+}
+
+fn select_project<'a>(
+    project_id: Option<&str>,
+    active_project_id: Option<&str>,
+    projects: &'a [ProjectHint],
+) -> Result<&'a ProjectHint> {
+    if let Some(id) = project_id {
+        return projects
+            .iter()
+            .find(|p| p.id == id)
+            .with_context(|| format!("project not found: {id}"));
+    }
+    if let Some(active) = active_project_id {
+        return projects
+            .iter()
+            .find(|p| p.id == active)
+            .with_context(|| format!("active project missing from projects.json: {active}"));
+    }
+    if let Some(first) = projects.first() {
+        return Ok(first);
+    }
+    bail!("no Easy Review projects configured; pass repo=owner/repo or ref with a PR URL")
+}
+
+fn find_project_for_slug<'a>(
+    projects: &'a [ProjectHint],
+    owner: &str,
+    repo: &str,
+) -> Option<&'a ProjectHint> {
+    projects.iter().find(|p| {
+        p.remote.as_deref().is_some_and(|remote| {
+            parse_remote_url(remote)
+                .is_some_and(|(o, r)| o.eq_ignore_ascii_case(owner) && r.eq_ignore_ascii_case(repo))
+        })
+    })
+}
+
+fn parse_repo_slug_pair(s: &str) -> Option<(String, String)> {
+    let trimmed = s.trim().trim_end_matches('/');
+    let (owner, repo) = trimmed.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() || owner.contains('\\') {
+        return None;
+    }
+    // Avoid treating filesystem paths as slugs.
+    if trimmed.starts_with('/') || trimmed.starts_with('~') || trimmed.starts_with('.') {
+        return None;
+    }
+    Some((owner.to_string(), repo.trim_end_matches(".git").to_string()))
+}
+
+fn parse_repo_number(s: &str) -> Option<(String, String, u64)> {
+    let trimmed = s.trim();
+    let (left, num_str) = trimmed
+        .split_once('#')
+        .or_else(|| trimmed.split_once('!'))?;
+    let number = num_str.parse::<u64>().ok()?;
+    if number == 0 {
+        return None;
+    }
+    let (owner, repo) = parse_repo_slug_pair(left)?;
+    Some((owner, repo, number))
+}
+
+fn expand_path(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed == "~" || trimmed.starts_with("~/") {
+        let home = dirs::home_dir()?;
+        let rest = trimmed.strip_prefix("~/").unwrap_or("");
+        return Some(home.join(rest));
+    }
+    if trimmed.starts_with('/') || trimmed.starts_with("./") || trimmed.starts_with("../") {
+        return Some(PathBuf::from(trimmed));
+    }
+    // Heuristic: absolute-looking macOS/Linux project paths without leading ./
+    if trimmed.contains('/') && !trimmed.contains('#') {
+        let path = PathBuf::from(trimmed);
+        if path.is_absolute() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_projects() -> Vec<ProjectHint> {
+        Vec::new()
+    }
+
+    #[test]
+    fn resolve_pr_url_via_ref() {
+        let input = ResolvePrRefInput {
+            ref_str: Some("https://github.com/acme/widgets/pull/42/files"),
+            pr_url: None,
+            repo: None,
+            project_id: None,
+            number: None,
+            projects: &empty_projects(),
+            active_project_id: None,
+        };
+        let pr = resolve_pr_ref(&input).unwrap();
+        assert_eq!(pr.owner, "acme");
+        assert_eq!(pr.repo, "widgets");
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.resolved_via, "ref_pr_url");
+    }
+
+    #[test]
+    fn resolve_repo_number_hash() {
+        let input = ResolvePrRefInput {
+            ref_str: Some("acme/widgets#7"),
+            pr_url: None,
+            repo: None,
+            project_id: None,
+            number: None,
+            projects: &empty_projects(),
+            active_project_id: None,
+        };
+        let pr = resolve_pr_ref(&input).unwrap();
+        assert_eq!(pr.number, 7);
+        assert_eq!(pr.resolved_via, "ref_repo_number");
+    }
+
+    #[test]
+    fn select_project_prefers_active_id() {
+        let projects = vec![
+            ProjectHint {
+                id: "first".into(),
+                name: "First".into(),
+                root_path: "/a".into(),
+                remote: Some("https://github.com/acme/one.git".into()),
+            },
+            ProjectHint {
+                id: "active".into(),
+                name: "Active".into(),
+                root_path: "/b".into(),
+                remote: Some("https://github.com/acme/two.git".into()),
+            },
+        ];
+        let picked = select_project(None, Some("active"), &projects).unwrap();
+        assert_eq!(picked.id, "active");
+    }
+
+    #[test]
+    fn select_project_errors_on_stale_active_id() {
+        let projects = vec![ProjectHint {
+            id: "first".into(),
+            name: "First".into(),
+            root_path: "/a".into(),
+            remote: Some("https://github.com/acme/one.git".into()),
+        }];
+        let err = select_project(None, Some("missing"), &projects).unwrap_err();
+        assert!(err.to_string().contains("active project missing"));
+    }
+
+    #[test]
+    fn parse_slug_rejects_path_like() {
+        assert!(parse_repo_slug_pair("/Users/me/proj").is_none());
+    }
+}

--- a/crates/er-engine/src/pr_review_feedback.rs
+++ b/crates/er-engine/src/pr_review_feedback.rs
@@ -1,0 +1,543 @@
+//! Headless read/write of PR review feedback: questions, notes, and AI findings.
+//!
+//! Used by `er-mcp` so client agents can inspect and respond to review artifacts
+//! stored in the managed PR bucket (`prs/pr-<N>/`).
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::ai::{
+    append_finding_response, compute_diff_hash, load_ai_state, ErNotes, ErQuestions, Finding,
+    ReviewQuestion, RiskLevel,
+};
+use crate::github::owner_repo_storage_slug;
+use crate::storage::resolve_managed_root_for_pr_bucket;
+use crate::sync::chrono_now;
+
+/// Slim finding row for MCP / API consumers (merged review + experts + professor).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrFindingItem {
+    pub id: String,
+    pub file: String,
+    pub severity: String,
+    pub category: String,
+    pub title: String,
+    pub description: String,
+    pub suggestion: String,
+    pub hunk_index: Option<usize>,
+    pub line_start: Option<usize>,
+    pub line_end: Option<usize>,
+    pub confidence: String,
+    pub resolved: bool,
+    pub outside_diff: bool,
+    pub responses: Vec<crate::ai::AiResponse>,
+    /// `review`, `professor`, or `expert:<id>`.
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrReviewFeedback {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub bucket_path: String,
+    pub diff_hash: String,
+    pub questions: Vec<ReviewQuestion>,
+    pub notes: Vec<ReviewQuestion>,
+    pub findings: Vec<PrFindingItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrFeedbackReply {
+    pub id: String,
+    pub kind: String,
+    pub parent_id: Option<String>,
+}
+
+fn resolve_pr_er_dir(owner: &str, repo: &str, pr: u64) -> Result<String> {
+    let slug = owner_repo_storage_slug(owner, repo);
+    let er_dir = resolve_managed_root_for_pr_bucket(&slug, pr).er_dir();
+    if er_dir.is_empty() {
+        bail!("failed to resolve managed PR storage for {owner}/{repo}#{pr}");
+    }
+    Ok(er_dir)
+}
+
+fn pr_bucket_path(er_dir: &str) -> String {
+    er_dir.to_string()
+}
+
+fn pr_diff_hash(er_dir: &str) -> String {
+    let diff_tmp = Path::new(er_dir).join("diff-tmp");
+    if let Ok(content) = std::fs::read_to_string(&diff_tmp) {
+        if !content.trim().is_empty() {
+            return compute_diff_hash(&content);
+        }
+    }
+    for name in ["review.json", "questions.json", "notes.json"] {
+        let path = Path::new(er_dir).join(name);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if name == "review.json" {
+                if let Ok(review) = serde_json::from_str::<crate::ai::ErReview>(&content) {
+                    if !review.diff_hash.is_empty() {
+                        return review.diff_hash;
+                    }
+                }
+            } else if name == "questions.json" {
+                if let Ok(qs) = serde_json::from_str::<ErQuestions>(&content) {
+                    if !qs.diff_hash.is_empty() {
+                        return qs.diff_hash;
+                    }
+                }
+            } else if let Ok(ns) = serde_json::from_str::<ErNotes>(&content) {
+                if !ns.diff_hash.is_empty() {
+                    return ns.diff_hash;
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+fn severity_label(level: RiskLevel) -> &'static str {
+    match level {
+        RiskLevel::High => "high",
+        RiskLevel::Medium => "medium",
+        RiskLevel::Low => "low",
+        RiskLevel::Info => "info",
+    }
+}
+
+fn finding_source(category: &str) -> String {
+    if category.starts_with("professor:") {
+        "professor".to_string()
+    } else if let Some(rest) = category.strip_prefix("expert:") {
+        format!("expert:{rest}")
+    } else {
+        "review".to_string()
+    }
+}
+
+fn collect_findings(review: &crate::ai::ErReview) -> Vec<PrFindingItem> {
+    let mut out = Vec::new();
+    for (file, fr) in &review.files {
+        for f in &fr.findings {
+            out.push(finding_to_item(file, f));
+        }
+    }
+    out.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.line_start.cmp(&b.line_start))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    out
+}
+
+fn finding_to_item(file: &str, f: &Finding) -> PrFindingItem {
+    PrFindingItem {
+        id: f.id.clone(),
+        file: file.to_string(),
+        severity: severity_label(f.severity).to_string(),
+        category: f.category.clone(),
+        title: f.title.clone(),
+        description: f.description.clone(),
+        suggestion: f.suggestion.clone(),
+        hunk_index: f.hunk_index,
+        line_start: f.line_start,
+        line_end: f.line_end,
+        confidence: format!("{:?}", f.confidence).to_ascii_lowercase(),
+        resolved: f.resolved,
+        outside_diff: f.outside_diff,
+        responses: f.responses.clone(),
+        source: finding_source(&f.category),
+    }
+}
+
+fn write_json_atomic<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(value)?;
+    std::fs::write(&tmp, json).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| format!("rename {}", path.display()))?;
+    Ok(())
+}
+
+fn load_questions(er_dir: &str) -> Result<ErQuestions> {
+    let path = Path::new(er_dir).join("questions.json");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content)
+            .with_context(|| format!("parse corrupt questions.json at {}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(ErQuestions {
+            version: 1,
+            diff_hash: String::new(),
+            questions: Vec::new(),
+        }),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn load_notes(er_dir: &str) -> Result<ErNotes> {
+    let path = Path::new(er_dir).join("notes.json");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content)
+            .with_context(|| format!("parse corrupt notes.json at {}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(ErNotes {
+            version: 1,
+            diff_hash: String::new(),
+            notes: Vec::new(),
+        }),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn next_thread_id(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    )
+}
+
+fn validate_parent_thread<'a>(
+    items: &'a [ReviewQuestion],
+    parent_id: &str,
+    kind: &str,
+) -> Result<&'a ReviewQuestion> {
+    let parent = items
+        .iter()
+        .find(|q| q.id == parent_id)
+        .with_context(|| format!("{kind} not found: {parent_id}"))?;
+    if parent.in_reply_to.is_some() {
+        bail!("reply to the top-level {kind} id, not a reply (flat threads)");
+    }
+    Ok(parent)
+}
+
+fn append_question_reply(
+    er_dir: &str,
+    parent: &ReviewQuestion,
+    text: &str,
+    author: &str,
+) -> Result<String> {
+    let mut questions = load_questions(er_dir)?;
+    let diff_hash = pr_diff_hash(er_dir);
+    if questions.diff_hash.is_empty() {
+        questions.diff_hash = diff_hash.clone();
+    } else if !diff_hash.is_empty() && questions.diff_hash != diff_hash {
+        questions.diff_hash = diff_hash;
+    }
+
+    let id = next_thread_id("q");
+    questions.questions.push(ReviewQuestion {
+        id: id.clone(),
+        timestamp: chrono_now(),
+        file: parent.file.clone(),
+        hunk_index: parent.hunk_index,
+        line_start: parent.line_start,
+        line_end: parent.line_end,
+        line_content: parent.line_content.clone(),
+        text: text.to_string(),
+        resolved: false,
+        stale: false,
+        context_before: parent.context_before.clone(),
+        context_after: parent.context_after.clone(),
+        old_line_start: parent.old_line_start,
+        hunk_header: parent.hunk_header.clone(),
+        anchor_status: parent.anchor_status.clone(),
+        relocated_at_hash: parent.relocated_at_hash.clone(),
+        in_reply_to: Some(parent.id.clone()),
+        author: author.to_string(),
+        promoted_to: None,
+        finding_ref: parent.finding_ref.clone(),
+    });
+
+    std::fs::create_dir_all(er_dir)?;
+    write_json_atomic(&Path::new(er_dir).join("questions.json"), &questions)?;
+    Ok(id)
+}
+
+fn append_note_reply(
+    er_dir: &str,
+    parent: &ReviewQuestion,
+    text: &str,
+    author: &str,
+) -> Result<String> {
+    let mut notes = load_notes(er_dir)?;
+    let diff_hash = pr_diff_hash(er_dir);
+    if notes.diff_hash.is_empty() {
+        notes.diff_hash = diff_hash.clone();
+    } else if !diff_hash.is_empty() && notes.diff_hash != diff_hash {
+        notes.diff_hash = diff_hash;
+    }
+
+    let id = next_thread_id("n");
+    notes.notes.push(ReviewQuestion {
+        id: id.clone(),
+        timestamp: chrono_now(),
+        file: parent.file.clone(),
+        hunk_index: parent.hunk_index,
+        line_start: parent.line_start,
+        line_end: parent.line_end,
+        line_content: parent.line_content.clone(),
+        text: text.to_string(),
+        resolved: false,
+        stale: false,
+        context_before: parent.context_before.clone(),
+        context_after: parent.context_after.clone(),
+        old_line_start: parent.old_line_start,
+        hunk_header: parent.hunk_header.clone(),
+        anchor_status: parent.anchor_status.clone(),
+        relocated_at_hash: parent.relocated_at_hash.clone(),
+        in_reply_to: Some(parent.id.clone()),
+        author: author.to_string(),
+        promoted_to: None,
+        finding_ref: parent.finding_ref.clone(),
+    });
+
+    std::fs::create_dir_all(er_dir)?;
+    write_json_atomic(&Path::new(er_dir).join("notes.json"), &notes)?;
+    Ok(id)
+}
+
+/// Read questions, notes, and merged AI findings from the managed PR bucket.
+pub fn get_pr_review_feedback(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    include_resolved: bool,
+) -> Result<PrReviewFeedback> {
+    let er_dir = resolve_pr_er_dir(owner, repo, number)?;
+    let diff_hash = pr_diff_hash(&er_dir);
+    let ai = load_ai_state(&er_dir, &diff_hash, None);
+
+    let questions = ai
+        .questions
+        .map(|qs| qs.questions)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|q| include_resolved || !q.resolved)
+        .collect();
+
+    let notes = ai
+        .notes
+        .map(|ns| ns.notes)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|n| include_resolved || !n.resolved)
+        .collect();
+
+    let findings = ai
+        .review
+        .as_ref()
+        .map(collect_findings)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|f| include_resolved || !f.resolved)
+        .collect();
+
+    Ok(PrReviewFeedback {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+        bucket_path: pr_bucket_path(&er_dir),
+        diff_hash,
+        questions,
+        notes,
+        findings,
+    })
+}
+
+/// Reply to a top-level question thread in `questions.json`.
+pub fn reply_to_pr_question(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    question_id: &str,
+    text: &str,
+    author: Option<&str>,
+) -> Result<PrFeedbackReply> {
+    if text.trim().is_empty() {
+        bail!("reply text must be non-empty");
+    }
+    let er_dir = resolve_pr_er_dir(owner, repo, number)?;
+    let questions = load_questions(&er_dir)?;
+    let parent = validate_parent_thread(&questions.questions, question_id, "question")?;
+    let author = author.unwrap_or("agent");
+    let id = append_question_reply(&er_dir, parent, text, author)?;
+    Ok(PrFeedbackReply {
+        id,
+        kind: "question".to_string(),
+        parent_id: Some(question_id.to_string()),
+    })
+}
+
+/// Reply to a top-level note thread in `notes.json`.
+pub fn reply_to_pr_note(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    note_id: &str,
+    text: &str,
+    author: Option<&str>,
+) -> Result<PrFeedbackReply> {
+    if text.trim().is_empty() {
+        bail!("reply text must be non-empty");
+    }
+    let er_dir = resolve_pr_er_dir(owner, repo, number)?;
+    let notes = load_notes(&er_dir)?;
+    let parent = validate_parent_thread(&notes.notes, note_id, "note")?;
+    let author = author.unwrap_or("agent");
+    let id = append_note_reply(&er_dir, parent, text, author)?;
+    Ok(PrFeedbackReply {
+        id,
+        kind: "note".to_string(),
+        parent_id: Some(note_id.to_string()),
+    })
+}
+
+/// Append a validation / follow-up reply on an AI finding (`review.json` or expert/professor sidecars).
+pub fn reply_to_pr_finding(
+    owner: &str,
+    repo: &str,
+    number: u64,
+    finding_id: &str,
+    text: &str,
+) -> Result<PrFeedbackReply> {
+    if text.trim().is_empty() {
+        bail!("reply text must be non-empty");
+    }
+    let er_dir = resolve_pr_er_dir(owner, repo, number)?;
+    let id = append_finding_response(&er_dir, finding_id, text)?;
+    Ok(PrFeedbackReply {
+        id,
+        kind: "finding".to_string(),
+        parent_id: Some(finding_id.to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{Confidence, ErFileReview, ErReview, Finding};
+    use std::collections::HashMap;
+
+    fn with_storage_root<F: FnOnce()>(f: F) {
+        let _guard = crate::storage::STORAGE_TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("ER_STORAGE_ROOT", dir.path());
+        f();
+        std::env::remove_var("ER_STORAGE_ROOT");
+    }
+
+    fn sample_question(id: &str) -> ReviewQuestion {
+        ReviewQuestion {
+            id: id.to_string(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            file: "src/a.rs".into(),
+            hunk_index: Some(0),
+            line_start: Some(10),
+            line_end: None,
+            line_content: "fn a() {}".into(),
+            text: "Why?".into(),
+            resolved: false,
+            stale: false,
+            context_before: vec![],
+            context_after: vec![],
+            old_line_start: None,
+            hunk_header: String::new(),
+            anchor_status: "original".into(),
+            relocated_at_hash: String::new(),
+            in_reply_to: None,
+            author: "You".into(),
+            promoted_to: None,
+            finding_ref: None,
+        }
+    }
+
+    #[test]
+    fn get_and_reply_roundtrip() {
+        with_storage_root(|| {
+            let er_dir = resolve_pr_er_dir("acme", "widgets", 5).unwrap();
+            std::fs::create_dir_all(&er_dir).unwrap();
+            let qs = ErQuestions {
+                version: 1,
+                diff_hash: "hash".into(),
+                questions: vec![sample_question("q-root")],
+            };
+            write_json_atomic(&Path::new(&er_dir).join("questions.json"), &qs).unwrap();
+
+            let feedback = get_pr_review_feedback("acme", "widgets", 5, true).unwrap();
+            assert_eq!(feedback.questions.len(), 1);
+            assert!(feedback.findings.is_empty());
+
+            let reply =
+                reply_to_pr_question("acme", "widgets", 5, "q-root", "Because.", None).unwrap();
+            assert_eq!(reply.kind, "question");
+
+            let feedback = get_pr_review_feedback("acme", "widgets", 5, true).unwrap();
+            assert_eq!(feedback.questions.len(), 2);
+            assert_eq!(feedback.questions[1].in_reply_to.as_deref(), Some("q-root"));
+            assert_eq!(feedback.questions[1].author, "agent");
+        });
+    }
+
+    #[test]
+    fn finding_reply_persists() {
+        with_storage_root(|| {
+            let er_dir = resolve_pr_er_dir("acme", "widgets", 6).unwrap();
+            std::fs::create_dir_all(&er_dir).unwrap();
+            let finding = Finding {
+                id: "f1".into(),
+                severity: RiskLevel::High,
+                category: "general".into(),
+                title: "Bug".into(),
+                description: "desc".into(),
+                hunk_index: None,
+                line_start: None,
+                line_end: None,
+                suggestion: String::new(),
+                related_files: vec![],
+                outside_diff: false,
+                confidence: Confidence::default(),
+                verification_plan: String::new(),
+                evidence: vec![],
+                responses: vec![],
+                resolved: false,
+                resolved_note: String::new(),
+                resolved_at: String::new(),
+                promoted_to: None,
+            };
+            let review = ErReview {
+                version: 1,
+                diff_hash: "h".into(),
+                created_at: String::new(),
+                base_branch: String::new(),
+                head_branch: String::new(),
+                files: [(
+                    "a.rs".into(),
+                    ErFileReview {
+                        risk: RiskLevel::Low,
+                        risk_reason: String::new(),
+                        summary: String::new(),
+                        findings: vec![finding],
+                    },
+                )]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+                file_hashes: HashMap::new(),
+            };
+            write_json_atomic(&Path::new(&er_dir).join("review.json"), &review).unwrap();
+
+            reply_to_pr_finding("acme", "widgets", 6, "f1", "Confirmed.").unwrap();
+            let feedback = get_pr_review_feedback("acme", "widgets", 6, true).unwrap();
+            assert_eq!(feedback.findings.len(), 1);
+            assert_eq!(feedback.findings[0].responses[0].text, "Confirmed.");
+        });
+    }
+}

--- a/crates/er-mcp/Cargo.toml
+++ b/crates/er-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "er-mcp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Model Context Protocol server for easy-review PR triage"
 readme = "README.md"
@@ -17,7 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 dirs.workspace = true
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "sync"] }
-rmcp = { version = "2.2.0", features = ["server", "transport-io"] }
+rmcp = { version = "3.1", features = ["server", "transport-io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 schemars = "1"

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -1,6 +1,7 @@
 # er-mcp — Easy Review MCP server
 
-Stdio [Model Context Protocol](https://modelcontextprotocol.io) server for PR triage.
+Stdio [Model Context Protocol](https://modelcontextprotocol.io) server for PR triage
+(MCP **2026-07-28** / “MCP 2.0”, with dual-era fallback for initialize-based clients).
 Ask an MCP client things like:
 
 - “Give me the top 5 priority PRs to review”
@@ -184,7 +185,11 @@ open_in_easy_review       → { "number": 42 }
 - Client-owned uploads live in `er-engine::sidecar_upload` (prepare kit + validated write).
 - JSON Schema + prompt contracts live in `er-engine::sidecar_specs` (`get_artifact_specs`).
 - Desktop Saved pins live in `er-engine::projects_pins` (Value-preserving `projects.json` writes).
-- `er-mcp` is a thin `rmcp` stdio wrapper over those APIs.
+- `er-mcp` is a thin `rmcp` 3.x stdio wrapper over those APIs.
+- **Protocol:** prefers `2026-07-28` (stateless `server/discover` + per-request `_meta`).
+  Still advertises older revisions so Cursor / Claude Code / Codex that use the
+  legacy `initialize` handshake keep working. Tool handlers are request-scoped
+  (no session state) — the same shape Streamable HTTP expects.
 
 ## Notes
 

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -1,200 +1,103 @@
 # er-mcp — Easy Review MCP server
 
-Stdio [Model Context Protocol](https://modelcontextprotocol.io) server for PR triage
-(MCP **2026-07-28** / “MCP 2.0”, with dual-era fallback for initialize-based clients).
-Ask an MCP client things like:
+Stdio [Model Context Protocol](https://modelcontextprotocol.io) server (MCP **2026-07-28**).
+Thin REST API over `er-engine` — use **skills** for workflows.
 
-- “Give me the top 5 priority PRs to review”
-- “Show me the smallest / low-hanging-fruit PRs”
-- “How many production lines changed in PR #42?” (excludes tests, Storybook, generated, docs)
-- “Which open PRs are outdated, blocked, failing CI, or waiting on the author?”
-- “What’s my review debt?” / “Any stale PRs?” / “Already addressed feedback?”
-- “Priority across all my Easy Review projects”
-- “Prepare a review kit for PR #42 — I’ll write triage/tour and upload them”
-
-Uses the authenticated `gh` CLI (same as Easy Review desktop/TUI). Optionally reads
-`~/.config/er/projects.json` so you can omit `repo=` when a project is configured.
-
-## Tools
+## MCP tools (11)
 
 | Tool | Purpose |
 |------|---------|
-| `list_projects` | Easy Review projects (id, name, remote) |
-| `list_prs` | Open PRs with size, review decision, merge state |
-| `priority_prs` | Ranked “review next” queue |
-| `low_hanging_fruit` | Smallest open PRs (defaults to production-only line enrichment) |
-| `cross_repo_queue` | Priority queue across all configured projects |
-| `my_review_debt` | Requested of you; you have not approved / requested changes |
-| `pr_diff_stats` | Adds/dels split by production / test / storybook / generated / docs |
-| `diff_hotspots` | Top production files by churn in a PR |
-| `compare_prod_size` | Rank a list of PR numbers by production-only lines |
-| `prs_by_status` | Filter: `ready_to_review`, `outdated`, `blocked_conflicts`, `waiting_on_author`, … |
-| `prs_stale` | No GitHub activity for N days (default 14) |
-| `prs_blocked` | Conflicts, `mergeStateStatus=BLOCKED`, or failing CI |
-| `prs_failing_ci` | Failing `gh pr checks` |
-| `prs_already_addressed` | All review threads resolved or outdated |
-| `prepare_review` | Write shared `diff-tmp`, return `diff_hash` + prompts |
-| `get_artifact_specs` | JSON Schema + examples + prompts for triage/review/tour (no PR needed) |
-| `upload_artifacts` | Validate + write `triage` / `review` / `tour` JSON you produced |
-| `pin_pr` | Pin a PR into Desktop Saved PRs (`projects.json`) |
-| `unpin_pr` | Remove a PR from Desktop Saved |
-| `list_pinned_prs` | List Saved PRs + which sidecars exist |
-| `list_artifacts` | Scan managed storage for uploaded triage/review/tour (marks `pinned`) |
-| `summarize_triage` | Local managed `triage.json` / `review.json` / `tour.json` summary |
-| `open_in_easy_review` | GitHub URL + desktop/TUI open instructions |
-| `tool_ideas` | Catalog of shipped + future tools |
+| `projects_list` | Easy Review projects (`~/.config/er/projects.json`) |
+| `pr_resolve` | `ref` → owner, repo, number, `pr_url`, `bucket_path` |
+| `prs_query` | List/rank/filter open PRs (`sort`, `filter`, `cross_repo`) |
+| `pr_stats` | Production vs test/docs diff stats; batch + hotspots |
+| `pr_guide` | Prepare + upload guided tour (`tour.json`) |
+| `pr_prepare` | Fetch diff, write `diff-tmp`, return `diff_hash` + specs |
+| `pr_upload` | Validate + write triage/review/tour sidecars |
+| `pr_summarize` | Read triage/review/tour summary from managed storage |
+| `pr_feedback_get` | Questions, notes, AI findings |
+| `pr_feedback_reply` | Reply (`type`: question \| note \| finding) |
+| `pr_saved` | Pin / unpin / list saved PRs and artifacts |
 
-## AI sidecars (client-owned)
+## Universal `ref` targeting
 
-The MCP client agent **is** the reviewer. Easy Review prepares storage and
-validates uploads — it does not spawn agent CLIs.
+Every PR-scoped tool accepts **`ref`** (preferred) or `pr_url` / `repo` + `number`:
 
-1. `prepare_review` — fetches the PR diff via `gh`, writes `diff-tmp` into the
-   managed PR bucket, returns `diff_hash`, `diff_tmp_path`, and `artifact_specs`
-   (schemas/examples/prompts — the same payload as `get_artifact_specs`). Do **not**
-   also call `get_artifact_specs` in the same review run.
-   Managed path (sandbox **read-only** — read `diff-tmp`, write nothing here):
-   - macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
-   - Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
-2. You read `diff_tmp_path`, produce the sidecars (embed that exact `diff_hash`).
-   Author file contents once, inline in `upload_artifacts`.
-3. `upload_artifacts` — atomic write + schema/`diff_hash` validation.
-4. `summarize_triage` or open the PR in Desktop/TUI — sidecars are shared.
-5. Optionally `pin_pr` so the PR appears in Desktop Saved and `list_pinned_prs`.
+| `ref` | Example |
+|-------|---------|
+| PR URL | `https://github.com/acme/widgets/pull/42` |
+| Worktree path | `/Users/me/Projects/foo` |
+| `owner/repo#N` | `acme/widgets#42` |
+| `owner/repo` | `vilfred/ai-report-builder` (ER project → open PR in checkout) |
+| Branch | `feature/auth` |
+| Number | `42` (with active ER project) |
 
-Call `get_artifact_specs` alone only when you are not preparing a PR (offline authoring,
-schema inspection).
+Call `pr_resolve` first when ambiguous.
+
+## Skills (workflows)
+
+Install with **`bunx @easy-review/skills`** (or `npx @easy-review/skills`):
+
+| Skill | Intent |
+|-------|--------|
+| `er-review` | Prepare → author → upload sidecars |
+| `er-guide` | Guided tour only (`tour.json`) |
+| `er-queue` | What to review next (priority, debt, blocked, stale) |
+| `er-low-hanging-fruit` | Smallest / quick-win PRs |
+| `er-get-feedback` | Read questions, notes, findings |
+| `er-respond` | Reply on PR threads |
+| `er-saved` | Pin / list saved work |
+
+One skill: `bunx @easy-review/skills -s er-review`. Source: [`skills/`](../../skills/).
+
+Guided tour:
 
 ```text
-prepare_review     → { "number": 42, "kinds": ["triage", "tour"] }
-# …you write the JSON per artifact_specs…
-upload_artifacts   → { "number": 42, "kind": "tour", "files": { "tour.json": "..." } }
-pin_pr             → { "number": 42 }
-list_artifacts     → { "kinds": ["tour"] }   # discover uploaded sidecars
-summarize_triage   → { "number": 42 }
+pr_guide     → { "ref": "…", "action": "prepare" }
+pr_guide     → { "ref": "…", "action": "upload", "files": { "tour.json": "..." } }
 ```
 
-**Review uploads** need all four: `review.json`, `order.json`, `checklist.json`, `summary.md`.
+Full review flow:
 
-`upload_artifacts` validates serde deserialization + matching `diff_hash` **before** writing.
-It does **not** enforce the full JSON Schema — use `prepare_review`'s `artifact_specs`
-(or `get_artifact_specs` when used alone) as the authoring contract.
+```text
+pr_prepare   → { "ref": "…", "kinds": ["triage"] }
+# …author JSON per artifact_specs…
+pr_upload    → { "ref": "…", "kind": "triage", "files": { "triage.json": "..." } }
+pr_summarize → { "ref": "…" }
+```
+
+Guided tours use **`pr_guide`** (not `pr_prepare` / `pr_upload`). See `er-guide` skill.
+
+Review uploads need all four: `review.json`, `order.json`, `checklist.json`, `summary.md`.
+
+## `prs_query` reference
+
+```json
+{
+  "sort": "priority | smallest | updated",
+  "filter": "review_debt | stale | blocked | failing_ci | ready | addressed | …",
+  "cross_repo": false,
+  "production_lines": false,
+  "limit": 10,
+  "scan_limit": 15,
+  "stale_days": 14
+}
+```
 
 ## Build / run
 
 ```bash
-# npm launcher (downloads the release binary on first run)
 npx -y easy-review-mcp
-
-# From source
 cargo build -p er-mcp --release
-# binary: target/release/er-mcp
-
 cargo install --path crates/er-mcp
-# → ~/.cargo/bin/er-mcp
 ```
 
 Requires `gh auth login`.
 
-## Client setup (Claude / Cursor / Codex / OpenCode)
-
-Full guide with **`mcp.json`**, **`claude mcp add`**, **`codex mcp add`**, and OpenCode
-**`opencode.json`**:
-[docs/guide/mcp.html](../../docs/guide/mcp.html)
-([published](https://vilfredsikker.github.io/easy-review/guide/mcp.html)).
-
-npm launcher (package: [`npm/er-mcp`](../../npm/er-mcp)):
-
-```bash
-# Claude Code
-claude mcp add --scope user easy-review -- npx -y easy-review-mcp
-
-# Codex
-codex mcp add easy-review -- npx -y easy-review-mcp
-```
-
-Cursor — `~/.cursor/mcp.json` or `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "easy-review": {
-      "command": "npx",
-      "args": ["-y", "easy-review-mcp"]
-    }
-  }
-}
-```
-
-OpenCode — `~/.config/opencode/opencode.json` or project `opencode.json`:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "easy-review": {
-      "type": "local",
-      "command": ["npx", "-y", "easy-review-mcp"],
-      "enabled": true
-    }
-  }
-}
-```
-
-Or point `command` at a source-built `/absolute/path/to/er-mcp`.
-
-### Agent skill (“ER review”)
-
-Install the companion skill so agents know to call `prepare_review` → author →
-`upload_artifacts` when you say **“ER review”** (same as `npx skills add github/gh-stack`):
-
-```bash
-npx skills add VilfredSikker/easy-review -s er-review -g   # global; prompts for agents
-npx skills add VilfredSikker/easy-review -s er-review      # project
-npx skills add VilfredSikker/easy-review -s er-review -g -a cursor -y
-```
-
-Skill source: [`skills/er-review/SKILL.md`](../../skills/er-review/SKILL.md).
-
-## Example calls
-
-```text
-priority_prs              → { "limit": 5, "repo": "acme/widgets" }
-low_hanging_fruit         → { "limit": 5 }
-my_review_debt            → {}
-prs_stale                 → { "days": 14 }
-prs_blocked               → { "scan_limit": 20 }
-prs_already_addressed     → { "scan_limit": 15 }
-cross_repo_queue          → { "limit": 10 }
-pr_diff_stats             → { "number": 42 }
-diff_hotspots             → { "number": 42, "limit": 10 }
-compare_prod_size         → { "numbers": [12, 15, 18] }
-prepare_review            → { "number": 42, "kinds": ["tour"] }
-get_artifact_specs        → { "kinds": ["tour", "triage"] }
-upload_artifacts          → { "number": 42, "kind": "tour", "files": { "tour.json": "{...}" } }
-pin_pr                    → { "number": 42 }
-list_pinned_prs           → {}
-list_artifacts            → { "kinds": ["triage", "tour"], "limit": 20 }
-summarize_triage          → { "number": 42 }
-open_in_easy_review       → { "number": 42 }
-```
+Setup: [docs/guide/mcp.html](../../docs/guide/mcp.html).
 
 ## Architecture
 
-- Pure ranking / file classification live in `er-engine` (`review_queue`, `git::file_kind`, `git::diff_stats`, `sidecar_summary`).
-- Client-owned uploads live in `er-engine::sidecar_upload` (prepare kit + validated write).
-- JSON Schema + prompt contracts live in `er-engine::sidecar_specs` (`get_artifact_specs`).
-- Desktop Saved pins live in `er-engine::projects_pins` (Value-preserving `projects.json` writes).
-- `er-mcp` is a thin `rmcp` 3.x stdio wrapper over those APIs.
-- **Protocol:** prefers `2026-07-28` (stateless `server/discover` + per-request `_meta`).
-  Still advertises older revisions so Cursor / Claude Code / Codex that use the
-  legacy `initialize` handshake keep working. Tool handlers are request-scoped
-  (no session state) — the same shape Streamable HTTP expects.
-
-## Notes
-
-- `prs_failing_ci` / `prs_blocked` / `prs_already_addressed` fetch per-PR metadata — use `scan_limit` (capped at 20) to bound cost; enrichments run in parallel.
-- `compare_prod_size` caps at 12 PRs and fetches diffs in parallel.
-- `prepare_review` + `upload_artifacts` share storage with Desktop without touching `agent_slots`.
-- `open_in_easy_review` returns instructions; there is no `er://` deep-link handler yet.
-- Production line counts exclude paths classified as test, Storybook, generated/lock, or docs.
+- Ranking, diff stats, sidecar I/O live in `er-engine`.
+- `pr_resolve` lives in `er-engine::pr_resolve`.
+- `er-mcp` is a thin `rmcp` stdio wrapper.

--- a/crates/er-mcp/src/main.rs
+++ b/crates/er-mcp/src/main.rs
@@ -1,6 +1,8 @@
 //! Easy Review MCP — triage open PRs from Cursor / Claude / other MCP clients.
 //!
-//! Transport: stdio (JSON-RPC). Logging goes to stderr so it does not corrupt the protocol.
+//! Transport: stdio (JSON-RPC). Speaks MCP **2026-07-28** (stateless discover) and
+//! older initialize-based revisions via `rmcp` 3.x. Logging goes to stderr so it
+//! does not corrupt the protocol.
 
 mod projects;
 mod server;

--- a/crates/er-mcp/src/projects.rs
+++ b/crates/er-mcp/src/projects.rs
@@ -1,6 +1,7 @@
 //! Read Easy Review desktop project config (`~/.config/er/projects.json`).
 
 use anyhow::{Context, Result};
+use er_engine::pr_resolve::{self, ProjectHint, ResolvePrRefInput, ResolvedPrRef};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -35,6 +36,18 @@ pub fn load_projects() -> ProjectsFile {
     serde_json::from_str(&content).unwrap_or_default()
 }
 
+pub fn project_hints(file: &ProjectsFile) -> Vec<ProjectHint> {
+    file.projects
+        .iter()
+        .map(|p| ProjectHint {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            root_path: p.root_path.clone(),
+            remote: p.remote.clone(),
+        })
+        .collect()
+}
+
 /// Normalize `owner/repo` or a GitHub URL into `(owner, repo)`.
 pub fn parse_repo_slug(remote: &str) -> Result<(String, String)> {
     er_engine::github::parse_remote_url(remote)
@@ -53,16 +66,42 @@ pub fn parse_repo_slug(remote: &str) -> Result<(String, String)> {
         .with_context(|| format!("invalid repo slug: {remote}"))
 }
 
+/// Resolved PR target for MCP tools.
+pub type ResolvedPr = ResolvedPrRef;
+
+#[derive(Debug, Clone, Default)]
+pub struct PrTargetInput<'a> {
+    pub ref_str: Option<&'a str>,
+    pub pr_url: Option<&'a str>,
+    pub repo: Option<&'a str>,
+    pub project_id: Option<&'a str>,
+    pub number: Option<u64>,
+}
+
+pub fn resolve_pr_target(input: &PrTargetInput<'_>) -> Result<ResolvedPr> {
+    let file = load_projects();
+    let hints = project_hints(&file);
+    pr_resolve::resolve_pr_ref(&ResolvePrRefInput {
+        ref_str: input.ref_str,
+        pr_url: input.pr_url,
+        repo: input.repo,
+        project_id: input.project_id,
+        number: input.number,
+        projects: &hints,
+        active_project_id: file.active_id.as_deref(),
+    })
+}
+
 /// Resolve `(owner, repo)` from explicit slug, project id, or active project.
 pub fn resolve_repo(
     repo: Option<&str>,
     project_id: Option<&str>,
 ) -> Result<(String, String, Option<String>)> {
+    let file = load_projects();
     if let Some(slug) = repo {
         let (o, r) = parse_repo_slug(slug)?;
         return Ok((o, r, None));
     }
-    let file = load_projects();
     let project = if let Some(id) = project_id {
         file.projects
             .iter()
@@ -96,5 +135,30 @@ mod tests {
         assert_eq!((o, r), ("acme".into(), "widgets".into()));
         let (o, r) = parse_repo_slug("https://github.com/acme/widgets.git").unwrap();
         assert_eq!((o.as_str(), r.as_str()), ("acme", "widgets"));
+    }
+
+    #[test]
+    fn resolve_pr_from_url() {
+        let pr = resolve_pr_target(&PrTargetInput {
+            pr_url: Some("https://github.com/acme/widgets/pull/42/files"),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(pr.owner, "acme");
+        assert_eq!(pr.repo, "widgets");
+        assert_eq!(pr.number, 42);
+        assert!(pr.bucket_path.contains("prs/pr-42"));
+    }
+
+    #[test]
+    fn resolve_pr_from_repo_and_number() {
+        let pr = resolve_pr_target(&PrTargetInput {
+            repo: Some("acme/widgets"),
+            number: Some(7),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(pr.number, 7);
+        assert!(pr.bucket_path.contains("prs/pr-7"));
     }
 }

--- a/crates/er-mcp/src/server.rs
+++ b/crates/er-mcp/src/server.rs
@@ -1,5 +1,7 @@
-//! MCP tool surface for Easy Review PR triage.
+//! MCP tool surface for Easy Review — thin REST API over er-engine.
 
+use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use er_engine::git::ProdDiffStats;
@@ -7,19 +9,19 @@ use er_engine::github::{
     gh_pr_checks_state_remote, gh_pr_list_queue, gh_pr_prod_diff_stats,
     gh_pr_thread_addressing_remote,
 };
+use er_engine::pr_review_feedback::{
+    get_pr_review_feedback, reply_to_pr_finding, reply_to_pr_note, reply_to_pr_question,
+};
 use er_engine::projects_pins::{self, PinnedPr};
 use er_engine::review_queue::{
     filter_blocked, filter_by_status, filter_failing_ci, filter_review_debt, filter_stale,
-    open_in_easy_review, rank_low_hanging, rank_priority, score_pr, QueuePr, RankedPr,
-    ReviewStatus,
+    rank_low_hanging, rank_priority, score_pr, QueuePr, RankedPr, ReviewStatus,
 };
-use er_engine::sidecar_specs::{artifact_specs, artifact_specs_for_dir};
+use er_engine::sidecar_specs::artifact_specs_for_dir;
 use er_engine::sidecar_summary::{list_repo_pr_artifacts, present_kinds, summarize_pr_sidecars};
 use er_engine::sidecar_upload::{
     prepare_review_kit, upload_pr_artifacts, SidecarKind, UploadArtifactsRequest,
 };
-use std::borrow::Cow;
-
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::*,
@@ -29,200 +31,152 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::projects::{self, resolve_repo};
+use crate::projects::{self, PrTargetInput, ResolvedPr};
 
 #[derive(Clone)]
 pub struct ErMcp {
-    /// Kept so callers can compose routers; `#[tool_handler]` uses `Self::tool_router()`.
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RepoArgs {
-    /// GitHub `owner/repo` (or URL). Defaults to the active Easy Review project remote.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct PrRefFields {
+    /// Universal ref: PR URL, worktree path, `owner/repo`, `owner/repo#N`, branch name, or bare PR number.
+    #[serde(default)]
+    pub r#ref: Option<String>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
     #[serde(default)]
     pub repo: Option<String>,
-    /// Easy Review project id from `~/.config/er/projects.json`.
     #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
+    pub number: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct LimitRepoArgs {
+pub struct PrResolveArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PrsQueryArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
     #[serde(default)]
-    pub repo: Option<String>,
+    pub cross_repo: Option<bool>,
+    /// `priority` | `smallest` | `updated` (default `priority`).
     #[serde(default)]
-    pub project_id: Option<String>,
-    /// Max PRs to return (default 5, max 50).
+    pub sort: Option<String>,
+    /// `review_debt` | `stale` | `blocked` | `failing_ci` | `ready` | `outdated` |
+    /// `waiting_on_author` | `addressed` | `draft` | `approved` | `merge_ready`.
     #[serde(default)]
-    pub limit: Option<u32>,
-    /// When true, enrich candidates with production-only line counts (slower: fetches diffs).
+    pub filter: Option<String>,
+    #[serde(default)]
+    pub stale_days: Option<u32>,
     #[serde(default)]
     pub production_lines: Option<bool>,
-    /// Include draft PRs (default false for low-hanging fruit).
     #[serde(default)]
     pub include_drafts: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct StaleArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    /// Days without GitHub activity (default 14).
-    #[serde(default)]
-    pub days: Option<u32>,
     #[serde(default)]
     pub limit: Option<u32>,
+    #[serde(default)]
+    pub scan_limit: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct DiffStatsArgs {
+pub struct PrStatsArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+    /// Compare multiple PR numbers in one repo (max 12). When set, `target.number` is ignored.
     #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    /// PR number.
-    pub number: u64,
-    /// Include per-file breakdown (default false).
+    pub numbers: Option<Vec<u64>>,
     #[serde(default)]
     pub include_files: Option<bool>,
+    #[serde(default)]
+    pub include_hotspots: Option<bool>,
+    #[serde(default)]
+    pub hotspot_limit: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct StatusFilterArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    /// One of: ready_to_review, draft, outdated, blocked_conflicts, waiting_on_author, approved, merge_ready, inactive
-    pub status: String,
-    #[serde(default)]
-    pub limit: Option<u32>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PrNumberArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    pub number: u64,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HotspotsArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    pub number: u64,
-    /// Max production files to return (default 10).
-    #[serde(default)]
-    pub limit: Option<u32>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CompareProdArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    /// PR numbers to compare.
-    pub numbers: Vec<u64>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PrepareReviewArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    pub number: u64,
-    /// Artifact kinds to prepare prompts for. Default: triage, review, tour.
-    /// Allowed: triage, review, tour.
+pub struct PrPrepareArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
     #[serde(default)]
     pub kinds: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct UploadArtifactsArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    pub number: u64,
-    /// One of: triage, review, tour.
+pub struct PrUploadArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
     pub kind: String,
-    /// Map of relative filename → file contents (e.g. `{"tour.json": "{...}"}`).
-    pub files: std::collections::BTreeMap<String, String>,
-    /// Re-fetch PR diff before validating (default false — reuse prepare_review's diff-tmp).
+    pub files: BTreeMap<String, String>,
     #[serde(default)]
     pub refresh_diff: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ArtifactSpecsArgs {
-    /// Artifact kinds to return. Default: triage, review, tour.
-    /// Allowed: triage, review, tour.
+pub struct PrGuideArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+    /// `prepare` (default) fetches diff + tour spec; `upload` writes tour.json.
     #[serde(default)]
-    pub kinds: Option<Vec<String>>,
+    pub action: Option<String>,
+    /// Required for `upload`: `{ "tour.json": "..." }`.
+    #[serde(default)]
+    pub files: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub refresh_diff: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct PinPrArgs {
+pub struct PrSummarizeArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PrFeedbackGetArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
     #[serde(default)]
-    pub repo: Option<String>,
+    pub include_resolved: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PrFeedbackReplyArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+    /// `question` | `note` | `finding`.
+    pub r#type: String,
+    pub id: String,
+    pub text: String,
     #[serde(default)]
-    pub project_id: Option<String>,
-    /// PR number to pin into Desktop Saved PRs.
-    pub number: u64,
-    /// Optional title (fetched via `gh` when omitted).
+    pub author: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PrSavedArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+    /// `pin` | `unpin` | `list`.
+    pub action: String,
+    /// For `list`: `pinned` | `artifacts` | `all` (default `all`).
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub kinds: Option<Vec<String>>,
     #[serde(default)]
     pub title: Option<String>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListArtifactsArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    /// Optional kind filter (any-of): triage, review, tour.
-    #[serde(default)]
-    pub kinds: Option<Vec<String>>,
-    /// Max PRs to return (default 50, max 50).
     #[serde(default)]
     pub limit: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CrossRepoArgs {
-    /// Max PRs to return across all projects (default 10).
-    #[serde(default)]
-    pub limit: Option<u32>,
-    /// Enrich with production-only lines (slower).
-    #[serde(default)]
-    pub production_lines: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ScanLimitArgs {
-    #[serde(default)]
-    pub repo: Option<String>,
-    #[serde(default)]
-    pub project_id: Option<String>,
-    #[serde(default)]
-    pub limit: Option<u32>,
-    /// Max open PRs to scan for expensive enrichments (default 20, max 40).
-    #[serde(default)]
-    pub scan_limit: Option<u32>,
-}
-
-fn clamp_limit(limit: Option<u32>, default: u32) -> usize {
-    limit.unwrap_or(default).clamp(1, 50) as usize
+fn clamp_limit(limit: Option<u32>, default: u32, max: u32) -> usize {
+    limit.unwrap_or(default).clamp(1, max) as usize
 }
 
 fn now_epoch_secs() -> i64 {
@@ -242,28 +196,47 @@ fn tool_err(msg: impl Into<String>) -> McpError {
     McpError::invalid_params(msg.into(), None)
 }
 
-/// Best-effort PR title via `gh pr view --json title`.
-fn fetch_pr_title(owner: &str, repo: &str, number: u64) -> Option<String> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            &format!("{owner}/{repo}"),
-            "--json",
-            "title",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+fn target_input(target: &PrRefFields) -> PrTargetInput<'_> {
+    PrTargetInput {
+        ref_str: target.r#ref.as_deref(),
+        pr_url: target.pr_url.as_deref(),
+        repo: target.repo.as_deref(),
+        project_id: target.project_id.as_deref(),
+        number: target.number,
     }
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-    value
-        .get("title")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+}
+
+fn resolve_target(target: &PrRefFields) -> Result<ResolvedPr, McpError> {
+    projects::resolve_pr_target(&target_input(target)).map_err(|e| tool_err(e.to_string()))
+}
+
+/// Repo slug for queue/list tools: explicit `repo`, or `ref` when it names a repo (`owner/repo`).
+fn query_repo_args(target: &PrRefFields) -> (Option<&str>, Option<&str>) {
+    if target.repo.as_deref().is_some_and(|s| !s.trim().is_empty()) {
+        return (target.repo.as_deref(), target.project_id.as_deref());
+    }
+    let Some(raw) = target
+        .r#ref
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        return (None, target.project_id.as_deref());
+    };
+    if let Some((left, _)) = raw.split_once('#').or_else(|| raw.split_once('!')) {
+        return (Some(left), target.project_id.as_deref());
+    }
+    if er_engine::github::parse_github_pr_url(raw).is_some() {
+        return (None, target.project_id.as_deref());
+    }
+    if raw.contains('/') && !raw.starts_with('/') && !raw.starts_with('~') {
+        return (Some(raw), target.project_id.as_deref());
+    }
+    (None, target.project_id.as_deref())
+}
+
+fn fetch_pr_title(owner: &str, repo: &str, number: u64) -> Option<String> {
+    er_engine::github::gh_pr_title(owner, repo, number)
 }
 
 fn pinned_sidecar_json(
@@ -288,8 +261,7 @@ async fn load_queue(
     project_id: Option<&str>,
 ) -> Result<(String, String, Option<String>, Vec<QueuePr>), McpError> {
     let (owner, name, project_name) =
-        resolve_repo(repo, project_id).map_err(|e| tool_err(e.to_string()))?;
-
+        projects::resolve_repo(repo, project_id).map_err(|e| tool_err(e.to_string()))?;
     let prs = tokio::task::spawn_blocking({
         let owner = owner.clone();
         let name = name.clone();
@@ -298,7 +270,6 @@ async fn load_queue(
     .await
     .map_err(|e| McpError::internal_error(e.to_string(), None))?
     .map_err(|e| tool_err(e.to_string()))?;
-
     Ok((owner, name, project_name, prs))
 }
 
@@ -316,7 +287,6 @@ async fn enrich_production_lines(owner: &str, repo: &str, prs: &mut [QueuePr], m
             )
         })
         .collect();
-
     let mut by_number = std::collections::HashMap::new();
     for (number, handle) in jobs {
         if let Ok(Ok(stats)) = handle.await {
@@ -346,7 +316,6 @@ async fn enrich_ci(owner: &str, repo: &str, prs: &mut [QueuePr], max_enrich: usi
             )
         })
         .collect();
-
     let mut by_number = std::collections::HashMap::new();
     for (number, handle) in jobs {
         if let Ok(state) = handle.await {
@@ -360,12 +329,254 @@ async fn enrich_ci(owner: &str, repo: &str, prs: &mut [QueuePr], max_enrich: usi
     }
 }
 
+fn parse_status_filter(filter: &str) -> Result<ReviewStatus, McpError> {
+    match filter.trim().to_ascii_lowercase().as_str() {
+        "ready" | "ready_to_review" => Ok(ReviewStatus::ReadyToReview),
+        "draft" => Ok(ReviewStatus::Draft),
+        "outdated" | "behind" => Ok(ReviewStatus::Outdated),
+        "blocked_conflicts" | "conflicts" => Ok(ReviewStatus::BlockedConflicts),
+        "waiting_on_author" | "changes_requested" => Ok(ReviewStatus::WaitingOnAuthor),
+        "approved" => Ok(ReviewStatus::Approved),
+        "merge_ready" | "ready_to_merge" => Ok(ReviewStatus::MergeReady),
+        "inactive" | "closed" | "merged" => Ok(ReviewStatus::Inactive),
+        other => Err(tool_err(format!(
+            "unknown filter status '{other}'; use review_debt|stale|blocked|failing_ci|ready|outdated|waiting_on_author|addressed|draft|approved|merge_ready"
+        ))),
+    }
+}
+
+fn parse_kind(s: &str) -> Result<SidecarKind, McpError> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "triage" => Ok(SidecarKind::Triage),
+        "review" => Ok(SidecarKind::Review),
+        "tour" => Ok(SidecarKind::Tour),
+        other => Err(tool_err(format!(
+            "unknown kind '{other}'; expected triage|review|tour"
+        ))),
+    }
+}
+
+fn parse_prepare_kinds(kinds: Option<Vec<String>>) -> Result<Vec<SidecarKind>, McpError> {
+    let parsed: Vec<SidecarKind> = match kinds {
+        None => vec![SidecarKind::Triage],
+        Some(list) if list.is_empty() => return Err(tool_err("kinds must not be empty")),
+        Some(list) => list
+            .iter()
+            .map(|s| parse_kind(s))
+            .collect::<Result<_, _>>()?,
+    };
+    if parsed.contains(&SidecarKind::Tour) {
+        return Err(tool_err(
+            "tour uses pr_guide — omit tour from pr_prepare kinds",
+        ));
+    }
+    Ok(parsed)
+}
+
+async fn prepare_kit_json(
+    pr: &ResolvedPr,
+    kinds: &[SidecarKind],
+    note: &str,
+) -> Result<serde_json::Value, McpError> {
+    let kinds_vec = kinds.to_vec();
+    let kinds_for_specs = kinds.to_vec();
+    let owner = pr.owner.clone();
+    let name = pr.repo.clone();
+    let number = pr.number;
+
+    let kit = tokio::task::spawn_blocking(move || {
+        prepare_review_kit(&owner, &name, number, &kinds_vec, &[])
+    })
+    .await
+    .map_err(|e| McpError::internal_error(e.to_string(), None))?
+    .map_err(|e| tool_err(e.to_string()))?;
+
+    let specs = artifact_specs_for_dir(&kinds_for_specs, &kit.er_dir, &kit.base_ref, &kit.head_ref);
+    let mut kit = kit;
+    for artifact in &mut kit.artifacts {
+        artifact.prompt.clear();
+    }
+
+    Ok(json!({
+        "project": pr.project_name,
+        "repo": format!("{}/{}", pr.owner, pr.repo),
+        "number": pr.number,
+        "bucket_path": pr.bucket_path,
+        "pr_url": pr.pr_url,
+        "kit": kit,
+        "artifact_specs": specs,
+        "note": note,
+    }))
+}
+
 #[derive(Serialize)]
 struct TaggedRankedPr<'a> {
     project: Option<&'a str>,
     repo: String,
     #[serde(flatten)]
     ranked: RankedPr,
+}
+
+async fn query_single_repo(args: &PrsQueryArgs) -> Result<serde_json::Value, McpError> {
+    let limit = clamp_limit(args.limit, 10, 50);
+    let scan = clamp_limit(args.scan_limit, 15, 20);
+    let sort = args
+        .sort
+        .as_deref()
+        .unwrap_or("priority")
+        .to_ascii_lowercase();
+    let filter = args.filter.as_deref().map(|s| s.to_ascii_lowercase());
+
+    let (repo, project_id) = query_repo_args(&args.target);
+    let (owner, name, project_name, mut prs) = load_queue(repo, project_id).await?;
+
+    let needs_ci = matches!(filter.as_deref(), Some("blocked") | Some("failing_ci"));
+    if needs_ci {
+        let n = prs.len().min(scan);
+        enrich_ci(&owner, &name, &mut prs[..n], scan).await;
+    }
+
+    if args.production_lines.unwrap_or(false)
+        || sort == "smallest"
+        || filter.as_deref() == Some("blocked")
+    {
+        let window = prs.len().min(if sort == "smallest" {
+            25
+        } else {
+            scan.max(limit)
+        });
+        enrich_production_lines(&owner, &name, &mut prs[..window], window).await;
+    }
+
+    let ranked: Vec<RankedPr> = match filter.as_deref() {
+        Some("review_debt") => filter_review_debt(&prs, limit),
+        Some("stale") => {
+            let days = args.stale_days.unwrap_or(14).clamp(1, 365) as u64;
+            filter_stale(&prs, days, now_epoch_secs(), limit)
+        }
+        Some("blocked") => filter_blocked(&prs, limit),
+        Some("failing_ci") => filter_failing_ci(&prs, limit),
+        Some("addressed") => filter_addressed(&owner, &name, &prs, scan, limit).await?,
+        Some(f) => {
+            let status = parse_status_filter(f)?;
+            let mut rows = filter_by_status(&prs, status);
+            rows.truncate(limit);
+            rows
+        }
+        None => match sort.as_str() {
+            "smallest" => rank_low_hanging(&prs, limit, args.include_drafts.unwrap_or(false)),
+            "updated" => {
+                let mut scored: Vec<_> = prs.iter().map(score_pr).collect();
+                scored.sort_by(|a, b| b.pr.updated_at.cmp(&a.pr.updated_at));
+                scored.truncate(limit);
+                scored
+            }
+            _ => rank_priority(&prs, limit),
+        },
+    };
+
+    Ok(json!({
+        "repo": format!("{owner}/{name}"),
+        "project": project_name,
+        "sort": sort,
+        "filter": filter,
+        "count": ranked.len(),
+        "prs": ranked,
+    }))
+}
+
+async fn filter_addressed(
+    owner: &str,
+    name: &str,
+    prs: &[QueuePr],
+    scan: usize,
+    limit: usize,
+) -> Result<Vec<RankedPr>, McpError> {
+    let mut out = Vec::new();
+    for pr in prs
+        .iter()
+        .filter(|p| p.state.eq_ignore_ascii_case("OPEN"))
+        .take(scan)
+    {
+        let owner_c = owner.to_string();
+        let name_c = name.to_string();
+        let number = pr.number;
+        let summary = tokio::task::spawn_blocking(move || {
+            gh_pr_thread_addressing_remote(&owner_c, &name_c, number).unwrap_or_default()
+        })
+        .await
+        .unwrap_or_default();
+        if summary.all_addressed {
+            let mut ranked = score_pr(pr);
+            ranked.reasons.push(format!(
+                "threads addressed: {} resolved, {} outdated, {} open",
+                summary.resolved, summary.outdated, summary.open
+            ));
+            out.push(ranked);
+        }
+        if out.len() >= limit {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+async fn query_cross_repo(args: &PrsQueryArgs) -> Result<serde_json::Value, McpError> {
+    let limit = clamp_limit(args.limit, 10, 50);
+    let file = projects::load_projects();
+    let mut tagged: Vec<TaggedRankedPr<'_>> = Vec::new();
+    let mut batches: Vec<(String, String, String, Vec<QueuePr>)> = Vec::new();
+
+    let mut list_jobs = Vec::new();
+    for project in &file.projects {
+        let Some(remote) = project.remote.as_deref() else {
+            continue;
+        };
+        let Ok((owner, name)) = projects::parse_repo_slug(remote) else {
+            continue;
+        };
+        let project_name = project.name.clone();
+        list_jobs.push((
+            project_name,
+            owner.clone(),
+            name.clone(),
+            tokio::task::spawn_blocking(move || gh_pr_list_queue(&owner, &name, "open", 50)),
+        ));
+    }
+    for (project_name, owner, name, handle) in list_jobs {
+        let prs = handle.await.ok().and_then(|r| r.ok()).unwrap_or_default();
+        batches.push((project_name, owner, name, prs));
+    }
+
+    if args.production_lines.unwrap_or(false) {
+        for (_, owner, name, prs) in &mut batches {
+            let window = prs.len().min(10);
+            enrich_production_lines(owner, name, &mut prs[..window], window).await;
+        }
+    }
+
+    for (project_name, owner, name, prs) in &batches {
+        for pr in prs {
+            tagged.push(TaggedRankedPr {
+                project: Some(project_name.as_str()),
+                repo: format!("{owner}/{name}"),
+                ranked: score_pr(pr),
+            });
+        }
+    }
+    tagged.sort_by(|a, b| {
+        b.ranked
+            .priority_score
+            .cmp(&a.ranked.priority_score)
+            .then_with(|| a.ranked.total_lines.cmp(&b.ranked.total_lines))
+    });
+    tagged.truncate(limit);
+
+    Ok(json!({
+        "projects_scanned": batches.len(),
+        "limit": limit,
+        "prs": tagged,
+    }))
 }
 
 #[tool_router]
@@ -376,10 +587,8 @@ impl ErMcp {
         }
     }
 
-    #[tool(
-        description = "List Easy Review projects from ~/.config/er/projects.json (name, id, remote)."
-    )]
-    async fn list_projects(&self) -> Result<CallToolResult, McpError> {
+    #[tool(description = "List Easy Review projects from ~/.config/er/projects.json.")]
+    async fn projects_list(&self) -> Result<CallToolResult, McpError> {
         let file = projects::load_projects();
         text_json(&json!({
             "active_id": file.active_id,
@@ -393,92 +602,85 @@ impl ErMcp {
     }
 
     #[tool(
-        description = "List open PRs for a repo (or the active Easy Review project) with size, review decision, and merge state."
+        description = "Resolve a PR ref (URL, worktree path, owner/repo, owner/repo#N, branch, or number) to owner/repo/number + bucket_path."
     )]
-    async fn list_prs(
+    async fn pr_resolve(
         &self,
-        Parameters(args): Parameters<RepoArgs>,
+        Parameters(args): Parameters<PrResolveArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name, prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let ranked: Vec<_> = prs.iter().map(score_pr).collect();
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
+        let pr = resolve_target(&args.target)?;
+        text_json(&pr)
     }
 
     #[tool(
-        description = "Top priority PRs to review next. Scores by review request, readiness, size, labels, and blocked/outdated penalties."
+        description = "Query open PRs: sort (priority|smallest|updated), filter (review_debt|stale|blocked|failing_ci|ready|addressed|…), optional cross_repo."
     )]
-    async fn priority_prs(
+    async fn prs_query(
         &self,
-        Parameters(args): Parameters<LimitRepoArgs>,
+        Parameters(args): Parameters<PrsQueryArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 5);
-        let (owner, name, project_name, mut prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
+        let body = if args.cross_repo.unwrap_or(false) {
+            query_cross_repo(&args).await?
+        } else {
+            query_single_repo(&args).await?
+        };
+        text_json(&body)
+    }
 
-        if args.production_lines.unwrap_or(false) {
-            let window = (limit * 3).min(prs.len());
-            enrich_production_lines(&owner, &name, &mut prs[..window], window).await;
+    #[tool(
+        description = "PR diff stats (production vs test/docs). Single PR via ref, or batch via numbers=[…]. Optional hotspots."
+    )]
+    async fn pr_stats(
+        &self,
+        Parameters(args): Parameters<PrStatsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let hotspot_limit = clamp_limit(args.hotspot_limit, 10, 50);
+
+        if let Some(numbers) = args.numbers.filter(|n| !n.is_empty()) {
+            if numbers.len() > 12 {
+                return Err(tool_err("compare at most 12 PRs at a time"));
+            }
+            let (repo, project_id) = query_repo_args(&args.target);
+            let (owner, name, project_name) =
+                projects::resolve_repo(repo, project_id).map_err(|e| tool_err(e.to_string()))?;
+            let mut rows = Vec::new();
+            for number in numbers {
+                let owner_c = owner.clone();
+                let name_c = name.clone();
+                let stats = tokio::task::spawn_blocking(move || {
+                    gh_pr_prod_diff_stats(&owner_c, &name_c, number)
+                })
+                .await
+                .ok()
+                .and_then(|r| r.ok());
+                rows.push(match stats {
+                    Some(stats) => json!({
+                        "number": number,
+                        "production_lines": stats.production.lines_changed(),
+                        "total_lines": stats.total.lines_changed(),
+                        "production_files": stats.production.files,
+                    }),
+                    None => json!({ "number": number, "error": "failed to fetch diff" }),
+                });
+            }
+            rows.sort_by_key(|row| {
+                row.get("production_lines")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(u64::MAX)
+            });
+            return text_json(&json!({
+                "repo": format!("{owner}/{name}"),
+                "project": project_name,
+                "prs": rows,
+            }));
         }
 
-        let ranked = rank_priority(&prs, limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "limit": limit,
-            "production_lines_enriched": args.production_lines.unwrap_or(false),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "Smallest / low-hanging-fruit open PRs. Defaults to production-only line enrichment (excludes test, storybook, generated, docs)."
-    )]
-    async fn low_hanging_fruit(
-        &self,
-        Parameters(args): Parameters<LimitRepoArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 5);
-        let include_drafts = args.include_drafts.unwrap_or(false);
-        let (owner, name, project_name, mut prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-
-        if args.production_lines.unwrap_or(true) {
-            let window = prs.len().min(25);
-            enrich_production_lines(&owner, &name, &mut prs[..window], window).await;
-        }
-
-        let ranked = rank_low_hanging(&prs, limit, include_drafts);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "limit": limit,
-            "sorted_by": if args.production_lines.unwrap_or(true) {
-                "production_lines"
-            } else {
-                "total_github_lines"
-            },
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "Diff line stats for one PR, split into production vs test / storybook / generated / docs."
-    )]
-    async fn pr_diff_stats(
-        &self,
-        Parameters(args): Parameters<DiffStatsArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
         let include_files = args.include_files.unwrap_or(false);
+        let include_hotspots = args.include_hotspots.unwrap_or(false);
 
         let stats: ProdDiffStats = tokio::task::spawn_blocking({
             let owner = owner.clone();
@@ -494,443 +696,117 @@ impl ErMcp {
         } else {
             stats.summary_only()
         };
-
-        text_json(&json!({
+        let mut body = json!({
             "repo": format!("{owner}/{name}"),
-            "project": project_name,
+            "project": pr.project_name,
             "number": number,
+            "bucket_path": pr.bucket_path,
             "stats": stats,
             "production_lines": stats.production.lines_changed(),
             "total_lines": stats.total.lines_changed(),
-        }))
-    }
-
-    #[tool(
-        description = "List open PRs filtered by review status: ready_to_review, draft, outdated, blocked_conflicts, waiting_on_author, approved, merge_ready."
-    )]
-    async fn prs_by_status(
-        &self,
-        Parameters(args): Parameters<StatusFilterArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let status = parse_status(&args.status)?;
-        let limit = clamp_limit(args.limit, 20);
-        let (owner, name, project_name, prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let mut ranked = filter_by_status(&prs, status);
-        ranked.truncate(limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "status": status.as_str(),
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "PRs blocked by merge conflicts, mergeStateStatus=BLOCKED, or failing CI (fetches checks). Use for 'what is blocked?'."
-    )]
-    async fn prs_blocked(
-        &self,
-        Parameters(args): Parameters<ScanLimitArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 20);
-        let scan = clamp_limit(args.scan_limit, 15).min(20);
-        let (owner, name, project_name, mut prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let n = prs.len().min(scan);
-        enrich_ci(&owner, &name, &mut prs[..n], scan).await;
-        let ranked = filter_blocked(&prs, limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "Open PRs with failing CI checks. Fetches `gh pr checks` for a scan window."
-    )]
-    async fn prs_failing_ci(
-        &self,
-        Parameters(args): Parameters<ScanLimitArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 20);
-        let scan = clamp_limit(args.scan_limit, 15).min(20);
-        let (owner, name, project_name, mut prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let n = prs.len().min(scan);
-        enrich_ci(&owner, &name, &mut prs[..n], scan).await;
-        let ranked = filter_failing_ci(&prs, limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "PRs where review was requested of you and you have not approved / requested changes yet (your review debt)."
-    )]
-    async fn my_review_debt(
-        &self,
-        Parameters(args): Parameters<LimitRepoArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 20);
-        let (owner, name, project_name, prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let ranked = filter_review_debt(&prs, limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "Stale open PRs with no GitHub activity for N days (default 14). Uses PR updatedAt."
-    )]
-    async fn prs_stale(
-        &self,
-        Parameters(args): Parameters<StaleArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let days = args.days.unwrap_or(14).clamp(1, 365) as u64;
-        let limit = clamp_limit(args.limit, 20);
-        let (owner, name, project_name, prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-        let ranked = filter_stale(&prs, days, now_epoch_secs(), limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "days": days,
-            "count": ranked.len(),
-            "prs": ranked,
-        }))
-    }
-
-    #[tool(
-        description = "PRs where all review threads are resolved or outdated (feedback already addressed / fixed). Scans open PRs via GraphQL."
-    )]
-    async fn prs_already_addressed(
-        &self,
-        Parameters(args): Parameters<ScanLimitArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 20);
-        let scan = clamp_limit(args.scan_limit, 15).min(20);
-        let (owner, name, project_name, prs) =
-            load_queue(args.repo.as_deref(), args.project_id.as_deref()).await?;
-
-        let mut out = Vec::new();
-        for pr in prs
-            .iter()
-            .filter(|p| p.state.eq_ignore_ascii_case("OPEN"))
-            .take(scan)
-        {
-            let owner_c = owner.clone();
-            let name_c = name.clone();
-            let number = pr.number;
-            let summary = tokio::task::spawn_blocking(move || {
-                gh_pr_thread_addressing_remote(&owner_c, &name_c, number).unwrap_or_default()
-            })
-            .await
-            .unwrap_or_default();
-            if summary.all_addressed {
-                let mut ranked = score_pr(pr);
-                ranked.reasons.push(format!(
-                    "threads addressed: {} resolved, {} outdated, {} open",
-                    summary.resolved, summary.outdated, summary.open
-                ));
-                out.push(json!({
-                    "ranked": ranked,
-                    "threads": summary,
-                }));
-            }
-            if out.len() >= limit {
-                break;
-            }
+        });
+        if include_hotspots {
+            body["hotspots"] = json!(stats.production_hotspots(hotspot_limit));
         }
-
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "scanned": scan.min(prs.len()),
-            "count": out.len(),
-            "prs": out,
-        }))
+        text_json(&body)
     }
 
     #[tool(
-        description = "Priority PRs across ALL configured Easy Review projects (cross-repo review queue)."
+        description = "Prepare a PR review kit (diff-tmp + diff_hash + artifact_specs). You review; then call pr_upload."
     )]
-    async fn cross_repo_queue(
+    async fn pr_prepare(
         &self,
-        Parameters(args): Parameters<CrossRepoArgs>,
+        Parameters(args): Parameters<PrPrepareArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let limit = clamp_limit(args.limit, 10);
-        let file = projects::load_projects();
-        let mut tagged: Vec<TaggedRankedPr<'_>> = Vec::new();
-        // Collect owned strings first so we can borrow project names.
-        let mut batches: Vec<(String, String, String, Vec<QueuePr>)> = Vec::new();
+        let pr = resolve_target(&args.target)?;
+        let kinds = parse_prepare_kinds(args.kinds)?;
+        let body = prepare_kit_json(
+            &pr,
+            &kinds,
+            "Author files per artifact_specs; embed kit.diff_hash; then pr_upload.",
+        )
+        .await?;
+        text_json(&body)
+    }
 
-        let mut list_jobs = Vec::new();
-        for project in &file.projects {
-            let Some(remote) = project.remote.as_deref() else {
-                continue;
-            };
-            let Ok((owner, name)) = projects::parse_repo_slug(remote) else {
-                continue;
-            };
-            let project_name = project.name.clone();
-            list_jobs.push((
-                project_name,
-                owner.clone(),
-                name.clone(),
-                tokio::task::spawn_blocking(move || gh_pr_list_queue(&owner, &name, "open", 50)),
+    #[tool(
+        description = "Create a guided tour (tour.json) for a PR. action=prepare fetches diff + tour schema; action=upload writes tour.json."
+    )]
+    async fn pr_guide(
+        &self,
+        Parameters(args): Parameters<PrGuideArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let action = args
+            .action
+            .as_deref()
+            .unwrap_or("prepare")
+            .to_ascii_lowercase();
+        let pr = resolve_target(&args.target)?;
+
+        match action.as_str() {
+            "prepare" => {
+                let body = prepare_kit_json(
+                    &pr,
+                    &[SidecarKind::Tour],
+                    "Read diff_tmp_path, author tour.json per artifact_specs (3–7 pillars), embed kit.diff_hash, then pr_guide action=upload.",
+                )
+                .await?;
+                text_json(&body)
+            }
+            "upload" => {
+                let files = args
+                    .files
+                    .filter(|f| !f.is_empty())
+                    .ok_or_else(|| tool_err("upload requires files: { \"tour.json\": \"...\" }"))?;
+                let owner = pr.owner.clone();
+                let name = pr.repo.clone();
+                let number = pr.number;
+                let refresh_diff = args.refresh_diff.unwrap_or(false);
+
+                let result = tokio::task::spawn_blocking(move || {
+                    upload_pr_artifacts(UploadArtifactsRequest {
+                        owner,
+                        repo: name,
+                        pr: number,
+                        kind: SidecarKind::Tour,
+                        files,
+                        refresh_diff,
+                    })
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?;
+
+                text_json(&json!({
+                    "project": pr.project_name,
+                    "repo": format!("{}/{}", pr.owner, pr.repo),
+                    "number": pr.number,
+                    "bucket_path": pr.bucket_path,
+                    "uploaded": result,
+                    "note": "Open the PR in Desktop/TUI Guide tab, or pr_summarize.",
+                }))
+            }
+            _ => Err(tool_err("action must be prepare or upload")),
+        }
+    }
+
+    #[tool(
+        description = "Upload triage or review sidecars into shared Easy Review storage. Tours use pr_guide."
+    )]
+    async fn pr_upload(
+        &self,
+        Parameters(args): Parameters<PrUploadArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let pr = resolve_target(&args.target)?;
+        let kind = parse_kind(&args.kind)?;
+        if kind == SidecarKind::Tour {
+            return Err(tool_err(
+                "tour uploads use pr_guide with action=upload — not pr_upload",
             ));
         }
-        for (project_name, owner, name, handle) in list_jobs {
-            let prs = handle.await.ok().and_then(|r| r.ok()).unwrap_or_default();
-            batches.push((project_name, owner, name, prs));
-        }
-
-        if args.production_lines.unwrap_or(false) {
-            for (_, owner, name, prs) in &mut batches {
-                let window = prs.len().min(10);
-                enrich_production_lines(owner, name, &mut prs[..window], window).await;
-            }
-        }
-
-        for (project_name, owner, name, prs) in &batches {
-            for pr in prs {
-                tagged.push(TaggedRankedPr {
-                    project: Some(project_name.as_str()),
-                    repo: format!("{owner}/{name}"),
-                    ranked: score_pr(pr),
-                });
-            }
-        }
-        tagged.sort_by(|a, b| {
-            b.ranked
-                .priority_score
-                .cmp(&a.ranked.priority_score)
-                .then_with(|| a.ranked.total_lines.cmp(&b.ranked.total_lines))
-        });
-        tagged.truncate(limit);
-
-        text_json(&json!({
-            "projects_scanned": batches.len(),
-            "limit": limit,
-            "prs": tagged,
-        }))
-    }
-
-    #[tool(
-        name = "open_in_easy_review",
-        description = "How to open a PR in Easy Review (GitHub URL + desktop/TUI instructions). No OS deep-link yet."
-    )]
-    async fn open_in_easy_review_tool(
-        &self,
-        Parameters(args): Parameters<PrNumberArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let hint = open_in_easy_review(&owner, &name, args.number);
-        text_json(&json!({
-            "project": project_name,
-            "open": hint,
-        }))
-    }
-
-    #[tool(
-        description = "Summarize managed Easy Review triage.json / review.json / tour.json sidecars for a PR (local app data), if present."
-    )]
-    async fn summarize_triage(
-        &self,
-        Parameters(args): Parameters<PrNumberArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
-        let summary =
-            tokio::task::spawn_blocking(move || summarize_pr_sidecars(&owner, &name, number))
-                .await
-                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        text_json(&json!({
-            "project": project_name,
-            "summary": summary,
-        }))
-    }
-
-    #[tool(
-        description = "Top production-code files by churn in a PR (excludes test/storybook/generated/docs)."
-    )]
-    async fn diff_hotspots(
-        &self,
-        Parameters(args): Parameters<HotspotsArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
-        let limit = clamp_limit(args.limit, 10);
-        let stats: ProdDiffStats = tokio::task::spawn_blocking({
-            let owner = owner.clone();
-            let name = name.clone();
-            move || gh_pr_prod_diff_stats(&owner, &name, number)
-        })
-        .await
-        .map_err(|e| McpError::internal_error(e.to_string(), None))?
-        .map_err(|e| tool_err(e.to_string()))?;
-        let hotspots = stats.production_hotspots(limit);
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "number": number,
-            "production_lines": stats.production.lines_changed(),
-            "hotspots": hotspots,
-        }))
-    }
-
-    #[tool(
-        description = "Compare production-only changed lines for a list of PR numbers and rank smallest → largest."
-    )]
-    async fn compare_prod_size(
-        &self,
-        Parameters(args): Parameters<CompareProdArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        if args.numbers.is_empty() {
-            return Err(tool_err("numbers must be a non-empty array of PR numbers"));
-        }
-        if args.numbers.len() > 12 {
-            return Err(tool_err("compare at most 12 PRs at a time"));
-        }
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-
-        let jobs: Vec<_> = args
-            .numbers
-            .into_iter()
-            .map(|number| {
-                let owner_c = owner.clone();
-                let name_c = name.clone();
-                (
-                    number,
-                    tokio::task::spawn_blocking(move || {
-                        gh_pr_prod_diff_stats(&owner_c, &name_c, number)
-                    }),
-                )
-            })
-            .collect();
-
-        let mut rows = Vec::new();
-        for (number, handle) in jobs {
-            let stats = handle.await.ok().and_then(|r| r.ok());
-            let Some(stats) = stats else {
-                rows.push(json!({
-                    "number": number,
-                    "error": "failed to fetch diff",
-                }));
-                continue;
-            };
-            rows.push(json!({
-                "number": number,
-                "production_lines": stats.production.lines_changed(),
-                "total_lines": stats.total.lines_changed(),
-                "production_files": stats.production.files,
-                "test_lines": stats.test.lines_changed(),
-                "generated_lines": stats.generated.lines_changed(),
-            }));
-        }
-        rows.sort_by(|a, b| {
-            let la = a
-                .get("production_lines")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(u64::MAX);
-            let lb = b
-                .get("production_lines")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(u64::MAX);
-            la.cmp(&lb)
-        });
-
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project": project_name,
-            "prs": rows,
-        }))
-    }
-
-    #[tool(
-        description = "Prepare a PR review kit (writes shared diff-tmp, returns diff_hash + prompts). You (the MCP client agent) do the review yourself, then call upload_artifacts. Does not spawn agent CLIs."
-    )]
-    async fn prepare_review(
-        &self,
-        Parameters(args): Parameters<PrepareReviewArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
-        let kinds = parse_kinds(args.kinds).map_err(tool_err)?;
-        let kinds_for_specs = kinds.clone();
-
-        let kit = tokio::task::spawn_blocking(move || {
-            prepare_review_kit(&owner, &name, number, &kinds, &[])
-        })
-        .await
-        .map_err(|e| McpError::internal_error(e.to_string(), None))?
-        .map_err(|e| tool_err(e.to_string()))?;
-
-        let specs =
-            artifact_specs_for_dir(&kinds_for_specs, &kit.er_dir, &kit.base_ref, &kit.head_ref);
-
-        // Drop duplicate prompts from kit.artifacts — use artifact_specs[].prompt only.
-        let mut kit = kit;
-        for artifact in &mut kit.artifacts {
-            artifact.prompt.clear();
-        }
-
-        text_json(&json!({
-            "project": project_name,
-            "kit": kit,
-            "artifact_specs": specs,
-            "note": "Author files using artifact_specs schemas/examples/prompts; embed kit.diff_hash; then upload_artifacts. Upload validates serde shape + diff_hash (not full JSON Schema).",
-        }))
-    }
-
-    #[tool(
-        description = "Return JSON Schema, examples, and prepared-diff prompts for triage/review/tour sidecars so you can author upload_artifacts payloads precisely. No network / no PR required."
-    )]
-    async fn get_artifact_specs(
-        &self,
-        Parameters(args): Parameters<ArtifactSpecsArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let kinds = parse_kinds(args.kinds).map_err(tool_err)?;
-        let specs = artifact_specs(&kinds);
-        text_json(&json!({
-            "flow": "get_artifact_specs → prepare_review → author files per schema → upload_artifacts → summarize_triage",
-            "specs": specs,
-        }))
-    }
-
-    #[tool(
-        description = "Upload triage/review/tour sidecar files you produced into shared Easy Review storage. Validates JSON deserialize + diff_hash in memory before writing (does not enforce full JSON Schema from get_artifact_specs)."
-    )]
-    async fn upload_artifacts(
-        &self,
-        Parameters(args): Parameters<UploadArtifactsArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, project_name) =
-            resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-                .map_err(|e| tool_err(e.to_string()))?;
-        let kind = parse_kind(&args.kind).map_err(tool_err)?;
-        let number = args.number;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
         let files = args.files;
         let refresh_diff = args.refresh_diff.unwrap_or(false);
 
@@ -949,24 +825,146 @@ impl ErMcp {
         .map_err(|e| tool_err(e.to_string()))?;
 
         text_json(&json!({
-            "project": project_name,
+            "project": pr.project_name,
+            "repo": format!("{}/{}", pr.owner, pr.repo),
+            "number": pr.number,
+            "bucket_path": pr.bucket_path,
             "uploaded": result,
-            "note": "Sidecars are in shared managed storage — open the PR in Desktop/TUI, call summarize_triage, or pin_pr to bookmark in Desktop Saved.",
         }))
     }
 
-    #[tool(
-        description = "Pin a PR into Desktop Saved PRs (projects.json saved_prs) so you can find agent-reviewed work later. Does not auto-pin on upload — call explicitly after review."
-    )]
-    async fn pin_pr(
+    #[tool(description = "Summarize managed triage/review/tour sidecars for a PR.")]
+    async fn pr_summarize(
         &self,
-        Parameters(args): Parameters<PinPrArgs>,
+        Parameters(args): Parameters<PrSummarizeArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-            .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
+        let summary =
+            tokio::task::spawn_blocking(move || summarize_pr_sidecars(&owner, &name, number))
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        text_json(&json!({
+            "project": pr.project_name,
+            "repo": format!("{}/{}", pr.owner, pr.repo),
+            "number": pr.number,
+            "bucket_path": pr.bucket_path,
+            "summary": summary,
+        }))
+    }
+
+    #[tool(description = "Read review questions, notes, and AI findings for a PR.")]
+    async fn pr_feedback_get(
+        &self,
+        Parameters(args): Parameters<PrFeedbackGetArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
+        let include_resolved = args.include_resolved.unwrap_or(false);
+        let feedback = tokio::task::spawn_blocking(move || {
+            get_pr_review_feedback(&owner, &name, number, include_resolved)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        .map_err(|e| tool_err(e.to_string()))?;
+        text_json(&json!({
+            "project": pr.project_name,
+            "repo": format!("{}/{}", pr.owner, pr.repo),
+            "number": pr.number,
+            "bucket_path": pr.bucket_path,
+            "feedback": feedback,
+        }))
+    }
+
+    #[tool(description = "Reply to a question, note, or AI finding on a PR.")]
+    async fn pr_feedback_reply(
+        &self,
+        Parameters(args): Parameters<PrFeedbackReplyArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
+        let text = args.text;
+        let author = args.author;
+
+        let reply = match args.r#type.to_ascii_lowercase().as_str() {
+            "question" => {
+                let question_id = args.id.clone();
+                tokio::task::spawn_blocking(move || {
+                    reply_to_pr_question(
+                        &owner,
+                        &name,
+                        number,
+                        &question_id,
+                        &text,
+                        author.as_deref(),
+                    )
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?
+            }
+            "note" => {
+                let note_id = args.id.clone();
+                tokio::task::spawn_blocking(move || {
+                    reply_to_pr_note(&owner, &name, number, &note_id, &text, author.as_deref())
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?
+            }
+            "finding" => {
+                let finding_id = args.id.clone();
+                tokio::task::spawn_blocking(move || {
+                    reply_to_pr_finding(&owner, &name, number, &finding_id, &text)
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?
+            }
+            other => {
+                return Err(tool_err(format!(
+                    "type must be question, note, or finding (got '{other}')"
+                )));
+            }
+        };
+
+        text_json(&json!({
+            "project": pr.project_name,
+            "repo": format!("{}/{}", pr.owner, pr.repo),
+            "number": pr.number,
+            "bucket_path": pr.bucket_path,
+            "reply": reply,
+        }))
+    }
+
+    #[tool(description = "Pin, unpin, or list saved PRs and uploaded artifacts.")]
+    async fn pr_saved(
+        &self,
+        Parameters(args): Parameters<PrSavedArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        match args.action.to_ascii_lowercase().as_str() {
+            "pin" => self.pr_saved_pin(args).await,
+            "unpin" => self.pr_saved_unpin(args).await,
+            "list" => self.pr_saved_list(args).await,
+            _ => Err(tool_err("action must be pin, unpin, or list")),
+        }
+    }
+}
+
+impl ErMcp {
+    async fn pr_saved_pin(&self, args: PrSavedArgs) -> Result<CallToolResult, McpError> {
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
         let title_arg = args.title.clone();
-        let project_id_arg = args.project_id.clone();
+        let project_id_arg = args.target.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
             let (project_id, project_name) =
@@ -989,19 +987,15 @@ impl ErMcp {
             "project_id": project_id,
             "project": project_name,
             "pinned": pinned_sidecar_json(&pinned, &summary),
-            "note": "Also visible in Desktop sidebar Saved PRs.",
         }))
     }
 
-    #[tool(description = "Remove a PR from Desktop Saved PRs (unpin).")]
-    async fn unpin_pr(
-        &self,
-        Parameters(args): Parameters<PrNumberArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-            .map_err(|e| tool_err(e.to_string()))?;
-        let number = args.number;
-        let project_id_arg = args.project_id.clone();
+    async fn pr_saved_unpin(&self, args: PrSavedArgs) -> Result<CallToolResult, McpError> {
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
+        let project_id_arg = args.target.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
             let Some((project_id, project_name)) =
@@ -1026,218 +1020,121 @@ impl ErMcp {
         }))
     }
 
-    #[tool(
-        description = "List Desktop Saved (pinned) PRs for a repo/project, enriched with which triage/review/tour sidecars exist in managed storage."
-    )]
-    async fn list_pinned_prs(
-        &self,
-        Parameters(args): Parameters<RepoArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-            .map_err(|e| tool_err(e.to_string()))?;
-        let project_id_arg = args.project_id.clone();
-
-        let result = tokio::task::spawn_blocking(move || {
-            let Some((project_id, project_name)) =
-                projects_pins::resolve_project_for_list(project_id_arg.as_deref(), &owner, &name)?
-            else {
-                return Ok((None, None, owner, name, Vec::<serde_json::Value>::new()));
-            };
-            let pinned = projects_pins::list_pinned(&project_id)?;
-            let rows: Vec<_> = pinned
-                .iter()
-                .map(|entry| {
-                    let summary = summarize_pr_sidecars(&owner, &name, entry.number);
-                    pinned_sidecar_json(entry, &summary)
-                })
-                .collect();
-            Ok::<_, anyhow::Error>((Some(project_id), Some(project_name), owner, name, rows))
-        })
-        .await
-        .map_err(|e| McpError::internal_error(e.to_string(), None))?
-        .map_err(|e| tool_err(e.to_string()))?;
-
-        let (project_id, project_name, owner, name, prs) = result;
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project_id": project_id,
-            "project": project_name,
-            "count": prs.len(),
-            "prs": prs,
-        }))
-    }
-
-    #[tool(
-        description = "List PRs in managed storage that have uploaded triage/review/tour artifacts (whether pinned or not). Optional kinds filter. Marks pinned:true when in Desktop Saved."
-    )]
-    async fn list_artifacts(
-        &self,
-        Parameters(args): Parameters<ListArtifactsArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let (owner, name, _) = resolve_repo(args.repo.as_deref(), args.project_id.as_deref())
-            .map_err(|e| tool_err(e.to_string()))?;
+    async fn pr_saved_list(&self, args: PrSavedArgs) -> Result<CallToolResult, McpError> {
+        let source = args.source.as_deref().unwrap_or("all").to_ascii_lowercase();
+        let (repo, project_id) = query_repo_args(&args.target);
+        let (owner, name, project_name) =
+            projects::resolve_repo(repo, project_id).map_err(|e| tool_err(e.to_string()))?;
+        let limit = clamp_limit(args.limit, 50, 50);
+        let project_id_arg = args.target.project_id.clone();
         let kinds = match args.kinds {
             None => None,
             Some(list) if list.is_empty() => None,
             Some(list) => Some(
                 list.iter()
                     .map(|s| parse_kind(s))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(tool_err)?,
+                    .collect::<Result<Vec<_>, _>>()?,
             ),
         };
-        let limit = clamp_limit(args.limit, 50);
-        let project_id_arg = args.project_id.clone();
 
         let result = tokio::task::spawn_blocking(move || {
             let project =
                 projects_pins::resolve_project_for_list(project_id_arg.as_deref(), &owner, &name)?;
-            let (project_id, project_name, pinned_set) = match project {
+            let (project_id, project_name, pinned_set, pinned_rows) = match project {
                 Some((id, pname)) => {
+                    let pinned = projects_pins::list_pinned(&id)?;
                     let set = projects_pins::pinned_numbers(&id);
-                    (Some(id), Some(pname), set)
+                    let rows: Vec<_> = pinned
+                        .iter()
+                        .map(|entry| {
+                            let summary = summarize_pr_sidecars(&owner, &name, entry.number);
+                            pinned_sidecar_json(entry, &summary)
+                        })
+                        .collect();
+                    (Some(id), Some(pname), set, rows)
                 }
-                None => (None, None, std::collections::HashSet::new()),
+                None => (None, None, std::collections::HashSet::new(), Vec::new()),
             };
-            let filter = kinds.as_deref();
-            let listed = list_repo_pr_artifacts(&owner, &name, filter, limit);
-            let artifacts: Vec<_> = listed
-                .into_iter()
-                .map(|entry| {
-                    let number = entry.summary.number;
-                    json!({
-                        "number": number,
-                        "kinds": entry.kinds,
-                        "pinned": pinned_set.contains(&number),
-                        "mtime_secs": entry.mtime_secs,
-                        "bucket_path": entry.summary.bucket_path,
-                        "triage": entry.summary.triage,
-                        "review": entry.summary.review,
-                        "tour": entry.summary.tour,
-                        "missing": entry.summary.missing,
+
+            let artifact_rows: Vec<_> = if source == "pinned" {
+                Vec::new()
+            } else {
+                let filter = kinds.as_deref();
+                list_repo_pr_artifacts(&owner, &name, filter, limit)
+                    .into_iter()
+                    .map(|entry| {
+                        let number = entry.summary.number;
+                        json!({
+                            "number": number,
+                            "kinds": entry.kinds,
+                            "pinned": pinned_set.contains(&number),
+                            "mtime_secs": entry.mtime_secs,
+                            "bucket_path": entry.summary.bucket_path,
+                            "triage": entry.summary.triage,
+                            "review": entry.summary.review,
+                            "tour": entry.summary.tour,
+                            "missing": entry.summary.missing,
+                        })
                     })
-                })
-                .collect();
-            Ok::<_, anyhow::Error>((project_id, project_name, owner, name, artifacts))
+                    .collect()
+            };
+
+            Ok::<_, anyhow::Error>((
+                project_id,
+                project_name,
+                owner,
+                name,
+                pinned_rows,
+                artifact_rows,
+                source,
+            ))
         })
         .await
         .map_err(|e| McpError::internal_error(e.to_string(), None))?
         .map_err(|e| tool_err(e.to_string()))?;
 
-        let (project_id, project_name, owner, name, artifacts) = result;
-        text_json(&json!({
-            "repo": format!("{owner}/{name}"),
-            "project_id": project_id,
-            "project": project_name,
-            "count": artifacts.len(),
-            "artifacts": artifacts,
-        }))
-    }
-
-    #[tool(description = "Catalog of Easy Review MCP tools (shipped + future ideas).")]
-    async fn tool_ideas(&self) -> Result<CallToolResult, McpError> {
-        text_json(&json!({
-            "shipped": SHIPPED_TOOLS,
-            "ideas": FUTURE_IDEAS,
-        }))
-    }
-}
-
-fn parse_kind(s: &str) -> Result<SidecarKind, String> {
-    match s.trim().to_ascii_lowercase().as_str() {
-        "triage" => Ok(SidecarKind::Triage),
-        "review" => Ok(SidecarKind::Review),
-        "tour" => Ok(SidecarKind::Tour),
-        other => Err(format!(
-            "unknown kind '{other}'; expected triage|review|tour"
-        )),
+        let (project_id, proj_name, owner, name, pinned_rows, artifact_rows, source) = result;
+        let body = match source.as_str() {
+            "pinned" => json!({
+                "repo": format!("{owner}/{name}"),
+                "project_id": project_id,
+                "project": proj_name.or(project_name),
+                "pinned": pinned_rows,
+            }),
+            "artifacts" => json!({
+                "repo": format!("{owner}/{name}"),
+                "project_id": project_id,
+                "project": proj_name.or(project_name),
+                "artifacts": artifact_rows,
+            }),
+            _ => json!({
+                "repo": format!("{owner}/{name}"),
+                "project_id": project_id,
+                "project": proj_name.or(project_name),
+                "pinned": pinned_rows,
+                "artifacts": artifact_rows,
+            }),
+        };
+        text_json(&body)
     }
 }
-
-fn parse_kinds(kinds: Option<Vec<String>>) -> Result<Vec<SidecarKind>, String> {
-    match kinds {
-        None => Ok(vec![
-            SidecarKind::Triage,
-            SidecarKind::Review,
-            SidecarKind::Tour,
-        ]),
-        Some(list) if list.is_empty() => Err("kinds must not be empty".into()),
-        Some(list) => list.iter().map(|s| parse_kind(s)).collect(),
-    }
-}
-
-fn parse_status(s: &str) -> Result<ReviewStatus, McpError> {
-    match s.trim().to_ascii_lowercase().as_str() {
-        "ready_to_review" | "ready" => Ok(ReviewStatus::ReadyToReview),
-        "draft" => Ok(ReviewStatus::Draft),
-        "outdated" | "behind" => Ok(ReviewStatus::Outdated),
-        "blocked_conflicts" | "conflicts" => Ok(ReviewStatus::BlockedConflicts),
-        "waiting_on_author" | "changes_requested" => Ok(ReviewStatus::WaitingOnAuthor),
-        "approved" => Ok(ReviewStatus::Approved),
-        "merge_ready" | "ready_to_merge" => Ok(ReviewStatus::MergeReady),
-        "inactive" | "closed" | "merged" => Ok(ReviewStatus::Inactive),
-        other => Err(tool_err(format!(
-            "unknown status '{other}'; expected ready_to_review|draft|outdated|blocked_conflicts|waiting_on_author|approved|merge_ready (for CI/conflicts combo use prs_blocked)"
-        ))),
-    }
-}
-
-const SHIPPED_TOOLS: &[&str] = &[
-    "list_projects",
-    "list_prs",
-    "priority_prs",
-    "low_hanging_fruit",
-    "pr_diff_stats",
-    "prs_by_status",
-    "prs_blocked",
-    "prs_failing_ci",
-    "my_review_debt",
-    "prs_stale",
-    "prs_already_addressed",
-    "cross_repo_queue",
-    "open_in_easy_review",
-    "summarize_triage",
-    "diff_hotspots",
-    "compare_prod_size",
-    "prepare_review",
-    "get_artifact_specs",
-    "upload_artifacts",
-    "pin_pr",
-    "unpin_pr",
-    "list_pinned_prs",
-    "list_artifacts",
-    "tool_ideas",
-];
-
-const FUTURE_IDEAS: &[&str] = &[
-    "prepare/upload for expert / professor / arena artifacts",
-    "er:// deep-link / single-instance desktop open from MCP",
-    "required-checks-only CI filter (GitHub branch protection)",
-    "inbox_digest / export_review_brief / missing_tests",
-];
 
 #[tool_handler]
 impl ServerHandler for ErMcp {
     fn get_info(&self) -> ServerInfo {
-        // Prefer MCP 2026-07-28 (stateless / discover). Legacy initialize still
-        // negotiates down via supported_protocol_versions when the client asks.
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2026_07_28)
             .with_server_info(Implementation::new("er-mcp", env!("CARGO_PKG_VERSION")))
             .with_instructions(
-                "Easy Review MCP for PR triage and client-owned AI reviews. \
-             Queues: priority_prs, low_hanging_fruit, my_review_debt, cross_repo_queue. \
-             Filters: prs_by_status, prs_stale, prs_blocked, prs_failing_ci, prs_already_addressed. \
-             Sizing: pr_diff_stats, diff_hotspots, compare_prod_size. \
-             AI sidecars: get_artifact_specs (schemas+prompts) → prepare_review → upload_artifacts → summarize_triage. \
-             Find reviewed work: pin_pr (Desktop Saved) / list_pinned_prs / list_artifacts (scan managed storage). \
-             Open: open_in_easy_review.",
+                "Easy Review MCP — REST-style PR API. Resolve refs with pr_resolve. \
+                 Query queues with prs_query. Review: pr_prepare → pr_upload. \
+                 Guided tour: pr_guide (prepare → upload tour.json). \
+                 Feedback: pr_feedback_get / pr_feedback_reply. Saved: pr_saved. \
+                 Skills: er-review, er-guide, er-queue, er-low-hanging-fruit, er-get-feedback, er-respond, er-saved.",
             )
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        // Dual-era: modern clients use server/discover + per-request _meta;
-        // Cursor/Claude/Codex that still speak initialize negotiate a 2025 revision.
         Cow::Borrowed(ProtocolVersion::KNOWN_VERSIONS)
     }
 }
@@ -1252,18 +1149,6 @@ mod tests {
         assert_eq!(
             server.get_info().protocol_version,
             ProtocolVersion::V_2026_07_28
-        );
-        assert!(
-            server
-                .supported_protocol_versions()
-                .contains(&ProtocolVersion::V_2026_07_28),
-            "must advertise 2026-07-28 for discover clients"
-        );
-        assert!(
-            server
-                .supported_protocol_versions()
-                .contains(&ProtocolVersion::V_2025_11_25),
-            "must keep legacy initialize clients working"
         );
         assert!(server.get_info().capabilities.tools.is_some());
     }

--- a/crates/er-mcp/src/server.rs
+++ b/crates/er-mcp/src/server.rs
@@ -18,11 +18,12 @@ use er_engine::sidecar_summary::{list_repo_pr_artifacts, present_kinds, summariz
 use er_engine::sidecar_upload::{
     prepare_review_kit, upload_pr_artifacts, SidecarKind, UploadArtifactsRequest,
 };
+use std::borrow::Cow;
+
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::*,
-    service::RequestContext,
-    tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -1218,7 +1219,10 @@ const FUTURE_IDEAS: &[&str] = &[
 #[tool_handler]
 impl ServerHandler for ErMcp {
     fn get_info(&self) -> ServerInfo {
+        // Prefer MCP 2026-07-28 (stateless / discover). Legacy initialize still
+        // negotiates down via supported_protocol_versions when the client asks.
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2026_07_28)
             .with_server_info(Implementation::new("er-mcp", env!("CARGO_PKG_VERSION")))
             .with_instructions(
                 "Easy Review MCP for PR triage and client-owned AI reviews. \
@@ -1231,11 +1235,36 @@ impl ServerHandler for ErMcp {
             )
     }
 
-    async fn initialize(
-        &self,
-        _request: InitializeRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<InitializeResult, McpError> {
-        Ok(self.get_info())
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        // Dual-era: modern clients use server/discover + per-request _meta;
+        // Cursor/Claude/Codex that still speak initialize negotiate a 2025 revision.
+        Cow::Borrowed(ProtocolVersion::KNOWN_VERSIONS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertises_mcp_2026_07_28() {
+        let server = ErMcp::new();
+        assert_eq!(
+            server.get_info().protocol_version,
+            ProtocolVersion::V_2026_07_28
+        );
+        assert!(
+            server
+                .supported_protocol_versions()
+                .contains(&ProtocolVersion::V_2026_07_28),
+            "must advertise 2026-07-28 for discover clients"
+        );
+        assert!(
+            server
+                .supported_protocol_versions()
+                .contains(&ProtocolVersion::V_2025_11_25),
+            "must keep legacy initialize clients working"
+        );
+        assert!(server.get_info().capabilities.tools.is_some());
     }
 }

--- a/crates/er-tui/Cargo.toml
+++ b/crates/er-tui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "er-tui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Terminal UI for easy-review"
 

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -23,7 +23,7 @@
         <tr><td><strong>git</strong></td><td>Everything</td><td>Required. <code>er</code> shells out to git for all diff operations.</td></tr>
         <tr><td><strong>gh</strong> (GitHub CLI)</td><td>Pull request features</td><td>Optional. Used for PR metadata and two-way comment sync. Install from <a href="https://cli.github.com" target="_blank" rel="noopener">cli.github.com</a> and run <code>gh auth login</code>. No API token to manage.</td></tr>
         <tr><td>An AI coding tool</td><td>AI review</td><td>Optional. e.g. Claude Code, Codex, or Cursor. You bring your own tool and credentials.</td></tr>
-        <tr><td><strong>Rust 1.85+</strong></td><td>Building from source</td><td>Not needed if you use the install script. The workspace uses the 2024 edition.</td></tr>
+        <tr><td><strong>Rust 1.88+</strong></td><td>Building from source</td><td>Not needed if you use the install script. The workspace uses the 2021 edition; <code>er-mcp</code> needs 1.88 for <code>rmcp</code> 3.</td></tr>
         <tr><td><strong>Node.js / Bun</strong></td><td>Desktop UI dev</td><td>Only for working on the desktop frontend.</td></tr>
       </tbody>
     </table>

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -181,40 +181,34 @@ mkdir -p .cursor
 command = "npx"
 args = ["-y", "easy-review-mcp"]</code></pre>
 
-    <h2>Install the agent skill</h2>
+    <h2>Install agent skills</h2>
     <p>
-      MCP exposes the tools; the <code>er-review</code> skill teaches agents to run
-      <strong>prepare → author → upload</strong> when you say <em>“ER review”</em>.
-      Same install path as <code>github/gh-stack</code>:
+      MCP exposes the REST API; skills teach agents the workflows. Install the full pack:
     </p>
-    <pre><code><span class="cmt"># Global (user) — prompts for which agents to install into</span>
-npx skills add VilfredSikker/easy-review -s er-review -g
-
-<span class="cmt"># Project scope (omit -g)</span>
-npx skills add VilfredSikker/easy-review -s er-review
-
-<span class="cmt"># Non-interactive examples</span>
-npx skills add VilfredSikker/easy-review -s er-review -g -a cursor -y
-npx skills add VilfredSikker/easy-review -s er-review --all
-</code></pre>
-    <p>Skill source: <code>skills/er-review/SKILL.md</code> in the repo.</p>
+    <pre><code>bunx @easy-review/skills
+<span class="cmt"># or: npx @easy-review/skills</span>
+<span class="cmt"># one skill: bunx @easy-review/skills -s er-review</span></code></pre>
+    <p>Skills: <code>er-review</code>, <code>er-guide</code>, <code>er-queue</code>,
+      <code>er-low-hanging-fruit</code>, <code>er-get-feedback</code>, <code>er-respond</code>,
+      <code>er-saved</code>. Source: <code>skills/</code> in the repo.</p>
 
     <h2>Verify</h2>
     <ol>
       <li>Restart the client (or reload MCP tools).</li>
-      <li>Ask: <em>“List Easy Review projects”</em> or <em>“Top 5 priority PRs”</em>.</li>
-      <li>You should see tools like <code>priority_prs</code>, <code>prepare_review</code>, <code>upload_artifacts</code>.</li>
-      <li>After <code>npx skills add …</code>, try: <em>“ER review”</em> on a PR number.</li>
+      <li>Ask: <em>“List Easy Review projects”</em> or <em>“What should I review?”</em>.</li>
+      <li>You should see tools like <code>prs_query</code>, <code>pr_prepare</code>, <code>pr_guide</code>, <code>pr_upload</code>.</li>
+      <li>After <code>bunx @easy-review/skills</code>, try: <em>“ER review”</em> or <em>“create a guide”</em> on a PR.</li>
     </ol>
 
     <h2>What you can do</h2>
     <table>
       <thead><tr><th>Ask for…</th><th>Tool</th></tr></thead>
       <tbody>
-        <tr><td>Priority / small PRs</td><td><code>priority_prs</code>, <code>low_hanging_fruit</code>, <code>cross_repo_queue</code></td></tr>
-        <tr><td>Production-only size</td><td><code>pr_diff_stats</code>, <code>diff_hotspots</code>, <code>compare_prod_size</code></td></tr>
-        <tr><td>Blocked / stale / debt</td><td><code>prs_blocked</code>, <code>prs_stale</code>, <code>my_review_debt</code></td></tr>
-        <tr><td>AI sidecars (shared with Desktop)</td><td><code>get_artifact_specs</code> → <code>prepare_review</code> → <code>upload_artifacts</code></td></tr>
+        <tr><td>Priority / small PRs</td><td><code>prs_query</code> (<code>sort</code>, <code>filter</code>, <code>cross_repo</code>)</td></tr>
+        <tr><td>Production-only size</td><td><code>pr_stats</code></td></tr>
+        <tr><td>Guided tour</td><td><code>pr_guide</code> (prepare → upload <code>tour.json</code>)</td></tr>
+        <tr><td>Full AI review / triage</td><td><code>pr_prepare</code> → <code>pr_upload</code> → <code>pr_summarize</code></td></tr>
+        <tr><td>PR feedback threads</td><td><code>pr_feedback_get</code> / <code>pr_feedback_reply</code></td></tr>
       </tbody>
     </table>
     <p>Full tool list and AI upload flow:

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -13,7 +13,7 @@
     <h1>MCP server setup</h1>
     <p class="lead">
       <code>er-mcp</code> is a local stdio <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP</a>
-      server. Ask Claude Code, Cursor, Codex, or OpenCode for priority PRs, production-only diff size, blocked/stale filters,
+      server (MCP <strong>2026-07-28</strong> preferred; older initialize clients still work). Ask Claude Code, Cursor, Codex, or OpenCode for priority PRs, production-only diff size, blocked/stale filters,
       and to prepare/upload AI review sidecars into the same managed storage Desktop/TUI use.
     </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,7 @@
       </div>
 
       <p class="fade-up fade-up-5 text-xs text-text-muted font-mono">
-        Prebuilt binaries, or build with Rust 1.85+ · Single binary · Zero runtime dependencies
+        Prebuilt binaries, or build with Rust 1.88+ · Single binary · Zero runtime dependencies
       </p>
     </div>
   </section>
@@ -1496,7 +1496,7 @@
       </div>
 
       <p class="reveal-up text-sm text-text-muted mt-6">
-        Requires <span class="text-text-dim">git</span>; building from source needs <span class="text-text-dim">Rust 1.85+</span>. Single binary, no runtime dependencies.
+        Requires <span class="text-text-dim">git</span>; building from source needs <span class="text-text-dim">Rust 1.88+</span>. Single binary, no runtime dependencies.
       </p>
       <p class="reveal-up text-sm text-text-muted mt-3">
         Prefer a GUI? Install the desktop app from source — a signed direct-download <code class="text-text-dim">.dmg</code> is

--- a/npm/skills/README.md
+++ b/npm/skills/README.md
@@ -1,0 +1,64 @@
+# @easy-review/skills
+
+Install [Easy Review](https://github.com/VilfredSikker/easy-review) agent skills for Cursor, Claude Code, Codex, and other agents that support the [skills](https://www.npmjs.com/package/skills) installer.
+
+## Quick start
+
+```bash
+bunx @easy-review/skills
+# or
+npx @easy-review/skills
+```
+
+Install one skill:
+
+```bash
+bunx @easy-review/skills -s er-review
+```
+
+List bundled skills:
+
+```bash
+bunx @easy-review/skills --list
+```
+
+## Bundled skills
+
+| Skill | Purpose |
+|-------|---------|
+| `er-review` | Prepare → author → upload triage/review sidecars |
+| `er-guide` | Create guided tour (`tour.json`) |
+| `er-queue` | What to review next (priority, debt, blocked, stale) |
+| `er-low-hanging-fruit` | Smallest / quick-win PRs |
+| `er-get-feedback` | Read questions, notes, findings |
+| `er-respond` | Reply on PR threads |
+| `er-saved` | Pin / list saved PRs and artifacts |
+
+Pair with the MCP server:
+
+```bash
+bunx easy-review-mcp   # stdio MCP — see docs/guide/mcp.html
+```
+
+## Options
+
+```
+-g, --global     Install to user-level agent dirs (default)
+-p, --project    Install project-local
+-s, --skill      Skill name or * (default: all)
+-a, --agent      Agent id (cursor, claude-code, codex, …)
+```
+
+## Publish
+
+From repo root (after version bump in `package.json`):
+
+```bash
+cd npm/skills && npm publish --access public
+```
+
+`prepack` syncs skills from `../../skills/` and inlines shared docs.
+
+## Source
+
+Canonical skill sources: [`skills/`](../../skills/) at the repo root.

--- a/npm/skills/bin/easy-review-skills.js
+++ b/npm/skills/bin/easy-review-skills.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+"use strict";
+
+const { install, listSkills, SKILL_DIRS } = require("../lib/install.js");
+
+function printUsage() {
+  console.error(`@easy-review/skills — install Easy Review agent skills for Cursor, Claude Code, Codex, etc.
+
+Usage:
+  bunx @easy-review/skills              Install all ER skills globally (default)
+  bunx @easy-review/skills --list       List bundled skills
+  bunx @easy-review/skills -s er-review Install one skill
+
+Options:
+  -s, --skill <name>   Skill to install (${SKILL_DIRS.join(", ")}, or *)
+  -g, --global         Install globally (default)
+  -p, --project        Install project-local instead
+  -a, --agent <name>   Target agent (cursor, claude-code, codex, …)
+  -y, --yes            Skip prompts (default)
+  -h, --help           Show this help
+  -V, --version        Show version
+
+Also install the MCP server:
+  bunx easy-review-mcp   (or npx -y easy-review-mcp)
+
+Docs: https://vilfredsikker.github.io/easy-review/guide/mcp.html`);
+}
+
+function parseArgs(argv) {
+  const opts = { global: true, yes: true };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        opts.help = true;
+        break;
+      case "-V":
+      case "--version":
+        opts.version = true;
+        break;
+      case "-l":
+      case "--list":
+        opts.list = true;
+        break;
+      case "-g":
+      case "--global":
+        opts.global = true;
+        break;
+      case "-p":
+      case "--project":
+        opts.global = false;
+        break;
+      case "-y":
+      case "--yes":
+        opts.yes = true;
+        break;
+      case "-s":
+      case "--skill":
+        opts.skill = argv[++i];
+        break;
+      case "-a":
+      case "--agent":
+        opts.agent = argv[++i];
+        break;
+      case "--copy":
+        opts.copy = true;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`unknown option: ${arg}`);
+        }
+        opts.skill = arg;
+    }
+  }
+  return opts;
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err.message);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (opts.help) {
+    printUsage();
+    return;
+  }
+  if (opts.version) {
+    // eslint-disable-next-line global-require
+    console.log(require("../package.json").version);
+    return;
+  }
+  if (opts.list) {
+    for (const row of listSkills()) {
+      console.log(`${row.name}\n  ${row.description}\n`);
+    }
+    return;
+  }
+
+  try {
+    install(opts);
+  } catch (err) {
+    console.error(`@easy-review/skills: ${err.message || err}`);
+    process.exit(typeof err.code === "number" ? err.code : 1);
+  }
+}
+
+main();

--- a/npm/skills/lib/install.js
+++ b/npm/skills/lib/install.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+const { syncSkills, SKILL_DIRS, OUT_ROOT } = require("../scripts/sync-skills.js");
+
+function skillsBundleDir() {
+  return OUT_ROOT;
+}
+
+function ensureBundle() {
+  const bundle = skillsBundleDir();
+  const missing = SKILL_DIRS.some(
+    (name) => !require("node:fs").existsSync(path.join(bundle, name, "SKILL.md")),
+  );
+  if (missing) {
+    syncSkills();
+  }
+  return bundle;
+}
+
+function resolveSkillsCli() {
+  try {
+    return require.resolve("skills/bin/cli.mjs");
+  } catch {
+    return null;
+  }
+}
+
+function runSkillsAdd(bundleDir, options) {
+  const cli = resolveSkillsCli();
+  const skill = options.skill ?? "*";
+  const args = ["add", bundleDir, "-s", skill, "-y"];
+  if (options.global !== false) {
+    args.push("-g");
+  }
+  if (options.agent) {
+    args.push("-a", options.agent);
+  }
+  if (options.copy) {
+    args.push("--copy");
+  }
+
+  const env = { ...process.env };
+
+  if (cli) {
+    const result = spawnSync(process.execPath, [cli, ...args], {
+      stdio: "inherit",
+      env,
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    return result.status ?? 1;
+  }
+
+  const result = spawnSync("npx", ["-y", "skills@1", ...args], {
+    stdio: "inherit",
+    env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return result.status ?? 1;
+}
+
+function listSkills() {
+  ensureBundle();
+  return SKILL_DIRS.map((name) => {
+    const file = path.join(skillsBundleDir(), name, "SKILL.md");
+    const text = require("node:fs").readFileSync(file, "utf8");
+    const desc = text.match(/^description:\s*>?\s*\n((?:\s+.+\n?)+)/m);
+    const description = desc
+      ? desc[1]
+          .split("\n")
+          .map((l) => l.trim())
+          .filter(Boolean)
+          .join(" ")
+      : "";
+    return { name, description };
+  });
+}
+
+function install(options = {}) {
+  const bundleDir = ensureBundle();
+  const code = runSkillsAdd(bundleDir, options);
+  if (code !== 0) {
+    const err = new Error(`skills add failed with exit code ${code}`);
+    err.code = code;
+    throw err;
+  }
+  return { bundleDir, skill: options.skill ?? "*" };
+}
+
+module.exports = {
+  ensureBundle,
+  install,
+  listSkills,
+  skillsBundleDir,
+  SKILL_DIRS,
+};

--- a/npm/skills/lib/install.test.js
+++ b/npm/skills/lib/install.test.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { listSkills, SKILL_DIRS } = require("./install.js");
+
+describe("install", () => {
+  it("lists bundled skills after sync", () => {
+    const rows = listSkills();
+    assert.equal(rows.length, SKILL_DIRS.length);
+    assert.ok(rows.some((r) => r.name === "er-review" && r.description.includes("ER review")));
+  });
+});

--- a/npm/skills/package-lock.json
+++ b/npm/skills/package-lock.json
@@ -1,0 +1,121 @@
+{
+  "name": "@easy-review/skills",
+  "version": "0.4.8",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@easy-review/skills",
+      "version": "0.4.8",
+      "license": "MIT",
+      "dependencies": {
+        "skills": "^1.5.22"
+      },
+      "bin": {
+        "easy-review-skills": "bin/easy-review-skills.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/skills": {
+      "version": "1.5.22",
+      "resolved": "https://registry.npmjs.org/skills/-/skills-1.5.22.tgz",
+      "integrity": "sha512-cHiLjwZEawWFvudIqeeMZlvZayTLbRouydMbblyrdiyH7ZLbqUrSrEEr+Tg+X265iztRlVMsyOYRwpD5JxBsvg==",
+      "license": "MIT",
+      "dependencies": {
+        "tar": "^7.5.20",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "add-skill": "bin/cli.mjs",
+        "skills": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=22.20.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/npm/skills/package.json
+++ b/npm/skills/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@easy-review/skills",
+  "version": "0.4.8",
+  "description": "Install Easy Review agent skills (er-review, er-guide, er-queue, er-low-hanging-fruit, er-get-feedback, er-respond, er-saved) for Cursor, Claude Code, and Codex.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VilfredSikker/easy-review.git",
+    "directory": "npm/skills"
+  },
+  "homepage": "https://vilfredsikker.github.io/easy-review/guide/mcp.html",
+  "bugs": {
+    "url": "https://github.com/VilfredSikker/easy-review/issues"
+  },
+  "keywords": [
+    "easy-review",
+    "skills",
+    "cursor",
+    "claude-code",
+    "codex",
+    "code-review",
+    "mcp",
+    "agent"
+  ],
+  "bin": {
+    "easy-review-skills": "./bin/easy-review-skills.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "scripts/",
+    "skills/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "skills": "^1.5.22"
+  },
+  "scripts": {
+    "prepare": "node scripts/sync-skills.js",
+    "prepack": "node scripts/sync-skills.js",
+    "test": "node --test lib/*.test.js scripts/*.test.js",
+    "start": "node ./bin/easy-review-skills.js --list"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/skills/scripts/sync-skills.js
+++ b/npm/skills/scripts/sync-skills.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Copy Easy Review skills from the repo root into this package and inline
+ * skills/_shared so installed SKILL.md files are self-contained.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PKG_ROOT = path.join(__dirname, "..");
+const REPO_SKILLS = path.join(PKG_ROOT, "..", "..", "skills");
+const OUT_ROOT = path.join(PKG_ROOT, "skills");
+
+const SKILL_DIRS = [
+  "er-review",
+  "er-guide",
+  "er-queue",
+  "er-low-hanging-fruit",
+  "er-get-feedback",
+  "er-respond",
+  "er-saved",
+];
+
+function readShared(name) {
+  const file = path.join(REPO_SKILLS, "_shared", name);
+  if (!fs.existsSync(file)) {
+    throw new Error(`missing shared doc: ${file}`);
+  }
+  return fs
+    .readFileSync(file, "utf8")
+    .trim()
+    .replace(/^#[^\n]+\n+/, "");
+}
+
+function sharedBlockFor(skillMarkdown) {
+  const parts = [];
+  if (skillMarkdown.includes("PREREQUISITES.md")) {
+    parts.push(readShared("PREREQUISITES.md"));
+  }
+  if (skillMarkdown.includes("REF_RESOLUTION.md")) {
+    parts.push(readShared("REF_RESOLUTION.md"));
+  }
+  return parts.join("\n\n");
+}
+
+function inlineShared(skillMarkdown) {
+  const block = sharedBlockFor(skillMarkdown);
+  const lines = [];
+  for (const line of skillMarkdown.split("\n")) {
+    if (!line.includes("../_shared/")) {
+      lines.push(line);
+      continue;
+    }
+    const prefix = line.replace(/See \[`[^`]+`\]\([^)]+\)(?: and \[`[^`]+`\]\([^)]+\))?\.?/g, "").trim();
+    if (prefix) {
+      lines.push(prefix);
+    }
+  }
+  const without = lines.join("\n");
+  const match = without.match(/^(---\n[\s\S]*?\n---\n\n#[^\n]+\n\n)/);
+  if (match && block) {
+    return without.replace(match[1], `${match[1]}${block}\n\n`);
+  }
+  if (block) {
+    return `${without}\n\n${block}\n`;
+  }
+  return without;
+}
+
+function syncSkills() {
+  if (!fs.existsSync(REPO_SKILLS)) {
+    throw new Error(`repo skills directory not found: ${REPO_SKILLS}`);
+  }
+
+  fs.rmSync(OUT_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(OUT_ROOT, { recursive: true });
+
+  for (const dir of SKILL_DIRS) {
+    const srcDir = path.join(REPO_SKILLS, dir);
+    const srcFile = path.join(srcDir, "SKILL.md");
+    if (!fs.existsSync(srcFile)) {
+      throw new Error(`missing skill: ${srcFile}`);
+    }
+    const outDir = path.join(OUT_ROOT, dir);
+    fs.mkdirSync(outDir, { recursive: true });
+    const raw = fs.readFileSync(srcFile, "utf8");
+    const inlined = inlineShared(raw);
+    fs.writeFileSync(path.join(outDir, "SKILL.md"), inlined, "utf8");
+  }
+
+  return { count: SKILL_DIRS.length, out: OUT_ROOT };
+}
+
+if (require.main === module) {
+  try {
+    const result = syncSkills();
+    console.error(`synced ${result.count} skills → ${result.out}`);
+  } catch (err) {
+    console.error(`sync-skills: ${err.message || err}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { syncSkills, SKILL_DIRS, OUT_ROOT };

--- a/npm/skills/scripts/sync-skills.test.js
+++ b/npm/skills/scripts/sync-skills.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { syncSkills, SKILL_DIRS, OUT_ROOT } = require("../scripts/sync-skills.js");
+
+describe("sync-skills", () => {
+  it("copies all ER skills with inlined shared docs", () => {
+    const { count } = syncSkills();
+    assert.equal(count, SKILL_DIRS.length);
+    for (const name of SKILL_DIRS) {
+      const file = path.join(OUT_ROOT, name, "SKILL.md");
+      assert.ok(fs.existsSync(file), `missing ${file}`);
+      const text = fs.readFileSync(file, "utf8");
+      assert.ok(!text.includes("../_shared/"), `${name} still has _shared links`);
+      if (name === "er-queue") {
+        assert.ok(text.includes("MCP server"), `${name} missing prerequisites`);
+        assert.ok(text.includes("pr_resolve") || text.includes("ref"), `${name} missing ref docs`);
+      } else if (name === "er-review" || name === "er-low-hanging-fruit") {
+        assert.ok(text.includes("pr_resolve"), `${name} missing ref resolution`);
+      } else {
+        assert.ok(text.includes("pr_resolve") || text.includes("ref"), `${name} missing ref docs`);
+      }
+    }
+  });
+});

--- a/npm/skills/skills/er-get-feedback/SKILL.md
+++ b/npm/skills/skills/er-get-feedback/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: er-get-feedback
+description: >
+  Read open review questions, local notes, and AI findings on a PR from Easy Review
+  managed storage. Use when the user asks what's open on a PR, wants feedback summary,
+  or before responding to review threads. Accepts PR URL, worktree path, owner/repo, or branch.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — get feedback (`er-get-feedback`)
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+Read-only.
+
+## Trigger phrases
+
+- "What's open on this PR?" / "any feedback?" / "review questions"
+- "Show findings" / "notes on PR #42"
+- User gives PR URL, path, `owner/repo`, branch, or number
+
+## Workflow
+
+1. **`pr_resolve`** if needed, or pass `ref` directly.
+2. **`pr_feedback_get`** with `{ "ref": "…", "include_resolved": false }` (true only if user wants history).
+3. Optional **`pr_summarize`** for triage/review/tour sidecar summary.
+
+## Output format
+
+Group by type:
+
+- **Questions** — things a human wants answered
+- **Notes** — hand-off instructions for an agent
+- **Findings** — AI review items (by severity if present)
+
+Do **not** write replies in this skill — use **`er-respond`**.

--- a/npm/skills/skills/er-guide/SKILL.md
+++ b/npm/skills/skills/er-guide/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: er-guide
+description: >
+  Create an Easy Review guided tour (tour.json) for a PR via er-mcp. Use when the user
+  asks for a guide, guided tour, walkthrough, or tour for a PR. Accepts PR URL, worktree
+  path, owner/repo, branch, or number.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — guided tour (`er-guide`)
+
+- MCP server **`easy-review`** connected (`npx -y easy-review-mcp` or `er-mcp` on PATH).
+- Authenticated **`gh`** (`gh auth status`).
+- Optional: Easy Review projects in `~/.config/er/projects.json` (Desktop writes this).
+
+Managed PR storage (read `diff-tmp` only; never write here directly):
+
+- macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+- Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+
+Always upload sidecars through **`pr_upload`**, not by writing into the managed directory.
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+Creates **`tour.json`** — the pillar-based walkthrough shown in Desktop/TUI **Guide** tab.
+
+
+## Trigger phrases
+
+- "Create a guide" / "guided tour" / "walk me through this PR"
+- "Generate tour" / "ER guide" / "tour.json"
+- User gives PR URL, worktree path, `owner/repo`, branch, or number
+
+## Workflow
+
+1. **`pr_resolve`** when `ref` is ambiguous; otherwise pass `ref` on each call.
+2. **`pr_guide`** `{ "ref": "…", "action": "prepare" }` (default action).
+   - Writes `diff-tmp`, returns `diff_hash`, `diff_tmp_path`, `artifact_specs` for **tour only**.
+3. **Read the diff** at `diff_tmp_path`.
+4. **Author `tour.json`** — embed exact `diff_hash`; 3–7 pillars; every changed file once.
+5. **`pr_guide`** `{ "ref": "…", "action": "upload", "files": { "tour.json": "..." } }`.
+6. Optional: **`pr_summarize`**, **`pr_saved`** (`action: pin`).
+
+## Tour rules (from artifact spec)
+
+- One `tour.json` only — no separate triage/review files.
+- Foundation / core pillars first; group related files under `related[]` when helpful.
+- Titles and blurbs should explain *why* each area matters, not just what changed.
+
+## Anti-patterns
+
+- Do not use `pr_prepare` + `pr_upload` for tour-only work — use **`pr_guide`** (smaller payload).
+- Do not skip `prepare` or invent `diff_hash`.
+- Do not spawn Desktop AI Hub tour agents — you author the JSON.

--- a/npm/skills/skills/er-low-hanging-fruit/SKILL.md
+++ b/npm/skills/skills/er-low-hanging-fruit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: er-low-hanging-fruit
+description: >
+  Find the smallest / quickest PRs to review using production-only line counts.
+  Use when the user asks for low-hanging fruit, smallest PRs, quick wins, or wants
+  to compare PR sizes. Optional ref scopes to one repo.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — low-hanging fruit (`er-low-hanging-fruit`)
+
+- MCP server **`easy-review`** connected (`npx -y easy-review-mcp` or `er-mcp` on PATH).
+- Authenticated **`gh`** (`gh auth status`).
+- Optional: Easy Review projects in `~/.config/er/projects.json` (Desktop writes this).
+
+Managed PR storage (read `diff-tmp` only; never write here directly):
+
+- macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+- Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+
+Always upload sidecars through **`pr_upload`**, not by writing into the managed directory.
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+
+## Trigger phrases
+
+- "Low-hanging fruit" / "smallest PRs" / "quick wins"
+- "Compare PR sizes" / "which PR is smallest?"
+
+## MCP calls
+
+**Ranked smallest (default):**
+
+```json
+{
+  "sort": "smallest",
+  "production_lines": true,
+  "limit": 5,
+  "repo": "owner/name"
+}
+```
+
+Use `ref: "owner/repo"` or `projects_list` when repo omitted.
+
+**Compare specific PR numbers:**
+
+```json
+{ "ref": "owner/repo", "numbers": [12, 15, 18] }
+```
+
+via **`pr_stats`** with `numbers` array.
+
+**Single PR depth:**
+
+```json
+{ "ref": "https://github.com/o/r/pull/42", "include_hotspots": true }
+```
+
+## Output
+
+Table: `#`, title, production lines, total lines, review state. Offer **`er-review`** on pick — do not auto-review.

--- a/npm/skills/skills/er-queue/SKILL.md
+++ b/npm/skills/skills/er-queue/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: er-queue
+description: >
+  Find PRs to review next — priority queue, review debt, blocked, stale, or cross-repo.
+  Use when the user asks what to review, review debt, blocked PRs, stale PRs, or
+  priority across Easy Review projects.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — review queue (`er-queue`)
+
+- MCP server **`easy-review`** connected (`npx -y easy-review-mcp` or `er-mcp` on PATH).
+- Authenticated **`gh`** (`gh auth status`).
+- Optional: Easy Review projects in `~/.config/er/projects.json` (Desktop writes this).
+
+Managed PR storage (read `diff-tmp` only; never write here directly):
+
+- macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+- Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+
+Always upload sidecars through **`pr_upload`**, not by writing into the managed directory.
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+
+## Trigger phrases
+
+- "What should I review?" / "priority PRs" / "review queue"
+- "My review debt" / "PRs waiting on me"
+- "Blocked PRs" / "failing CI" / "stale PRs"
+- "Across all my projects" / "cross-repo queue"
+
+## MCP: `prs_query`
+
+| Intent | Call |
+|--------|------|
+| Priority (default) | `{ "sort": "priority", "limit": 10 }` |
+| Review debt | `{ "filter": "review_debt" }` |
+| Stale | `{ "filter": "stale", "stale_days": 14 }` |
+| Blocked | `{ "filter": "blocked", "scan_limit": 15 }` |
+| Failing CI | `{ "filter": "failing_ci" }` |
+| Cross-repo | `{ "cross_repo": true, "limit": 10 }` |
+| Ready to review | `{ "filter": "ready" }` |
+
+Optional: `production_lines: true` for production-only line enrichment (slower).
+
+Scoped to one repo: pass `ref` as `owner/repo` on `prs_query` (or `repo` + `project_id`).
+
+## Output
+
+Present a compact table: `#`, title, score/reasons, size, status. Offer **`er-review`** on the user's pick — do not auto-review.

--- a/npm/skills/skills/er-respond/SKILL.md
+++ b/npm/skills/skills/er-respond/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: er-respond
+description: >
+  Reply to review questions, local notes, or AI findings on a PR via Easy Review MCP.
+  Use when the user wants to answer a question, validate a finding, or respond on a PR
+  thread. Accepts PR URL, worktree path, owner/repo, or branch.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — respond (`er-respond`)
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+Mutating.
+
+## Trigger phrases
+
+- "Answer this question" / "reply to the note" / "validate this finding"
+- "Respond on PR #42" with question/note/finding id
+
+## Workflow
+
+1. **`pr_feedback_get`** first (unless user gave `type` + `id` explicitly).
+2. **`pr_feedback_reply`**:
+
+```json
+{
+  "ref": "…",
+  "type": "question",
+  "id": "q-…",
+  "text": "…"
+}
+```
+
+`type`: `question` | `note` | `finding`
+
+3. **`pr_feedback_get`** again to confirm.
+
+## Rules
+
+- Route question → `question`, note → `note`, finding → `finding`.
+- Do not resolve or delete items (not supported via MCP yet).
+- Do not invent ids — use ids from `pr_feedback_get`.

--- a/npm/skills/skills/er-review/SKILL.md
+++ b/npm/skills/skills/er-review/SKILL.md
@@ -12,9 +12,53 @@ metadata:
 
 # Easy Review — review workflow (`er-review`)
 
+- MCP server **`easy-review`** connected (`npx -y easy-review-mcp` or `er-mcp` on PATH).
+- Authenticated **`gh`** (`gh auth status`).
+- Optional: Easy Review projects in `~/.config/er/projects.json` (Desktop writes this).
+
+Managed PR storage (read `diff-tmp` only; never write here directly):
+
+- macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+- Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+
+Always upload sidecars through **`pr_upload`**, not by writing into the managed directory.
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
 You are the reviewer. MCP prepares storage and validates uploads — it does **not** spawn agent CLIs.
 
-See [`../_shared/PREREQUISITES.md`](../_shared/PREREQUISITES.md) and [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
 
 ## Trigger phrases
 

--- a/npm/skills/skills/er-saved/SKILL.md
+++ b/npm/skills/skills/er-saved/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: er-saved
+description: >
+  Pin, unpin, or list saved PRs and uploaded Easy Review artifacts in Desktop Saved
+  and managed storage. Use when the user wants to pin a reviewed PR, list saved work,
+  or find PRs with triage/review/tour sidecars.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — saved PRs (`er-saved`)
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.
+
+
+## Trigger phrases
+
+- "Pin this PR" / "save to Desktop"
+- "List saved PRs" / "what have I reviewed?"
+- "Show uploaded artifacts"
+
+## MCP: `pr_saved`
+
+| Action | Call |
+|--------|------|
+| Pin | `{ "action": "pin", "ref": "…" }` |
+| Unpin | `{ "action": "unpin", "ref": "…" }` |
+| Saved only | `{ "action": "list", "source": "pinned" }` |
+| Artifacts scan | `{ "action": "list", "source": "artifacts" }` |
+| Both | `{ "action": "list", "source": "all" }` |
+
+Optional `kinds: ["triage", "tour"]` on list to filter artifacts.
+
+Only pin when the user asks or after a successful **`er-review`** they asked to save.

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -4,7 +4,7 @@
 # Unconditional updates fail on overlayfs when RUSTUP_HOME=/usr/local/rustup (EXDEV on rename).
 set -euo pipefail
 
-MIN_RUST_VERSION="${MIN_RUST_VERSION:-1.85.0}"
+MIN_RUST_VERSION="${MIN_RUST_VERSION:-1.88.0}"
 
 printf '>>> [install:] start\n'
 

--- a/skills/_shared/PREREQUISITES.md
+++ b/skills/_shared/PREREQUISITES.md
@@ -1,0 +1,12 @@
+# Easy Review MCP — prerequisites
+
+- MCP server **`easy-review`** connected (`npx -y easy-review-mcp` or `er-mcp` on PATH).
+- Authenticated **`gh`** (`gh auth status`).
+- Optional: Easy Review projects in `~/.config/er/projects.json` (Desktop writes this).
+
+Managed PR storage (read `diff-tmp` only; never write here directly):
+
+- macOS: `~/Library/Application Support/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+- Linux: `~/.local/share/easy-review/repos/<owner-repo>/prs/pr-<N>/`
+
+Always upload sidecars through **`pr_upload`**, not by writing into the managed directory.

--- a/skills/_shared/REF_RESOLUTION.md
+++ b/skills/_shared/REF_RESOLUTION.md
@@ -1,0 +1,35 @@
+# PR ref resolution (all ER skills)
+
+Pass the user's target as **`ref`** on any PR-scoped MCP tool, or call **`pr_resolve`** first.
+
+## Accepted `ref` forms
+
+| User types | Example | Resolves via |
+|------------|---------|--------------|
+| PR URL | `https://github.com/o/r/pull/42` | URL parse |
+| Worktree path | `/Users/me/Projects/foo` | git toplevel → open PR for current branch |
+| `owner/repo#N` | `acme/widgets#42` | Explicit PR number |
+| `owner/repo` | `vilfred/ai-report-builder` | ER project with that remote → open PR in that checkout |
+| Branch name | `feature/auth` | `gh pr list --head` in project/cwd repo |
+| Bare number | `42` | Active ER project or `repo=` |
+
+## Skill workflow
+
+1. If the user gave a ref (URL, path, slug, branch, number), pass it as `ref` on the tool call.
+2. If ambiguous, call **`pr_resolve`** once and use the returned `repo`, `number`, `pr_url`, `bucket_path`.
+3. Do not guess a different PR than `pr_resolve` returns.
+
+## Examples
+
+```text
+er-review https://github.com/acme/widgets/pull/42
+er-review /Users/me/Projects/Discovery/discovery
+er-review vilfred/ai-report-builder
+er-get-feedback feature/my-branch
+```
+
+## Errors
+
+- **No open PR for branch** — ask for a PR URL or `owner/repo#N`.
+- **No ER project for owner/repo** — pass a worktree path or configure the project in Desktop.
+- **No PR on current branch** — checkout the PR branch or pass an explicit URL.

--- a/skills/er-get-feedback/SKILL.md
+++ b/skills/er-get-feedback/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: er-get-feedback
+description: >
+  Read open review questions, local notes, and AI findings on a PR from Easy Review
+  managed storage. Use when the user asks what's open on a PR, wants feedback summary,
+  or before responding to review threads. Accepts PR URL, worktree path, owner/repo, or branch.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — get feedback (`er-get-feedback`)
+
+Read-only. See [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "What's open on this PR?" / "any feedback?" / "review questions"
+- "Show findings" / "notes on PR #42"
+- User gives PR URL, path, `owner/repo`, branch, or number
+
+## Workflow
+
+1. **`pr_resolve`** if needed, or pass `ref` directly.
+2. **`pr_feedback_get`** with `{ "ref": "…", "include_resolved": false }` (true only if user wants history).
+3. Optional **`pr_summarize`** for triage/review/tour sidecar summary.
+
+## Output format
+
+Group by type:
+
+- **Questions** — things a human wants answered
+- **Notes** — hand-off instructions for an agent
+- **Findings** — AI review items (by severity if present)
+
+Do **not** write replies in this skill — use **`er-respond`**.

--- a/skills/er-guide/SKILL.md
+++ b/skills/er-guide/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: er-guide
+description: >
+  Create an Easy Review guided tour (tour.json) for a PR via er-mcp. Use when the user
+  asks for a guide, guided tour, walkthrough, or tour for a PR. Accepts PR URL, worktree
+  path, owner/repo, branch, or number.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — guided tour (`er-guide`)
+
+Creates **`tour.json`** — the pillar-based walkthrough shown in Desktop/TUI **Guide** tab.
+
+See [`../_shared/PREREQUISITES.md`](../_shared/PREREQUISITES.md) and [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "Create a guide" / "guided tour" / "walk me through this PR"
+- "Generate tour" / "ER guide" / "tour.json"
+- User gives PR URL, worktree path, `owner/repo`, branch, or number
+
+## Workflow
+
+1. **`pr_resolve`** when `ref` is ambiguous; otherwise pass `ref` on each call.
+2. **`pr_guide`** `{ "ref": "…", "action": "prepare" }` (default action).
+   - Writes `diff-tmp`, returns `diff_hash`, `diff_tmp_path`, `artifact_specs` for **tour only**.
+3. **Read the diff** at `diff_tmp_path`.
+4. **Author `tour.json`** — embed exact `diff_hash`; 3–7 pillars; every changed file once.
+5. **`pr_guide`** `{ "ref": "…", "action": "upload", "files": { "tour.json": "..." } }`.
+6. Optional: **`pr_summarize`**, **`pr_saved`** (`action: pin`).
+
+## Tour rules (from artifact spec)
+
+- One `tour.json` only — no separate triage/review files.
+- Foundation / core pillars first; group related files under `related[]` when helpful.
+- Titles and blurbs should explain *why* each area matters, not just what changed.
+
+## Anti-patterns
+
+- Do not use `pr_prepare` + `pr_upload` for tour-only work — use **`pr_guide`** (smaller payload).
+- Do not skip `prepare` or invent `diff_hash`.
+- Do not spawn Desktop AI Hub tour agents — you author the JSON.

--- a/skills/er-low-hanging-fruit/SKILL.md
+++ b/skills/er-low-hanging-fruit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: er-low-hanging-fruit
+description: >
+  Find the smallest / quickest PRs to review using production-only line counts.
+  Use when the user asks for low-hanging fruit, smallest PRs, quick wins, or wants
+  to compare PR sizes. Optional ref scopes to one repo.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — low-hanging fruit (`er-low-hanging-fruit`)
+
+See [`../_shared/PREREQUISITES.md`](../_shared/PREREQUISITES.md) and [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "Low-hanging fruit" / "smallest PRs" / "quick wins"
+- "Compare PR sizes" / "which PR is smallest?"
+
+## MCP calls
+
+**Ranked smallest (default):**
+
+```json
+{
+  "sort": "smallest",
+  "production_lines": true,
+  "limit": 5,
+  "repo": "owner/name"
+}
+```
+
+Use `ref: "owner/repo"` or `projects_list` when repo omitted.
+
+**Compare specific PR numbers:**
+
+```json
+{ "ref": "owner/repo", "numbers": [12, 15, 18] }
+```
+
+via **`pr_stats`** with `numbers` array.
+
+**Single PR depth:**
+
+```json
+{ "ref": "https://github.com/o/r/pull/42", "include_hotspots": true }
+```
+
+## Output
+
+Table: `#`, title, production lines, total lines, review state. Offer **`er-review`** on pick — do not auto-review.

--- a/skills/er-queue/SKILL.md
+++ b/skills/er-queue/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: er-queue
+description: >
+  Find PRs to review next — priority queue, review debt, blocked, stale, or cross-repo.
+  Use when the user asks what to review, review debt, blocked PRs, stale PRs, or
+  priority across Easy Review projects.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — review queue (`er-queue`)
+
+See [`../_shared/PREREQUISITES.md`](../_shared/PREREQUISITES.md) and [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "What should I review?" / "priority PRs" / "review queue"
+- "My review debt" / "PRs waiting on me"
+- "Blocked PRs" / "failing CI" / "stale PRs"
+- "Across all my projects" / "cross-repo queue"
+
+## MCP: `prs_query`
+
+| Intent | Call |
+|--------|------|
+| Priority (default) | `{ "sort": "priority", "limit": 10 }` |
+| Review debt | `{ "filter": "review_debt" }` |
+| Stale | `{ "filter": "stale", "stale_days": 14 }` |
+| Blocked | `{ "filter": "blocked", "scan_limit": 15 }` |
+| Failing CI | `{ "filter": "failing_ci" }` |
+| Cross-repo | `{ "cross_repo": true, "limit": 10 }` |
+| Ready to review | `{ "filter": "ready" }` |
+
+Optional: `production_lines: true` for production-only line enrichment (slower).
+
+Scoped to one repo: pass `ref` as `owner/repo` on `prs_query` (or `repo` + `project_id`).
+
+## Output
+
+Present a compact table: `#`, title, score/reasons, size, status. Offer **`er-review`** on the user's pick — do not auto-review.

--- a/skills/er-respond/SKILL.md
+++ b/skills/er-respond/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: er-respond
+description: >
+  Reply to review questions, local notes, or AI findings on a PR via Easy Review MCP.
+  Use when the user wants to answer a question, validate a finding, or respond on a PR
+  thread. Accepts PR URL, worktree path, owner/repo, or branch.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — respond (`er-respond`)
+
+Mutating. See [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "Answer this question" / "reply to the note" / "validate this finding"
+- "Respond on PR #42" with question/note/finding id
+
+## Workflow
+
+1. **`pr_feedback_get`** first (unless user gave `type` + `id` explicitly).
+2. **`pr_feedback_reply`**:
+
+```json
+{
+  "ref": "…",
+  "type": "question",
+  "id": "q-…",
+  "text": "…"
+}
+```
+
+`type`: `question` | `note` | `finding`
+
+3. **`pr_feedback_get`** again to confirm.
+
+## Rules
+
+- Route question → `question`, note → `note`, finding → `finding`.
+- Do not resolve or delete items (not supported via MCP yet).
+- Do not invent ids — use ids from `pr_feedback_get`.

--- a/skills/er-saved/SKILL.md
+++ b/skills/er-saved/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: er-saved
+description: >
+  Pin, unpin, or list saved PRs and uploaded Easy Review artifacts in Desktop Saved
+  and managed storage. Use when the user wants to pin a reviewed PR, list saved work,
+  or find PRs with triage/review/tour sidecars.
+metadata:
+  author: easy-review
+  version: "0.1.0"
+---
+
+# Easy Review — saved PRs (`er-saved`)
+
+See [`../_shared/REF_RESOLUTION.md`](../_shared/REF_RESOLUTION.md).
+
+## Trigger phrases
+
+- "Pin this PR" / "save to Desktop"
+- "List saved PRs" / "what have I reviewed?"
+- "Show uploaded artifacts"
+
+## MCP: `pr_saved`
+
+| Action | Call |
+|--------|------|
+| Pin | `{ "action": "pin", "ref": "…" }` |
+| Unpin | `{ "action": "unpin", "ref": "…" }` |
+| Saved only | `{ "action": "list", "source": "pinned" }` |
+| Artifacts scan | `{ "action": "list", "source": "artifacts" }` |
+| Both | `{ "action": "list", "source": "all" }` |
+
+Optional `kinds: ["triage", "tour"]` on list to filter artifacts.
+
+Only pin when the user asks or after a successful **`er-review`** they asked to save.


### PR DESCRIPTION
## Summary

Upgrade `er-mcp` to the MCP **2026-07-28** protocol era (stateless `server/discover`) via **rmcp 3.1**, while keeping legacy `initialize`-based clients (Cursor, Claude Code, Codex) working through dual-era negotiation.

## Changes

- **Protocol**: `get_info()` now advertises `ProtocolVersion::V_2026_07_28`; `supported_protocol_versions()` returns the full `KNOWN_VERSIONS` list so legacy clients negotiate down (verified against vendored rmcp 3.1.0 — its default `initialize` negotiates via `supported_protocol_versions`)
- **MSRV**: workspace `rust-version` bumped 1.85 → **1.88** (required by rmcp 3), applied via `rust-version.workspace = true` across all crate manifests; `cloud-agent-install.sh` guard and all docs updated consistently
- **Deps**: rmcp/rmcp-macros 2.2.0 → 3.1.0 (base64 0.23 + uuid arrive as transitive deps in the lockfile)
- **Docs**: README, AGENTS.md, `docs/guide/{installation,mcp}.html`, `docs/index.html`, `crates/er-mcp/README.md` all synced; fixed stale "2024 edition" claims (workspace is `edition 2021`)

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p er-mcp --all-targets -- -D warnings` — pass
- `cargo test -p er-mcp` — 2 passed (incl. new `advertises_mcp_2026_07_28` test asserting both protocol eras)
- `cargo test -p er-engine -p er-desktop` — 1120 passed (lockfile bump compatible)
- Full `--workspace` build skipped (builds Tauri; per AGENTS.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large MCP API break for any client still calling old tool names; new feedback reply paths write to managed PR storage. Protocol and dependency upgrades are well-tested but affect all MCP consumers.
> 
> **Overview**
> Upgrades **`er-mcp`** to MCP **2026-07-28** via **rmcp 3.1**, advertises that protocol while still negotiating with older clients, and bumps workspace **Rust to 1.88**.
> 
> The MCP surface is redesigned from many granular tools into **11 REST-style tools** (`pr_resolve`, `prs_query`, `pr_stats`, `pr_prepare` / `pr_upload`, `pr_guide`, `pr_feedback_get` / `pr_feedback_reply`, `pr_saved`, etc.), all sharing a universal **`ref`** (URL, worktree path, `owner/repo#N`, branch, number).
> 
> **`er-engine`** adds **`pr_resolve`** (ref → owner/repo/number + bucket path, with `gh` branch lookup and Easy Review projects) and **`pr_review_feedback`** (read/reply on questions, notes, and AI findings in managed PR storage), plus **`get_repo_root_at`** and small **`github`** helpers.
> 
> Agent workflows move to **`@easy-review/skills`** (`npm/skills`): seven skills with shared ref docs, release workflow publishes the skills package alongside the MCP launcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bccfbb357b76ef60240ecbcf69966031455e404. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->