### PR TITLE
fix(desktop): key PR links and GitHub status to the tab's own repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "er-desktop"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "er-engine"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "er-mcp"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "er-tui"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -5393,6 +5393,12 @@ fn build_local_branch_tab(
 
     new_tab.local_branch_view = Some(name);
     new_tab.mode = er_engine::app::DiffMode::Branch;
+    // The tab's own remote is the repo actually being viewed — NOT the active
+    // project's remote (a project may point at a different repo than the
+    // worktree/branch it reviews). Resolve it from this repo's git remote so
+    // PR links, the GitHub status card, and the PR-list cache all key on the
+    // right repo.
+    new_tab.remote_repo = projects::resolve_repo_remote(&proj.root_path);
     new_tab.sync_managed_storage();
     let t_local_refresh = std::time::Instant::now();
     match new_tab.refresh_diff_without_remote_fetch_quick() {
@@ -7376,6 +7382,10 @@ pub fn open_project_branch(
     .map_err(|e| e.to_string())?;
     new_tab.local_branch_view = Some(branch);
     new_tab.mode = er_engine::app::DiffMode::Branch;
+    // The tab's own remote is the repo actually being viewed, not the active
+    // project's remote — resolve it from this repo's git remote (see
+    // `build_local_branch_tab`).
+    new_tab.remote_repo = projects::resolve_repo_remote(&proj.root_path);
     new_tab.sync_managed_storage();
     refresh_branch_open_diff(&mut new_tab)?;
 

--- a/crates/er-desktop/src/projects.rs
+++ b/crates/er-desktop/src/projects.rs
@@ -361,6 +361,12 @@ fn query_remote(root_path: &str) -> Option<String> {
     }
 }
 
+/// Resolve the `owner/repo` slug for a repo root from its own git remote.
+/// Returns `None` when the repo has no GitHub remote (offline / no gh).
+pub fn resolve_repo_remote(root_path: &str) -> Option<String> {
+    query_remote(root_path).filter(|s| !s.is_empty())
+}
+
 /// Lightweight tab identity for project registration (testable without git/gh).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TabProjectRef {

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -595,6 +595,10 @@ pub struct TabSummary {
     pub kind: String, // "working" | "local_branch" | "remote_pr"
     pub branch: Option<String>,
     pub pr_number: Option<u64>,
+    /// The repo (owner/repo slug) this tab actually views — may differ from
+    /// the active project's remote (worktrees/branches from other repos).
+    #[serde(default)]
+    pub remote: Option<String>,
     pub repo_root: String,
     pub is_active: bool,
     pub change_token: String,
@@ -739,13 +743,31 @@ pub(crate) fn resolve_github_status_key(
         .unwrap_or(&tab.current_branch);
 
     // 2. Local PR tab: trust the tab's own pr_number; only resolve the slug.
+    //    When the tab knows its own remote (local PR tabs resolve it from the
+    //    repo's git remote), restrict the slug search to that repo — otherwise
+    //    a PR number that exists in several repos (e.g. #73 in both easy-review
+    //    and design-system) matches an arbitrary repo's PR.
     if let Some(number) = tab.pr_number {
+        let matches = |slug: &str, prs: &[PrInfo]| {
+            let in_repo = tab
+                .remote_repo
+                .as_deref()
+                .map(|r| r.eq_ignore_ascii_case(slug))
+                .unwrap_or(true);
+            in_repo && prs.iter().any(|p| p.number == number)
+        };
         return pr_cache
             .iter()
-            .find(|(_, prs)| prs.iter().any(|p| p.number == number))
+            .find(|(slug, prs)| matches(slug, prs))
             .or_else(|| {
                 pr_cache
                     .iter()
+                    .filter(|(slug, _)| {
+                        tab.remote_repo
+                            .as_deref()
+                            .map(|r| r.eq_ignore_ascii_case(slug))
+                            .unwrap_or(true)
+                    })
                     .find(|(_, prs)| prs.iter().any(|p| p.head_ref == branch))
             })
             .and_then(|(slug, _)| {
@@ -754,16 +776,28 @@ pub(crate) fn resolve_github_status_key(
             });
     }
 
-    // 3. Plain branch / working tab: match by head_ref, prefer an OPEN PR.
-    pr_cache.iter().find_map(|(slug, prs)| {
-        prs.iter()
-            .filter(|p| p.head_ref == branch)
-            .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
-            .and_then(|p| {
-                slug.split_once('/')
-                    .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
-            })
-    })
+    // 3. Plain branch / working tab: match by head_ref, preferring an OPEN PR.
+    //    When the tab knows its own remote (branch tabs resolve it from the
+    //    repo's git remote), restrict the match to that repo — otherwise a
+    //    branch name that exists in several repos matches an arbitrary PR in
+    //    the wrong one.
+    pr_cache
+        .iter()
+        .filter(|(slug, _)| {
+            tab.remote_repo
+                .as_deref()
+                .map(|r| r.eq_ignore_ascii_case(slug))
+                .unwrap_or(true)
+        })
+        .find_map(|(slug, prs)| {
+            prs.iter()
+                .filter(|p| p.head_ref == branch)
+                .min_by_key(|p| if p.state == "OPEN" { 0 } else { 1 })
+                .and_then(|p| {
+                    slug.split_once('/')
+                        .map(|(o, r)| (o.to_string(), r.to_string(), p.number))
+                })
+        })
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1031,6 +1065,10 @@ pub struct WorktreeSnapshot {
     pub is_pr: bool,
     pub pr_number: Option<u64>,
     pub is_merged: bool,
+    /// The repo (owner/repo slug) this worktree belongs to, from its own git
+    /// remote — may differ from the active project's remote.
+    #[serde(default)]
+    pub remote: Option<String>,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1936,6 +1974,7 @@ fn build_snapshot_inner(
                 kind: kind.to_string(),
                 branch: t.local_branch_view.clone(),
                 pr_number: t.pr_number,
+                remote: t.remote_repo.clone(),
                 repo_root: t.repo_root.clone(),
                 is_active: i == active_tab,
                 change_token: t.branch_diff_hash.clone(),
@@ -2391,8 +2430,8 @@ struct WorktreesMetaKey {
     fingerprint: u64,
 }
 
-/// Per-worktree PR metadata `(is_pr, pr_number, is_merged)` keyed by worktree path.
-type WorktreeMetaMap = HashMap<String, (bool, Option<u64>, bool)>;
+/// Per-worktree PR metadata `(is_pr, pr_number, is_merged, remote)` keyed by worktree path.
+type WorktreeMetaMap = HashMap<String, (bool, Option<u64>, bool, Option<String>)>;
 
 /// Cached per-worktree PR metadata `(is_pr, pr_number, is_merged)` keyed by path.
 ///
@@ -2452,18 +2491,20 @@ fn build_worktrees(
     let meta = worktrees_meta_cached(key, || {
         wts.iter()
             .map(|wt| {
-                (
-                    wt.path.clone(),
-                    detect_pr_meta(&wt.path, &wt.branch, base_branch, skip_merged),
-                )
+                let (is_pr, pr_number, is_merged) =
+                    detect_pr_meta(&wt.path, &wt.branch, base_branch, skip_merged);
+                let remote = crate::projects::resolve_repo_remote(&wt.path);
+                (wt.path.clone(), (is_pr, pr_number, is_merged, remote))
             })
             .collect()
     });
 
     wts.into_iter()
         .map(|wt| {
-            let (is_pr, pr_number, is_merged) =
-                meta.get(&wt.path).copied().unwrap_or((false, None, false));
+            let (is_pr, pr_number, is_merged, remote) = meta
+                .get(&wt.path)
+                .cloned()
+                .unwrap_or((false, None, false, None));
             WorktreeSnapshot {
                 is_current: wt.path == current_root,
                 branch: wt.branch,
@@ -2471,6 +2512,7 @@ fn build_worktrees(
                 is_pr,
                 pr_number,
                 is_merged,
+                remote,
             }
         })
         .collect()
@@ -3684,6 +3726,39 @@ mod tests {
         );
     }
 
+    /// A local PR tab that knows its own remote must not resolve the slug from
+    /// a DIFFERENT repo that happens to have the same PR number — the exact
+    /// "opens easy-review#73 while reviewing design-system#73" bug.
+    #[test]
+    fn github_key_local_pr_tab_restricts_slug_to_own_remote() {
+        let branch = "feat/floating-toolbar-design-system";
+        let mut cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        // Same PR number in two repos: the tab's own repo and another.
+        cache.insert(
+            "reshapebiotech/design-system".to_string(),
+            vec![pr_with(73, branch, "OPEN")],
+        );
+        cache.insert(
+            "VilfredSikker/easy-review".to_string(),
+            vec![pr_with(73, "claude/issue-69-reference-highlight", "MERGED")],
+        );
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.local_branch_view = Some(branch.to_string());
+        tab.pr_number = Some(73);
+        tab.remote_repo = Some("reshapebiotech/design-system".to_string());
+
+        assert_eq!(
+            resolve_github_status_key(&tab, &cache),
+            Some((
+                "reshapebiotech".to_string(),
+                "design-system".to_string(),
+                73
+            )),
+            "must resolve the PR in the tab's own repo, not the colliding easy-review#73"
+        );
+    }
+
     /// Even if the tab's own PR isn't in the cache yet, the slug is recovered
     /// from any PR on the head branch and the tab's number is forced.
     #[test]
@@ -3734,6 +3809,28 @@ mod tests {
         assert_eq!(
             resolve_github_status_key(&tab, &cache),
             Some(("octo".to_string(), "cat".to_string(), 11))
+        );
+    }
+
+    /// A branch tab that knows its own remote must not match a PR in a
+    /// different repo, even when the head branch name collides there.
+    #[test]
+    fn github_key_branch_tab_restricts_to_own_remote() {
+        let branch = "feature/x";
+        let mut cache: HashMap<String, Vec<PrInfo>> = HashMap::new();
+        cache.insert("octo/cat".to_string(), vec![pr_with(11, branch, "OPEN")]);
+        // Same branch name exists in a different repo.
+        cache.insert("other/repo".to_string(), vec![pr_with(99, branch, "OPEN")]);
+
+        let mut tab = TabState::new_for_test(vec![]);
+        tab.local_branch_view = Some(branch.to_string());
+        tab.pr_number = None;
+        tab.remote_repo = Some("octo/cat".to_string());
+
+        assert_eq!(
+            resolve_github_status_key(&tab, &cache),
+            Some(("octo".to_string(), "cat".to_string(), 11)),
+            "must match the PR in the tab's own repo, not the colliding repo"
         );
     }
 
@@ -4388,7 +4485,7 @@ mod tests {
         let compute = || {
             calls.set(calls.get() + 1);
             let mut m = HashMap::new();
-            m.insert("/wt".to_string(), (true, Some(7u64), false));
+            m.insert("/wt".to_string(), (true, Some(7u64), false, None));
             m
         };
         let key = || WorktreesMetaKey {
@@ -4402,7 +4499,7 @@ mod tests {
         // First call: cache miss → compute runs once, value flows through.
         let v1 = worktrees_meta_cached(key(), compute);
         assert_eq!(calls.get(), 1);
-        assert_eq!(v1.get("/wt").copied(), Some((true, Some(7), false)));
+        assert_eq!(v1.get("/wt").cloned(), Some((true, Some(7), false, None)));
 
         // Same key within TTL: cache hit → no recompute, same value.
         let v2 = worktrees_meta_cached(key(), compute);
@@ -4411,7 +4508,7 @@ mod tests {
             1,
             "same worktree set within TTL must reuse cached meta, not respawn git subprocesses"
         );
-        assert_eq!(v2.get("/wt").copied(), Some((true, Some(7), false)));
+        assert_eq!(v2.get("/wt").cloned(), Some((true, Some(7), false, None)));
 
         // Changed fingerprint (worktree added/removed/switched): miss → recompute.
         let changed = WorktreesMetaKey {

--- a/crates/er-engine/src/app/state/mod.rs
+++ b/crates/er-engine/src/app/state/mod.rs
@@ -1111,6 +1111,9 @@ impl TabState {
         });
         tab.pr_head_ref = Some(format!("refs/er/pr/{pr_number}/head"));
         tab.pr_number = Some(pr_number);
+        tab.remote_repo = crate::github::get_repo_info(&tab.repo_root)
+            .ok()
+            .map(|(owner, repo)| format!("{owner}/{repo}"));
         tab.pr_data = pr_data;
         tab.last_diff_head_oid = head_oid;
         tab.mode = DiffMode::PrDiff;
@@ -1192,6 +1195,9 @@ impl TabState {
         });
         tab.pr_head_ref = Some(format!("refs/er/pr/{}/head", pr_number));
         tab.pr_number = Some(pr_number);
+        tab.remote_repo = crate::github::get_repo_info(&tab.repo_root)
+            .ok()
+            .map(|(owner, repo)| format!("{owner}/{repo}"));
         tab.pr_commits =
             crate::github::gh_pr_commits(&tab.repo_root, pr_number, 250).unwrap_or_default();
         tab.mode = DiffMode::Branch;
@@ -1220,6 +1226,9 @@ impl TabState {
         });
         tab.pr_head_ref = Some(format!("refs/er/pr/{}/head", pr_number));
         tab.pr_number = Some(pr_number);
+        tab.remote_repo = crate::github::get_repo_info(&tab.repo_root)
+            .ok()
+            .map(|(owner, repo)| format!("{owner}/{repo}"));
         tab.pr_data = pr_data;
         tab.pr_commits = pr_commits;
         tab.mode = DiffMode::Branch;

--- a/desktop-ui/src/lib/prUrl.test.ts
+++ b/desktop-ui/src/lib/prUrl.test.ts
@@ -117,14 +117,14 @@ describe("resolveActivePrUrl", () => {
     expect(resolveActivePrUrl(snap)).toBe("https://github.com/x/y/pull/99");
   });
 
-  it("builds URL from project remote and tab pr_number", () => {
+  it("builds URL from tab remote first, falling back to project remote", () => {
     const snap = minimalSnapshot({
       projects: [
         {
           id: "p1",
           name: "proj",
           root_path: "/tmp",
-          remote: "git@github.com:org/repo.git",
+          remote: "git@github.com:wrong/repo.git",
           is_active: true,
           local_branches: [],
           auto_branches: [],
@@ -142,8 +142,59 @@ describe("resolveActivePrUrl", () => {
           kind: "working",
           branch: "feat",
           pr_number: 42,
+          remote: "git@github.com:org/repo.git",
           repo_root: "/tmp",
           is_active: true,
+          change_token: "",
+        },
+      ],
+      active_tab: 0,
+    });
+    // The tab's own remote wins over the active project's remote — a project
+    // may point at a different repo than the branch actually being viewed.
+    expect(resolveActivePrUrl(snap)).toBe("https://github.com/org/repo/pull/42");
+  });
+
+  it("falls back to the current worktree's remote when the tab has none", () => {
+    const snap = minimalSnapshot({
+      projects: [
+        {
+          id: "p1",
+          name: "proj",
+          root_path: "/tmp",
+          remote: "git@github.com:wrong/repo.git",
+          is_active: true,
+          local_branches: [],
+          auto_branches: [],
+          saved_prs: [],
+          my_prs: [],
+          prs_to_review: [],
+          recent_prs: [],
+          recently_merged: [],
+        },
+      ],
+      worktrees: [
+        {
+          path: "/tmp/wt",
+          branch: "feat",
+          is_current: true,
+          is_pr: false,
+          pr_number: 42,
+          is_merged: false,
+          remote: "git@github.com:org/repo.git",
+        },
+      ],
+      tabs: [
+        {
+          idx: 0,
+          label: "feat",
+          kind: "working",
+          branch: "feat",
+          pr_number: null,
+          remote: null,
+          repo_root: "/tmp",
+          is_active: true,
+          change_token: "",
         },
       ],
       active_tab: 0,

--- a/desktop-ui/src/lib/prUrl.ts
+++ b/desktop-ui/src/lib/prUrl.ts
@@ -38,7 +38,16 @@ export function resolveActivePrUrl(snapshot: AppSnapshot | null): string | null 
 
   if (prNumber == null) return null;
 
-  const remote = snapshot.projects.find((p) => p.is_active)?.remote;
+  // Resolve the repo from the tab's own remote first — a project may point at
+  // a different repo than the branch/PR actually being viewed (e.g. a project
+  // registered under the EasyReview repo reviewing a PR from another repo).
+  // Fall back to the current worktree's remote, then the active project's.
+  const worktreeRemote = snapshot.worktrees.find((w) => w.is_current)?.remote ?? null;
+  const remote =
+    activeTab?.remote ??
+    worktreeRemote ??
+    snapshot.projects.find((p) => p.is_active)?.remote ??
+    null;
   if (!remote) return null;
 
   const slug = parseGithubSlug(remote);

--- a/desktop-ui/src/lib/resolveTabRoot.test.ts
+++ b/desktop-ui/src/lib/resolveTabRoot.test.ts
@@ -8,6 +8,7 @@ const tab = (overrides: Partial<TabSummary> = {}): TabSummary => ({
   kind: "local_branch",
   branch: "feat",
   pr_number: null,
+  remote: null,
   repo_root: "/Users/me/Projects/discovery",
   is_active: true,
   change_token: "",
@@ -73,6 +74,7 @@ describe("resolveTabRoot", () => {
           is_pr: false,
           pr_number: null,
           is_merged: false,
+          remote: null,
         },
         {
           path: "/Users/me/Projects/discovery/.claude/worktrees/vilfred+dev-6490-1-frontend-and-backend-mock",
@@ -81,6 +83,7 @@ describe("resolveTabRoot", () => {
           is_pr: true,
           pr_number: 6490,
           is_merged: false,
+          remote: null,
         },
       ],
     });

--- a/desktop-ui/src/lib/snapshotChrome.test.ts
+++ b/desktop-ui/src/lib/snapshotChrome.test.ts
@@ -37,6 +37,7 @@ function tab(partial: Partial<TabSummary> & Pick<TabSummary, "idx" | "label">): 
     kind: "remote_pr",
     branch: null,
     pr_number: null,
+    remote: null,
     repo_root: "/repo",
     is_active: false,
     change_token: "t",

--- a/desktop-ui/src/lib/stories/BranchContextBar.stories.ts
+++ b/desktop-ui/src/lib/stories/BranchContextBar.stories.ts
@@ -55,6 +55,7 @@ export const RemotePrTab: Story = {
           kind: "remote_pr",
           branch: null,
           pr_number: 154,
+          remote: "octocat/Hello-World",
           repo_root: "",
           is_active: true,
           change_token: "",

--- a/desktop-ui/src/lib/stories/MainLayout.stories.ts
+++ b/desktop-ui/src/lib/stories/MainLayout.stories.ts
@@ -135,7 +135,7 @@ export const SparseData: Story = {
       ...emptySnapshot,
       branch: "main",
       base: "origin/main",
-      worktrees: [{ path: "/Users/me/repo", branch: "main", is_current: true, is_pr: false, pr_number: null, is_merged: false }],
+      worktrees: [{ path: "/Users/me/repo", branch: "main", is_current: true, is_pr: false, pr_number: null, is_merged: false, remote: null }],
     },
   },
 };

--- a/desktop-ui/src/lib/stories/TabStrip.stories.ts
+++ b/desktop-ui/src/lib/stories/TabStrip.stories.ts
@@ -8,6 +8,7 @@ function tab(overrides: Partial<TabSummary> & { idx: number; label: string }): T
     kind: "working",
     branch: null,
     pr_number: null,
+    remote: null,
     repo_root: "/Users/me/code/repo",
     is_active: false,
     change_token: "",

--- a/desktop-ui/src/lib/stories/fixtures.ts
+++ b/desktop-ui/src/lib/stories/fixtures.ts
@@ -413,9 +413,9 @@ export const prDraft: PrSnapshot = {
 // ─── worktrees + commits ────────────────────────────────────────────────────
 
 export const worktreesMulti: WorktreeSnapshot[] = [
-  { path: "/Users/vilfred/Projects/discovery-platform", branch: "show-experiment-params", is_current: true, is_pr: false, pr_number: null, is_merged: false },
-  { path: "/Users/vilfred/Projects/discovery-platform/.worktrees/fix-forward-button", branch: "fix-forward-button", is_current: false, is_pr: true, pr_number: 142, is_merged: false },
-  { path: "/Users/vilfred/Projects/.codex/worktrees/c175", branch: "c175", is_current: false, is_pr: false, pr_number: null, is_merged: true },
+  { path: "/Users/vilfred/Projects/discovery-platform", branch: "show-experiment-params", is_current: true, is_pr: false, pr_number: null, is_merged: false, remote: "Vilfred/discovery-platform" },
+  { path: "/Users/vilfred/Projects/discovery-platform/.worktrees/fix-forward-button", branch: "fix-forward-button", is_current: false, is_pr: true, pr_number: 142, is_merged: false, remote: "Vilfred/discovery-platform" },
+  { path: "/Users/vilfred/Projects/.codex/worktrees/c175", branch: "c175", is_current: false, is_pr: false, pr_number: null, is_merged: true, remote: "Vilfred/discovery-platform" },
 ];
 
 const isoAgo = (ms: number) => new Date(Date.now() - ms).toISOString();
@@ -435,6 +435,7 @@ export const tabsWorkingActive: TabSummary[] = [
     kind: "working",
     branch: "show-experiment-params",
     pr_number: 142,
+    remote: "Vilfred/discovery-platform",
     repo_root: "/Users/vilfred/Projects/discovery-platform",
     is_active: true,
     change_token: "",
@@ -551,6 +552,7 @@ export const remoteOnlyProjectSnapshot: AppSnapshot = {
       kind: "remote_pr",
       branch: null,
       pr_number: 123,
+      remote: "owner/repo",
       repo_root: "",
       is_active: true,
       change_token: "",

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -239,6 +239,8 @@ export interface WorktreeSnapshot {
   is_pr: boolean;
   pr_number: number | null;
   is_merged: boolean;
+  /** Repo (owner/repo slug) this worktree belongs to, from its own git remote. */
+  remote: string | null;
 }
 
 export interface BranchInfo {
@@ -324,6 +326,8 @@ export interface TabSummary {
   kind: "working" | "local_branch" | "remote_pr";
   branch: string | null;
   pr_number: number | null;
+  /** Repo (owner/repo slug) this tab actually views — may differ from the active project's remote. */
+  remote: string | null;
   repo_root: string;
   is_active: boolean;
   change_token: string;


### PR DESCRIPTION
## Problem

When reviewing a PR from a project registered under a different repo (e.g. the EasyReview project while reviewing `reshapebiotech/design-system`), the Branch tab and topbar showed the **wrong repo and PR**:

- `Open PR #73` opened `github.com/VilfredSikker/easy-review/pull/73` instead of `reshapebiotech/design-system/pull/73`
- The GitHub status card showed another repo's PR summary/description ("Closes #69"), checks, and review state
- Approval was blocked as "approving your own PR" because `is_authored_by_me` was computed against the wrong repo's author

## Root cause

Local PR tabs and branch tabs never set `tab.remote_repo` to the repo actually being viewed. Two resolution paths then picked the wrong repo:

1. **Frontend** (`resolveActivePrUrl`): fell back to the *active project's* remote instead of the tab's repo.
2. **Backend** (`resolve_github_status_key` case 2): resolved the owner/repo slug by PR number **across all repos** in the cache — so a same-number PR in another repo (both easy-review and design-system have #73) could win.

## Fix

- Set `tab.remote_repo` from the repo's own `origin` remote in the local-PR tab constructors (`new_local_pr`, `new_local_pr_from_github_diff`, `new_stub_pr_tab`) and the branch-tab open paths (`build_local_branch_tab`, `open_project_branch`)
- Restrict `resolve_github_status_key`'s slug match to the tab's own repo for local PR tabs (case 2) and branch tabs (case 3)
- Emit the tab/worktree remote in `TabSummary` and `WorktreeSnapshot` so `resolveActivePrUrl` prefers the tab's repo over the active project's

## Testing

- `github_key_local_pr_tab_restricts_slug_to_own_remote` regression test reproduces the exact easy-review#73 vs design-system#73 collision
- er-engine: 911 tests pass · er-desktop: 156 tests pass · desktop-ui: 602 tests pass
- clippy + fmt clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub PR resolution and status keying used for links and review UI; logic is narrowed with tests but wrong slug choice previously caused user-visible misrouting.
> 
> **Overview**
> Fixes **wrong GitHub PR URLs, status cards, and approval context** when the active project points at a different repo than the branch or PR being reviewed (e.g. same PR number `#73` in easy-review vs design-system).
> 
> **Backend:** Local branch and PR tab open paths now set **`tab.remote_repo`** from that repo’s git `origin` (via `resolve_repo_remote` / `get_repo_info`), not the active project. **`resolve_github_status_key`** restricts PR-cache slug matching to the tab’s remote for local PR and plain branch tabs so cross-repo number/branch collisions don’t win.
> 
> **Snapshots & UI:** **`TabSummary`** and **`WorktreeSnapshot`** expose **`remote`**; **`resolveActivePrUrl`** prefers active tab → current worktree → active project when building `github.com/.../pull/N` links.
> 
> Regression tests cover the design-system vs easy-review `#73` collision and branch-name collisions across repos. Crate versions bump to **0.4.9**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc4e365e5f9ed503f097cbbdecb8b534e857792. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->