### PR TITLE
feat(desktop): Mermaid diagram AI command and Context tab

### DIFF
--- a/crates/er-desktop/permissions/app-commands.toml
+++ b/crates/er-desktop/permissions/app-commands.toml
@@ -20,6 +20,8 @@ commands.allow = [
   "bulk_review_pillar",
   "unbulk_review_pillar",
   "generate_tour",
+  "generate_diagram",
+  "delete_diagram",
   "open_in_editor",
   "open_in_vscode",
   "open_source",

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3375,6 +3375,137 @@ pub async fn generate_tour(state: State<'_, AppState>) -> Result<AppSnapshot, St
     .await
 }
 
+/// Generate a mermaid diagram of the active view's diff (`kind` =
+/// `mental-model` | `subsystems` | `flows` | `custom`). The agent writes one
+/// sidecar, `{er_dir}/diagrams/<kind>.json` (presets overwrite on re-run;
+/// customs get a timestamped id and accumulate). Diagrams are per-view-bucket,
+/// like triage: the active bucket is both write target and (via
+/// `load_ai_state`) read source. The mtime poll picks up the result.
+#[tauri::command]
+pub async fn generate_diagram(
+    kind: String,
+    custom_prompt: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<AppSnapshot, String> {
+    let state = state.inner().clone();
+    run_blocking(move || {
+        if !er_engine::ai::is_valid_diagram_kind(&kind) {
+            return Err(format!("Unknown diagram kind: {kind}"));
+        }
+        let custom_prompt = custom_prompt
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty());
+        if kind == er_engine::ai::DIAGRAM_KIND_CUSTOM && custom_prompt.is_none() {
+            return Err("A custom diagram needs a prompt".to_string());
+        }
+
+        let mut app = state.app.lock().map_err(|e| e.to_string())?;
+        let scope = "branch".to_string();
+
+        let (repo_root, branch_label, base_branch, er_dir, pr_number, remote_repo, is_remote) = {
+            let tab = app.tab();
+            let branch_label = tab
+                .local_branch_view
+                .clone()
+                .unwrap_or_else(|| tab.current_branch.clone());
+            (
+                tab.repo_root.clone(),
+                branch_label,
+                tab.base_branch.clone(),
+                tab.er_dir(),
+                tab.pr_number,
+                tab.remote_repo.clone(),
+                tab.remote_repo.is_some(),
+            )
+        };
+
+        let diagrams_dir = format!("{er_dir}/diagrams");
+        std::fs::create_dir_all(&diagrams_dir)
+            .map_err(|e| format!("Failed to create diagrams directory: {e}"))?;
+
+        let mut raw = app
+            .tab()
+            .raw_diff_for_review(&scope)
+            .map_err(|e| e.to_string())?;
+        let ignore = projects::review_ignore_globs_for_repo(&repo_root, remote_repo.as_deref());
+        if !ignore.is_empty() {
+            raw = er_engine::git::filter_raw_diff_exclude_globs(&raw, &ignore);
+        }
+        if raw.trim().is_empty() {
+            return Err("Nothing to diagram".to_string());
+        }
+        let diff_hash = er_engine::ai::prepared_diff::ensure_diff_artifacts(&er_dir, &raw)?;
+
+        // Presets regenerate in place (`mental-model.json`, …); each custom
+        // prompt produces a new timestamped diagram so they accumulate.
+        let output_file = if kind == er_engine::ai::DIAGRAM_KIND_CUSTOM {
+            let ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            format!("custom-{ms}.json")
+        } else {
+            format!("{kind}.json")
+        };
+
+        let scope_label = if app.tab().tour_context_is_pr() {
+            "PR diff"
+        } else {
+            "branch diff"
+        };
+        let prompt = er_engine::ai::prompts::build_diagram_prompt_prepared_diff(
+            scope_label,
+            &er_dir,
+            &output_file,
+            &diff_hash,
+            &kind,
+            custom_prompt.as_deref(),
+        );
+        let target = er_engine::app::BackgroundTaskTarget {
+            repo_root,
+            er_dir: er_dir.clone(),
+            branch_label,
+            base_branch,
+            scope,
+            pr_number,
+            remote_repo,
+            managed_local: !is_remote,
+        };
+        app.spawn_background_diagram(&kind, target, prompt, true)
+            .map_err(|e| e.to_string())?;
+        state
+            .desktop_revision
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(snap_from(&app, &state))
+    })
+    .await
+}
+
+/// Delete one diagram sidecar (`{er_dir}/diagrams/<id>.json`) from the active
+/// view bucket.
+#[tauri::command]
+pub async fn delete_diagram(id: String, state: State<'_, AppState>) -> Result<AppSnapshot, String> {
+    let state = state.inner().clone();
+    run_blocking(move || {
+        if !er_engine::ai::is_safe_diagram_id(&id) {
+            return Err(format!("Invalid diagram id: {id}"));
+        }
+        let mut app = state.app.lock().map_err(|e| e.to_string())?;
+        let path = std::path::Path::new(&app.tab().er_dir())
+            .join("diagrams")
+            .join(format!("{id}.json"));
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|e| format!("Failed to delete diagram: {e}"))?;
+        }
+        app.tab_mut().reload_ai_state();
+        state
+            .desktop_revision
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(snap_from(&app, &state))
+    })
+    .await
+}
+
 pub use er_engine::ai::{ExpertInfo, ReviewerInfo};
 
 #[tauri::command]

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -3438,15 +3438,7 @@ pub async fn generate_diagram(
 
         // Presets regenerate in place (`mental-model.json`, …); each custom
         // prompt produces a new timestamped diagram so they accumulate.
-        let output_file = if kind == er_engine::ai::DIAGRAM_KIND_CUSTOM {
-            let ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis())
-                .unwrap_or(0);
-            format!("custom-{ms}.json")
-        } else {
-            format!("{kind}.json")
-        };
+        let output_file = er_engine::ai::diagram_output_file(&kind);
 
         let scope_label = if app.tab().tour_context_is_pr() {
             "PR diff"
@@ -3461,6 +3453,8 @@ pub async fn generate_diagram(
             &kind,
             custom_prompt.as_deref(),
         );
+        let output_path = er_engine::ai::diagram_sidecar_path(&er_dir, &output_file)
+            .ok_or_else(|| format!("Invalid diagram output file: {output_file}"))?;
         let target = er_engine::app::BackgroundTaskTarget {
             repo_root,
             er_dir: er_dir.clone(),
@@ -3471,7 +3465,13 @@ pub async fn generate_diagram(
             remote_repo,
             managed_local: !is_remote,
         };
-        app.spawn_background_diagram(&kind, target, prompt, true)
+        let host_write = er_engine::app::HostWriteDiagram {
+            output_path,
+            kind: kind.clone(),
+            diff_hash,
+            custom_prompt,
+        };
+        app.spawn_background_diagram(&kind, target, prompt, true, host_write)
             .map_err(|e| e.to_string())?;
         state
             .desktop_revision

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -1814,6 +1814,8 @@ fn main() {
             commands::bulk_review_pillar,
             commands::unbulk_review_pillar,
             commands::generate_tour,
+            commands::generate_diagram,
+            commands::delete_diagram,
             commands::open_in_editor,
             commands::open_in_vscode,
             commands::open_source,

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -973,6 +973,24 @@ pub struct AiSnapshot {
     /// Top-level GitHub comments eligible for batch validate (!resolved, !outdated).
     pub eligible_comment_count: usize,
     pub triage: Option<TriageSnapshot>,
+    /// Mermaid diagrams of the diff (`diagrams/*.json`), for the Context tab.
+    pub diagrams: Vec<DiagramSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiagramSnapshot {
+    /// File-stem id (`diagrams/<id>.json`) — delete/regenerate target.
+    pub id: String,
+    /// `mental-model` | `subsystems` | `flows` | `custom`.
+    pub kind: String,
+    pub title: String,
+    /// User prompt for custom diagrams (empty for presets).
+    pub prompt: String,
+    /// Bare mermaid source.
+    pub mermaid: String,
+    /// True when the diagram's diff hash matches the current diff.
+    pub fresh: bool,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2328,6 +2346,7 @@ fn empty_ai_snapshot() -> AiSnapshot {
         has_review_json: false,
         eligible_comment_count: 0,
         triage: None,
+        diagrams: Vec::new(),
     }
 }
 
@@ -3537,6 +3556,24 @@ fn build_ai_snapshot(tab: &TabState, pending: Option<&PendingAiReplies>) -> AiSn
         }
     });
 
+    // A diagram is fresh when it was generated against the diff it is viewed
+    // with: branch bucket diagrams hash the branch diff, PR bucket diagrams
+    // hash the PR diff (`tab.diff_hash` after a full refresh) — accept either.
+    let diagrams = ai
+        .diagrams
+        .iter()
+        .map(|d| DiagramSnapshot {
+            id: d.id.clone(),
+            kind: d.kind.clone(),
+            title: d.title.clone(),
+            prompt: d.prompt.clone(),
+            mermaid: d.mermaid.clone(),
+            fresh: d.diff_hash == tab.branch_diff_hash
+                || (!tab.diff_hash.is_empty() && d.diff_hash == tab.diff_hash),
+            created_at: d.created_at.clone(),
+        })
+        .collect();
+
     AiSnapshot {
         fresh: !ai.is_stale,
         stale_reason,
@@ -3556,6 +3593,7 @@ fn build_ai_snapshot(tab: &TabState, pending: Option<&PendingAiReplies>) -> AiSn
         has_review_json,
         eligible_comment_count,
         triage,
+        diagrams,
     }
 }
 

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -975,6 +975,19 @@ pub struct AiSnapshot {
     pub triage: Option<TriageSnapshot>,
     /// Mermaid diagrams of the diff (`diagrams/*.json`), for the Context tab.
     pub diagrams: Vec<DiagramSnapshot>,
+    /// Built-in diagram generate presets (mental-model / subsystems / flows).
+    /// Always populated from the engine catalog so the UI never hand-rolls
+    /// a parallel list that can drift from `prompts.rs` / kind validation.
+    #[serde(default)]
+    pub diagram_presets: Vec<DiagramPresetSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiagramPresetSnapshot {
+    /// `mental-model` | `subsystems` | `flows`.
+    pub kind: String,
+    pub label: String,
+    pub description: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2347,7 +2360,19 @@ fn empty_ai_snapshot() -> AiSnapshot {
         eligible_comment_count: 0,
         triage: None,
         diagrams: Vec::new(),
+        diagram_presets: diagram_preset_snapshots(),
     }
+}
+
+fn diagram_preset_snapshots() -> Vec<DiagramPresetSnapshot> {
+    er_engine::ai::diagram_presets()
+        .into_iter()
+        .map(|p| DiagramPresetSnapshot {
+            kind: p.kind,
+            label: p.label,
+            description: p.description,
+        })
+        .collect()
 }
 
 /// Load the most recent 10 commits for the file viewer's commit history
@@ -3594,6 +3619,7 @@ fn build_ai_snapshot(tab: &TabState, pending: Option<&PendingAiReplies>) -> AiSn
         eligible_comment_count,
         triage,
         diagrams,
+        diagram_presets: diagram_preset_snapshots(),
     }
 }
 
@@ -3961,6 +3987,22 @@ mod tests {
 
         assert_eq!(snapshot.threads.len(), 1);
         assert!(snapshot.threads[0].stale);
+    }
+
+    #[test]
+    fn ai_snapshot_includes_diagram_presets_from_engine_catalog() {
+        let tab = TabState::new_for_test(vec![]);
+        let snapshot = build_ai_snapshot(&tab, None);
+        let kinds: Vec<&str> = snapshot
+            .diagram_presets
+            .iter()
+            .map(|p| p.kind.as_str())
+            .collect();
+        assert_eq!(kinds, vec!["mental-model", "subsystems", "flows"]);
+        assert!(snapshot
+            .diagram_presets
+            .iter()
+            .all(|p| !p.label.is_empty() && !p.description.is_empty()));
     }
 
     #[test]

--- a/crates/er-engine/src/ai/CLAUDE.md
+++ b/crates/er-engine/src/ai/CLAUDE.md
@@ -34,7 +34,7 @@ paths below use the repo-local `.er/` names, which are identical.
 | `triage.json` | `TriageReview` | Fast branch scan / routing verdict |
 | `professor.json` | — | Teaching insights |
 | `experts/*.json` | — | Domain-specific expert findings |
-| `diagrams/*.json` | `ErDiagram` | Mermaid diagrams of the diff (mental-model / subsystems / flows / custom). Presets overwrite in place; custom diagrams accumulate as timestamped ids. Per-view-bucket like triage/review. |
+| `diagrams/*.json` | `ErDiagram` | Mermaid diagrams of the diff (mental-model / subsystems / flows / custom). Presets overwrite in place; custom diagrams accumulate as timestamped ids. Per-view-bucket like triage/review. **Host-owned write:** the agent runs read-only and emits JSON on stdout; `persist_diagram_from_agent_stdout` validates and atomically writes only this path (prompt-injection confinement). |
 | `questions.json` | `ErQuestions` | Personal review questions (written by `er`) |
 | `notes.json` | `ErNotes` | Local actionable notes — private, agent hand-off oriented (written by `er`) |
 | `github-comments.json` | `ErGitHubComments` | GitHub PR comments, two-way sync (written by `er`) |

--- a/crates/er-engine/src/ai/CLAUDE.md
+++ b/crates/er-engine/src/ai/CLAUDE.md
@@ -18,6 +18,7 @@ paths below use the repo-local `.er/` names, which are identical.
 | `experts.rs` | Expert review files (`experts/*.json`) |
 | `triage.rs` | Fast branch triage (`triage.json`) |
 | `professor.rs` | Learning/teaching insights (`professor.json`) |
+| `diagrams.rs` | Mermaid diagram sidecars (`diagrams/*.json`) + preset catalog |
 | `finding_cleanup.rs` / `finding_responses.rs` | Finding lifecycle: cleanup and AI responses |
 | `relocate.rs` | Re-anchor findings/comments when the diff shifts |
 
@@ -33,6 +34,7 @@ paths below use the repo-local `.er/` names, which are identical.
 | `triage.json` | `TriageReview` | Fast branch scan / routing verdict |
 | `professor.json` | — | Teaching insights |
 | `experts/*.json` | — | Domain-specific expert findings |
+| `diagrams/*.json` | `ErDiagram` | Mermaid diagrams of the diff (mental-model / subsystems / flows / custom). Presets overwrite in place; custom diagrams accumulate as timestamped ids. Per-view-bucket like triage/review. |
 | `questions.json` | `ErQuestions` | Personal review questions (written by `er`) |
 | `notes.json` | `ErNotes` | Local actionable notes — private, agent hand-off oriented (written by `er`) |
 | `github-comments.json` | `ErGitHubComments` | GitHub PR comments, two-way sync (written by `er`) |
@@ -41,7 +43,7 @@ paths below use the repo-local `.er/` names, which are identical.
 
 **`AiState`** — Aggregate state for one tab: optional `review`, `order`,
 `summary`, `agent_summaries`, `checklist`, `questions`, `github_comments`,
-`triage`, legacy `feedback`, plus:
+`triage`, `diagrams`, legacy `feedback`, plus:
 - `is_stale` — true if any sidecar's `diff_hash` differs from the current diff
 - `stale_files` — per-file staleness set
 - `comment_index` — lazily-built `CommentIndexData` for O(1) per-file comment lookup

--- a/crates/er-engine/src/ai/diagrams.rs
+++ b/crates/er-engine/src/ai/diagrams.rs
@@ -109,3 +109,25 @@ pub fn is_safe_diagram_id(id: &str) -> bool {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagram_presets_are_valid_kinds_in_display_order() {
+        let presets = diagram_presets();
+        let kinds: Vec<&str> = presets.iter().map(|p| p.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DIAGRAM_KIND_MENTAL_MODEL,
+                DIAGRAM_KIND_SUBSYSTEMS,
+                DIAGRAM_KIND_FLOWS
+            ]
+        );
+        assert!(presets.iter().all(|p| is_valid_diagram_kind(&p.kind)));
+        assert!(!is_valid_diagram_kind("not-a-kind"));
+        assert!(is_valid_diagram_kind(DIAGRAM_KIND_CUSTOM));
+    }
+}

--- a/crates/er-engine/src/ai/diagrams.rs
+++ b/crates/er-engine/src/ai/diagrams.rs
@@ -1,0 +1,111 @@
+//! Mermaid diagram sidecars (`diagrams/*.json`) — AI-generated visual overviews
+//! of a diff (mental model, subsystems, flows, or a custom prompt).
+//!
+//! Each diagram lives in its own file under `{er_dir}/diagrams/<id>.json`, so
+//! regenerating one preset only overwrites that preset's file and custom
+//! diagrams accumulate. Diagrams are per-view-bucket like triage/review: the
+//! active view's `TabState::er_dir()` is both the write target
+//! (`generate_diagram`) and the read source (`load_ai_state`).
+
+use serde::{Deserialize, Serialize};
+
+pub const DIAGRAM_KIND_MENTAL_MODEL: &str = "mental-model";
+pub const DIAGRAM_KIND_SUBSYSTEMS: &str = "subsystems";
+pub const DIAGRAM_KIND_FLOWS: &str = "flows";
+pub const DIAGRAM_KIND_CUSTOM: &str = "custom";
+
+/// One AI-generated mermaid diagram of a diff.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErDiagram {
+    pub version: u32,
+    pub diff_hash: String,
+    #[serde(default)]
+    pub created_at: String,
+    /// `mental-model` | `subsystems` | `flows` | `custom`.
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub title: String,
+    /// User-supplied prompt for `custom` diagrams (empty for presets). Kept so
+    /// a custom diagram can be regenerated with the same intent.
+    #[serde(default)]
+    pub prompt: String,
+    /// Mermaid diagram source (bare source — no ``` fences).
+    pub mermaid: String,
+    /// File-stem id (`diagrams/<id>.json`); assigned by the loader from the
+    /// filename, not trusted from the file body.
+    #[serde(default)]
+    pub id: String,
+    /// Runtime-only staleness flag, set by the loader when the diagram's
+    /// `diff_hash` no longer matches the current diff.
+    #[serde(skip)]
+    pub stale: bool,
+}
+
+/// A selectable diagram preset in the UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiagramPresetInfo {
+    pub kind: String,
+    pub label: String,
+    pub description: String,
+}
+
+/// Built-in diagram presets, in display order. `custom` is not listed — it is
+/// the free-form prompt entry in the UI.
+pub fn diagram_presets() -> Vec<DiagramPresetInfo> {
+    vec![
+        DiagramPresetInfo {
+            kind: DIAGRAM_KIND_MENTAL_MODEL.to_string(),
+            label: "Mental model".to_string(),
+            description: "High-level map of the areas this diff touches and how they relate"
+                .to_string(),
+        },
+        DiagramPresetInfo {
+            kind: DIAGRAM_KIND_SUBSYSTEMS.to_string(),
+            label: "Subsystems".to_string(),
+            description: "Changed files grouped by subsystem, with interactions".to_string(),
+        },
+        DiagramPresetInfo {
+            kind: DIAGRAM_KIND_FLOWS.to_string(),
+            label: "Flows".to_string(),
+            description: "Runtime flow through the changed code for the main scenarios".to_string(),
+        },
+    ]
+}
+
+pub fn diagram_kind_label(kind: &str) -> &'static str {
+    match kind {
+        DIAGRAM_KIND_MENTAL_MODEL => "Mental model",
+        DIAGRAM_KIND_SUBSYSTEMS => "Subsystems",
+        DIAGRAM_KIND_FLOWS => "Flows",
+        DIAGRAM_KIND_CUSTOM => "Custom",
+        _ => "Diagram",
+    }
+}
+
+pub fn is_valid_diagram_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        DIAGRAM_KIND_MENTAL_MODEL
+            | DIAGRAM_KIND_SUBSYSTEMS
+            | DIAGRAM_KIND_FLOWS
+            | DIAGRAM_KIND_CUSTOM
+    )
+}
+
+/// Background task kind for a diagram run — `diagram:<diagram-kind>`, so two
+/// different presets against the same view bucket don't dedupe against each
+/// other (and are distinguishable in the UI).
+pub fn diagram_task_kind(kind: &str) -> String {
+    format!("diagram:{kind}")
+}
+
+/// Diagram id sanity check — ids become file names (`diagrams/<id>.json`), so
+/// reject anything that could escape the directory.
+pub fn is_safe_diagram_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 120
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}

--- a/crates/er-engine/src/ai/diagrams.rs
+++ b/crates/er-engine/src/ai/diagrams.rs
@@ -6,13 +6,25 @@
 //! diagrams accumulate. Diagrams are per-view-bucket like triage/review: the
 //! active view's `TabState::er_dir()` is both the write target
 //! (`generate_diagram`) and the read source (`load_ai_state`).
+//!
+//! **Write confinement:** the agent runs with read-only tools and emits the
+//! diagram JSON on stdout. Easy Review validates and atomically writes only
+//! `diagrams/<id>.json` — so attacker-controlled diff content cannot steer
+//! Write/Edit into the repo or other sidecars via prompt injection.
 
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
 
 pub const DIAGRAM_KIND_MENTAL_MODEL: &str = "mental-model";
 pub const DIAGRAM_KIND_SUBSYSTEMS: &str = "subsystems";
 pub const DIAGRAM_KIND_FLOWS: &str = "flows";
 pub const DIAGRAM_KIND_CUSTOM: &str = "custom";
+
+/// Delimiters the agent must wrap its JSON payload with (host-owned write).
+pub const DIAGRAM_JSON_BEGIN: &str = "---DIAGRAM_JSON---";
+pub const DIAGRAM_JSON_END: &str = "---END_DIAGRAM_JSON---";
 
 /// One AI-generated mermaid diagram of a diff.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,9 +122,254 @@ pub fn is_safe_diagram_id(id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
+/// Absolute path for a diagram sidecar under `er_dir`, or `None` if `file_name`
+/// is not a safe `<id>.json`.
+pub fn diagram_sidecar_path(er_dir: &str, file_name: &str) -> Option<PathBuf> {
+    let id = file_name.strip_suffix(".json")?;
+    if !is_safe_diagram_id(id) {
+        return None;
+    }
+    Some(Path::new(er_dir).join("diagrams").join(file_name))
+}
+
+/// Output filename for a new diagram of `kind` — presets overwrite in place
+/// (`<kind>.json`, one file per preset); `custom` gets a fresh timestamped id
+/// so custom diagrams accumulate instead of overwriting each other.
+pub fn diagram_output_file(kind: &str) -> String {
+    if kind == DIAGRAM_KIND_CUSTOM {
+        let ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        format!("custom-{ms}.json")
+    } else {
+        format!("{kind}.json")
+    }
+}
+
+/// Parse agent stdout into a validated [`ErDiagram`] and atomically write it
+/// to `output_path` (must already be a safe `…/diagrams/<id>.json`).
+///
+/// The agent must not have Write/Edit tools; this is the only write path.
+pub fn persist_diagram_from_agent_stdout(
+    stdout: &str,
+    stream_json: bool,
+    expected_kind: &str,
+    expected_diff_hash: &str,
+    custom_prompt: Option<&str>,
+    output_path: &Path,
+) -> Result<()> {
+    let mut diagram = parse_diagram_from_agent_stdout(stdout, stream_json)?;
+    validate_and_normalize_diagram(
+        &mut diagram,
+        expected_kind,
+        expected_diff_hash,
+        custom_prompt,
+    )?;
+    write_diagram_atomic(output_path, &diagram)
+}
+
+/// Validate + atomically write a diagram JSON body an MCP client already
+/// authored (plain JSON, not wrapped agent stdout — see
+/// [`persist_diagram_from_agent_stdout`] for the desktop host-owned-write
+/// variant). The MCP caller is the reviewing agent itself, so there is no
+/// stdout-extraction step, but `kind`/`diff_hash`/`prompt` are still pinned
+/// from the harness rather than trusted from the body.
+pub fn persist_diagram_json(
+    json_text: &str,
+    expected_kind: &str,
+    expected_diff_hash: &str,
+    custom_prompt: Option<&str>,
+    output_path: &Path,
+) -> Result<()> {
+    let mut diagram: ErDiagram = serde_json::from_str(json_text).context("parse diagram JSON")?;
+    validate_and_normalize_diagram(
+        &mut diagram,
+        expected_kind,
+        expected_diff_hash,
+        custom_prompt,
+    )?;
+    write_diagram_atomic(output_path, &diagram)
+}
+
+fn parse_diagram_from_agent_stdout(stdout: &str, stream_json: bool) -> Result<ErDiagram> {
+    let text = if stream_json {
+        extract_agent_stdout_text(stdout)
+    } else {
+        stdout.to_string()
+    };
+    let json_text = extract_diagram_json_payload(&text)
+        .ok_or_else(|| anyhow::anyhow!("agent did not emit a diagram JSON payload"))?;
+    serde_json::from_str(&json_text).context("parse diagram JSON from agent output")
+}
+
+fn validate_and_normalize_diagram(
+    diagram: &mut ErDiagram,
+    expected_kind: &str,
+    expected_diff_hash: &str,
+    custom_prompt: Option<&str>,
+) -> Result<()> {
+    if !is_valid_diagram_kind(expected_kind) {
+        bail!("invalid expected diagram kind: {expected_kind}");
+    }
+    // Never trust the agent for kind / hash / custom prompt — pin from the
+    // harness so a prompt-injected payload cannot retarget the sidecar.
+    diagram.kind = expected_kind.to_string();
+    if diagram.diff_hash.trim().is_empty() || diagram.diff_hash != expected_diff_hash {
+        diagram.diff_hash = expected_diff_hash.to_string();
+    }
+    if expected_kind == DIAGRAM_KIND_CUSTOM {
+        diagram.prompt = custom_prompt.unwrap_or("").to_string();
+    } else {
+        diagram.prompt.clear();
+    }
+    if diagram.version == 0 {
+        diagram.version = 1;
+    }
+    if diagram.created_at.trim().is_empty() {
+        diagram.created_at = unix_now_secs_string();
+    }
+    let mermaid = diagram.mermaid.trim();
+    if mermaid.is_empty() {
+        bail!("diagram mermaid source is empty");
+    }
+    if mermaid.len() > 200_000 {
+        bail!("diagram mermaid source is too large");
+    }
+    diagram.mermaid = mermaid.to_string();
+    if diagram.title.trim().is_empty() {
+        diagram.title = diagram_kind_label(expected_kind).to_string();
+    }
+    // id is assigned by the loader from the filename; clear any agent value.
+    diagram.id.clear();
+    Ok(())
+}
+
+fn write_diagram_atomic(path: &Path, diagram: &ErDiagram) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("diagram path has no parent"))?;
+    std::fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
+    let body = serde_json::to_string_pretty(diagram).context("serialize diagram")?;
+    let tmp = parent.join(format!(
+        ".{}.tmp",
+        path.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("diagram.json")
+    ));
+    std::fs::write(&tmp, body).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| format!("rename onto {}", path.display()))?;
+    Ok(())
+}
+
+fn extract_diagram_json_payload(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if let Some(start) = trimmed.find(DIAGRAM_JSON_BEGIN) {
+        let after = &trimmed[start + DIAGRAM_JSON_BEGIN.len()..];
+        if let Some(end) = after.find(DIAGRAM_JSON_END) {
+            let body = after[..end].trim();
+            if !body.is_empty() {
+                return Some(strip_optional_fence(body));
+            }
+        }
+    }
+    if let Some(block) = extract_fenced_json(trimmed) {
+        return Some(block);
+    }
+    if trimmed.starts_with('{') && serde_json::from_str::<Value>(trimmed).is_ok() {
+        return Some(trimmed.to_string());
+    }
+    for line in trimmed.lines().rev() {
+        let t = line.trim();
+        if t.starts_with('{') && serde_json::from_str::<Value>(t).is_ok() {
+            return Some(t.to_string());
+        }
+    }
+    None
+}
+
+fn strip_optional_fence(s: &str) -> String {
+    let t = s.trim();
+    if let Some(rest) = t.strip_prefix("```json") {
+        if let Some(end) = rest.find("```") {
+            return rest[..end].trim().to_string();
+        }
+    }
+    if let Some(rest) = t.strip_prefix("```") {
+        if let Some(end) = rest.find("```") {
+            return rest[..end].trim().to_string();
+        }
+    }
+    t.to_string()
+}
+
+fn extract_fenced_json(s: &str) -> Option<String> {
+    let start = s.find("```json")?;
+    let rest = &s[start + 7..];
+    let end = rest.find("```")?;
+    Some(rest[..end].trim().to_string())
+}
+
+/// Pull the model's final text from Claude/Cursor `stream-json` NDJSON logs
+/// (same shape as arena / card-AI extractors).
+fn extract_agent_stdout_text(stdout: &str) -> String {
+    let mut last_result: Option<String> = None;
+    let mut assistant_text: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if v.get("type").and_then(|t| t.as_str()) == Some("result") {
+            if let Some(r) = v.get("result").and_then(|r| r.as_str()) {
+                last_result = Some(r.to_string());
+            }
+        }
+        if v.get("type").and_then(|t| t.as_str()) == Some("assistant") {
+            if let Some(content) = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+            {
+                for item in content {
+                    if item.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                            let t = text.trim();
+                            if !t.is_empty() {
+                                assistant_text.push(t.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(r) = last_result.filter(|s| !s.trim().is_empty()) {
+        return r;
+    }
+    if !assistant_text.is_empty() {
+        return assistant_text.join("\n\n");
+    }
+    stdout.to_string()
+}
+
+fn unix_now_secs_string() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|_| "0".into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn diagram_presets_are_valid_kinds_in_display_order() {
@@ -129,5 +386,127 @@ mod tests {
         assert!(presets.iter().all(|p| is_valid_diagram_kind(&p.kind)));
         assert!(!is_valid_diagram_kind("not-a-kind"));
         assert!(is_valid_diagram_kind(DIAGRAM_KIND_CUSTOM));
+    }
+
+    #[test]
+    fn persist_diagram_from_marked_payload_writes_only_target_file() {
+        let dir = tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let path = diagram_sidecar_path(er_dir, "mental-model.json").unwrap();
+        let stdout = format!(
+            "thinking…\n{DIAGRAM_JSON_BEGIN}\n{}\n{DIAGRAM_JSON_END}\n",
+            r#"{
+  "version": 1,
+  "diff_hash": "evil-hash",
+  "kind": "flows",
+  "title": "Overview",
+  "prompt": "ignore me",
+  "mermaid": "flowchart TD\n  A-->B"
+}"#
+        );
+        persist_diagram_from_agent_stdout(
+            &stdout,
+            false,
+            DIAGRAM_KIND_MENTAL_MODEL,
+            "real-hash",
+            None,
+            &path,
+        )
+        .unwrap();
+        let loaded: ErDiagram =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded.kind, DIAGRAM_KIND_MENTAL_MODEL);
+        assert_eq!(loaded.diff_hash, "real-hash");
+        assert!(loaded.prompt.is_empty());
+        assert!(loaded.mermaid.contains("flowchart TD"));
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries, vec!["diagrams"]);
+    }
+
+    #[test]
+    fn parse_rejects_empty_mermaid() {
+        let dir = tempdir().unwrap();
+        let path = diagram_sidecar_path(dir.path().to_str().unwrap(), "flows.json").unwrap();
+        let stdout = format!(
+            "{DIAGRAM_JSON_BEGIN}\n{}\n{DIAGRAM_JSON_END}",
+            r#"{"version":1,"diff_hash":"h","kind":"flows","title":"t","prompt":"","mermaid":"  "}"#
+        );
+        let err =
+            persist_diagram_from_agent_stdout(&stdout, false, DIAGRAM_KIND_FLOWS, "h", None, &path)
+                .unwrap_err();
+        assert!(err.to_string().contains("empty"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn diagram_output_file_presets_are_stable_customs_are_timestamped() {
+        assert_eq!(
+            diagram_output_file(DIAGRAM_KIND_MENTAL_MODEL),
+            "mental-model.json"
+        );
+        assert_eq!(
+            diagram_output_file(DIAGRAM_KIND_SUBSYSTEMS),
+            "subsystems.json"
+        );
+        assert_eq!(diagram_output_file(DIAGRAM_KIND_FLOWS), "flows.json");
+        let custom = diagram_output_file(DIAGRAM_KIND_CUSTOM);
+        assert!(
+            custom.starts_with("custom-") && custom.ends_with(".json"),
+            "{custom}"
+        );
+    }
+
+    #[test]
+    fn persist_diagram_json_pins_kind_and_hash_like_stdout_variant() {
+        let dir = tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let path = diagram_sidecar_path(er_dir, "custom-1.json").unwrap();
+        let body = r#"{
+  "version": 1,
+  "diff_hash": "evil-hash",
+  "kind": "flows",
+  "title": "Overview",
+  "prompt": "ignore me",
+  "mermaid": "flowchart TD\n  A-->B"
+}"#;
+        persist_diagram_json(
+            body,
+            DIAGRAM_KIND_CUSTOM,
+            "real-hash",
+            Some("what the user actually asked"),
+            &path,
+        )
+        .unwrap();
+        let loaded: ErDiagram =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded.kind, DIAGRAM_KIND_CUSTOM);
+        assert_eq!(loaded.diff_hash, "real-hash");
+        assert_eq!(loaded.prompt, "what the user actually asked");
+        assert!(loaded.mermaid.contains("flowchart TD"));
+    }
+
+    #[test]
+    fn persist_diagram_json_rejects_invalid_json_without_writing() {
+        let dir = tempdir().unwrap();
+        let path = diagram_sidecar_path(dir.path().to_str().unwrap(), "flows.json").unwrap();
+        let err =
+            persist_diagram_json("not json", DIAGRAM_KIND_FLOWS, "h", None, &path).unwrap_err();
+        assert!(err.to_string().contains("parse diagram JSON"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn extract_from_stream_json_result_event() {
+        let stdout = concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","result":"---DIAGRAM_JSON---\n{\"version\":1,\"diff_hash\":\"h\",\"kind\":\"subsystems\",\"title\":\"S\",\"prompt\":\"\",\"mermaid\":\"flowchart LR\\n  A-->B\"}\n---END_DIAGRAM_JSON---"}"#,
+            "\n",
+        );
+        let d = parse_diagram_from_agent_stdout(stdout, true).unwrap();
+        assert!(d.mermaid.contains("flowchart LR"));
     }
 }

--- a/crates/er-engine/src/ai/loader.rs
+++ b/crates/er-engine/src/ai/loader.rs
@@ -1,4 +1,7 @@
 use super::comments::{ErFeedback, ErGitHubComments, ErNotes, ErQuestions};
+use super::diagrams::{
+    ErDiagram, DIAGRAM_KIND_FLOWS, DIAGRAM_KIND_MENTAL_MODEL, DIAGRAM_KIND_SUBSYSTEMS,
+};
 use super::experts::{
     expert_by_id, load_expert_reviews, merge_experts_into_review, synthesize_review_from_experts,
 };
@@ -286,6 +289,9 @@ pub fn load_ai_state(er_dir: &str, current_diff_hash: &str, branch_scope: Option
         }
     }
 
+    // Load .er/diagrams/*.json (mermaid diagrams — one file per generated diagram)
+    state.diagrams = load_diagrams(er_dir, current_diff_hash);
+
     // Load legacy .er-feedback.json (only if new files don't exist — migration support)
     if state.questions.is_none() && state.github_comments.is_none() {
         let feedback_path = Path::new(er_dir).join("feedback.json");
@@ -306,6 +312,53 @@ pub fn load_tour_sidecar(dir: &str, name: &str) -> Option<ErTour> {
     let path = Path::new(dir).join(name);
     let content = read_sidecar(&path).ok()?;
     serde_json::from_str::<ErTour>(&content).ok()
+}
+
+/// Load all mermaid diagrams from `{er_dir}/diagrams/*.json`. Each diagram is a
+/// standalone file (written one-per-run by the diagram agent), so unreadable or
+/// malformed files are skipped rather than failing the whole set. The `id` is
+/// the file stem and `stale` is computed against the current diff hash.
+/// Ordering: presets in their fixed display order, then customs newest-first.
+pub fn load_diagrams(er_dir: &str, current_diff_hash: &str) -> Vec<ErDiagram> {
+    let dir = Path::new(er_dir).join("diagrams");
+    let mut out: Vec<ErDiagram> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(content) = read_sidecar(&path) else {
+                continue;
+            };
+            let Ok(mut diagram) = serde_json::from_str::<ErDiagram>(&content) else {
+                continue;
+            };
+            if diagram.mermaid.trim().is_empty() {
+                continue;
+            }
+            diagram.id = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
+            diagram.stale = diagram.diff_hash != current_diff_hash;
+            out.push(diagram);
+        }
+    }
+    out.sort_by(|a, b| {
+        let rank = |d: &ErDiagram| match d.kind.as_str() {
+            k if k == DIAGRAM_KIND_MENTAL_MODEL => 0,
+            k if k == DIAGRAM_KIND_SUBSYSTEMS => 1,
+            k if k == DIAGRAM_KIND_FLOWS => 2,
+            _ => 3,
+        };
+        rank(a)
+            .cmp(&rank(b))
+            // Newest first within a rank (created_at is ISO 8601).
+            .then_with(|| b.created_at.cmp(&a.created_at))
+    });
+    out
 }
 
 /// Get the mtime of the most recently modified .er-* file
@@ -334,6 +387,18 @@ pub fn latest_er_mtime(er_dir: &str) -> Option<std::time::SystemTime> {
 
     let experts_dir = er_dir.join("experts");
     if let Ok(entries) = std::fs::read_dir(&experts_dir) {
+        for entry in entries.flatten() {
+            if let Ok(m) = entry.metadata().and_then(|m| m.modified()) {
+                latest = Some(match latest {
+                    Some(prev) => prev.max(m),
+                    None => m,
+                });
+            }
+        }
+    }
+
+    let diagrams_dir = er_dir.join("diagrams");
+    if let Ok(entries) = std::fs::read_dir(&diagrams_dir) {
         for entry in entries.flatten() {
             if let Ok(m) = entry.metadata().and_then(|m| m.modified()) {
                 latest = Some(match latest {
@@ -637,6 +702,60 @@ mod tests {
             .collect();
         // order 0 foundation first, then order 0 non-foundation, then order 1.
         assert_eq!(ordered, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn load_diagrams_reads_dir_sets_id_and_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let er_dir = dir.path().to_str().unwrap();
+        let diagrams_dir = dir.path().join("diagrams");
+        std::fs::create_dir_all(&diagrams_dir).unwrap();
+
+        let write = |name: &str, kind: &str, hash: &str, created: &str, mermaid: &str| {
+            let d = serde_json::json!({
+                "version": 1,
+                "diff_hash": hash,
+                "created_at": created,
+                "kind": kind,
+                "title": format!("title-{name}"),
+                "prompt": "",
+                "mermaid": mermaid,
+            });
+            std::fs::write(diagrams_dir.join(name), serde_json::to_string(&d).unwrap()).unwrap();
+        };
+
+        write(
+            "flows.json",
+            "flows",
+            "abc",
+            "2026-08-11T10:00:00Z",
+            "flowchart TD\nA-->B",
+        );
+        write(
+            "mental-model.json",
+            "mental-model",
+            "stale-hash",
+            "2026-08-11T09:00:00Z",
+            "flowchart TD\nC-->D",
+        );
+        write(
+            "custom-1.json",
+            "custom",
+            "abc",
+            "2026-08-11T12:00:00Z",
+            "sequenceDiagram\nA->>B: hi",
+        );
+        // Empty mermaid source and malformed JSON are skipped, not fatal.
+        write("empty.json", "custom", "abc", "2026-08-11T13:00:00Z", "  ");
+        std::fs::write(diagrams_dir.join("broken.json"), "{not json").unwrap();
+
+        let diagrams = load_diagrams(er_dir, "abc");
+        let ids: Vec<&str> = diagrams.iter().map(|d| d.id.as_str()).collect();
+        // Presets in fixed display order, then customs; broken/empty skipped.
+        assert_eq!(ids, vec!["mental-model", "flows", "custom-1"]);
+        assert!(!diagrams[1].stale); // flows matches the current diff hash
+        assert!(diagrams[0].stale); // mental-model was generated for another diff
+        assert!(load_ai_state(er_dir, "abc", None).diagrams.len() == 3);
     }
 
     #[test]

--- a/crates/er-engine/src/ai/mod.rs
+++ b/crates/er-engine/src/ai/mod.rs
@@ -1,4 +1,5 @@
 pub mod comments;
+pub mod diagrams;
 pub mod experts;
 pub mod finding_cleanup;
 pub mod finding_responses;
@@ -12,6 +13,7 @@ pub mod scoped_merge;
 pub mod triage;
 
 pub use comments::*;
+pub use diagrams::*;
 pub use experts::*;
 pub use finding_cleanup::*;
 pub use finding_responses::*;

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -614,25 +614,10 @@ Do NOT modify `review.json`, `order.json`, or any other file. Write only `{safe_
     )
 }
 
-/// Diagram generation when `{output_dir}/diff-tmp` is already prepared
-/// (desktop "Generate diagram"). Writes only `{output_dir}/diagrams/{output_file}`.
-/// Built with `push_str` instead of one `format!` so the mermaid examples and
-/// the user's custom prompt never collide with `format!` brace parsing.
-///
-/// `kind` is one of `mental-model` | `subsystems` | `flows` | `custom`; `custom_prompt`
-/// carries the user's free-form instructions for `custom`. One diagram per file, so
-/// re-running a preset replaces only that preset's diagram.
-pub fn build_diagram_prompt_prepared_diff(
-    scope: &str,
-    output_dir: &str,
-    output_file: &str,
-    diff_hash: &str,
-    kind: &str,
-    custom_prompt: Option<&str>,
-) -> String {
-    let safe_output_dir = sanitize_for_shell(output_dir);
-
-    let task = match kind {
+/// Per-kind task instructions shared by [`build_diagram_prompt_prepared_diff`]
+/// (desktop, host-owned write) and [`build_diagram_prompt_mcp`] (MCP clients).
+fn diagram_task_for_kind(kind: &str) -> &'static str {
+    match kind {
         super::diagrams::DIAGRAM_KIND_MENTAL_MODEL => {
             r#"Build a **mental model overview** of this diff: the 5–15 most important components, modules, or concepts the change touches, and how they relate. This is the map a reviewer holds in their head before reading code.
 
@@ -658,7 +643,28 @@ pub fn build_diagram_prompt_prepared_diff(
         _ => {
             r#"Build the diagram the user asked for in **Custom instructions** below. Pick the most fitting mermaid diagram type (`flowchart`, `sequenceDiagram`, `classDiagram`, `stateDiagram-v2`, `erDiagram`, …) for the request."#
         }
-    };
+    }
+}
+
+/// Diagram generation when `{output_dir}/diff-tmp` is already prepared
+/// (desktop "Generate diagram"). The agent emits JSON on stdout; the harness
+/// atomically writes `{output_dir}/diagrams/{output_file}` (no agent Write/Edit).
+/// Built with `push_str` instead of one `format!` so the mermaid examples and
+/// the user's custom prompt never collide with `format!` brace parsing.
+///
+/// `kind` is one of `mental-model` | `subsystems` | `flows` | `custom`; `custom_prompt`
+/// carries the user's free-form instructions for `custom`. One diagram per file, so
+/// re-running a preset replaces only that preset's diagram.
+pub fn build_diagram_prompt_prepared_diff(
+    scope: &str,
+    output_dir: &str,
+    output_file: &str,
+    diff_hash: &str,
+    kind: &str,
+    custom_prompt: Option<&str>,
+) -> String {
+    let safe_output_dir = sanitize_for_shell(output_dir);
+    let task = diagram_task_for_kind(kind);
 
     let mut prompt = String::new();
     prompt.push_str(
@@ -675,14 +681,87 @@ pub fn build_diagram_prompt_prepared_diff(
     prompt.push_str(&safe_output_dir);
     prompt.push_str("/diff-tmp` (the full diff) into context. You may read referenced source files under the repo to understand surrounding structure, but the diagram is about **the change**.\n3. ");
     prompt.push_str(task);
-    prompt.push_str("\n4. Write `");
-    prompt.push_str(&safe_output_dir);
-    prompt.push_str("/diagrams/");
-    prompt.push_str(output_file);
     prompt.push_str(
-        r#"` (and nothing else — create the `diagrams` directory if needed) with this exact shape:
+        "\n4. Emit the diagram JSON in your **final reply text** (do **not** use Write/Edit or any file tools — the harness writes the sidecar). Wrap the JSON exactly like this:\n\n",
+    );
+    prompt.push_str(crate::ai::diagrams::DIAGRAM_JSON_BEGIN);
+    prompt.push('\n');
+    prompt.push_str(
+        r#"{
+  "version": 1,
+  "diff_hash": "<sha256 from step 1>",
+  "created_at": "<ISO 8601>",
+  "kind": ""#,
+    );
+    prompt.push_str(kind);
+    prompt.push_str(
+        r#"",
+  "title": "<short diagram title>",
+  "prompt": "<the custom instructions, or empty string for presets>",
+  "mermaid": "<bare mermaid source — no ``` fences>"
+}
+"#,
+    );
+    prompt.push_str(crate::ai::diagrams::DIAGRAM_JSON_END);
+    prompt.push_str(
+        r#"
 
-```json
+## Mermaid rules (the renderer rejects invalid source)
+- First line must be the diagram type (`flowchart TD`, `sequenceDiagram`, …). No title/frontmatter comment before it.
+- Quote any node label containing special characters: `A["calls foo()"]`, not `A[calls foo()]`.
+- Keep ids alphanumeric (`parser`, `store2`) — put display text in the quoted label.
+- No `click` handlers, links, or raw HTML in labels.
+- Aim for readability in a ~350px-wide panel: ≤ 15 nodes for flowcharts, ≤ 8 participants for sequence diagrams. Omit detail rather than shrink it.
+
+Do NOT call Write, Edit, Bash redirects, or otherwise mutate the filesystem. Print only the marked JSON block above. The harness saves it as `diagrams/"#,
+    );
+    prompt.push_str(output_file);
+    prompt.push_str("`.");
+
+    if let Some(p) = custom_prompt.map(str::trim).filter(|s| !s.is_empty()) {
+        prompt.push_str("\n\n## Custom instructions (user-provided)\n");
+        prompt.push_str(p);
+    }
+
+    prompt
+}
+
+/// Diagram generation for MCP clients. Unlike
+/// [`build_diagram_prompt_prepared_diff`] (a restricted subprocess with no
+/// Write/Edit, so it must emit stdout for host-owned write), an MCP caller is
+/// the reviewing agent itself with full tool access — so it embeds the
+/// diagram JSON directly in the `pr_diagram` `action=upload` call instead of
+/// printing a delimited block.
+pub fn build_diagram_prompt_mcp(
+    scope: &str,
+    output_dir: &str,
+    diff_hash: &str,
+    kind: &str,
+    custom_prompt: Option<&str>,
+) -> String {
+    let safe_output_dir = sanitize_for_shell(output_dir);
+    let task = diagram_task_for_kind(kind);
+
+    let mut prompt = String::new();
+    prompt.push_str(
+        "You are preparing a **Mermaid diagram** of a code diff for a reviewer. A diff for scope `",
+    );
+    prompt.push_str(scope);
+    prompt.push_str("` is already captured at `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp`.\n\n## Steps\n1. The diff hash is `");
+    prompt.push_str(diff_hash);
+    prompt.push_str("` — SHA-256 of `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp`, computed by the harness. Record it as `diff_hash` in the output (do **not** run `sha256sum`).\n2. Read `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp` (the full diff) into context. You may read referenced source files under the repo to understand surrounding structure, but the diagram is about **the change**.\n3. ");
+    prompt.push_str(task);
+    prompt.push_str(
+        "\n4. Call `pr_diagram` with `action=\"upload\"`, the same `kind`, and `files` set to a single entry keyed by the output filename from `action=\"prepare\"` (`kit.output_file`), with this exact JSON shape as the value:\n\n",
+    );
+    prompt.push_str(
+        r#"```json
 {
   "version": 1,
   "diff_hash": "<sha256 from step 1>",
@@ -696,19 +775,18 @@ pub fn build_diagram_prompt_prepared_diff(
   "prompt": "<the custom instructions, or empty string for presets>",
   "mermaid": "<bare mermaid source — no ``` fences>"
 }
-```
+```"#,
+    );
+    prompt.push_str(
+        r#"
 
 ## Mermaid rules (the renderer rejects invalid source)
 - First line must be the diagram type (`flowchart TD`, `sequenceDiagram`, …). No title/frontmatter comment before it.
 - Quote any node label containing special characters: `A["calls foo()"]`, not `A[calls foo()]`.
 - Keep ids alphanumeric (`parser`, `store2`) — put display text in the quoted label.
 - No `click` handlers, links, or raw HTML in labels.
-- Aim for readability in a ~350px-wide panel: ≤ 15 nodes for flowcharts, ≤ 8 participants for sequence diagrams. Omit detail rather than shrink it.
-
-Do NOT modify `review.json`, `tour.json`, or any other file. Write only `diagrams/"#,
+- Aim for readability in a ~350px-wide panel: ≤ 15 nodes for flowcharts, ≤ 8 participants for sequence diagrams. Omit detail rather than shrink it."#,
     );
-    prompt.push_str(output_file);
-    prompt.push_str("`.");
 
     if let Some(p) = custom_prompt.map(str::trim).filter(|s| !s.is_empty()) {
         prompt.push_str("\n\n## Custom instructions (user-provided)\n");

--- a/crates/er-engine/src/ai/prompts.rs
+++ b/crates/er-engine/src/ai/prompts.rs
@@ -614,6 +614,110 @@ Do NOT modify `review.json`, `order.json`, or any other file. Write only `{safe_
     )
 }
 
+/// Diagram generation when `{output_dir}/diff-tmp` is already prepared
+/// (desktop "Generate diagram"). Writes only `{output_dir}/diagrams/{output_file}`.
+/// Built with `push_str` instead of one `format!` so the mermaid examples and
+/// the user's custom prompt never collide with `format!` brace parsing.
+///
+/// `kind` is one of `mental-model` | `subsystems` | `flows` | `custom`; `custom_prompt`
+/// carries the user's free-form instructions for `custom`. One diagram per file, so
+/// re-running a preset replaces only that preset's diagram.
+pub fn build_diagram_prompt_prepared_diff(
+    scope: &str,
+    output_dir: &str,
+    output_file: &str,
+    diff_hash: &str,
+    kind: &str,
+    custom_prompt: Option<&str>,
+) -> String {
+    let safe_output_dir = sanitize_for_shell(output_dir);
+
+    let task = match kind {
+        super::diagrams::DIAGRAM_KIND_MENTAL_MODEL => {
+            r#"Build a **mental model overview** of this diff: the 5–15 most important components, modules, or concepts the change touches, and how they relate. This is the map a reviewer holds in their head before reading code.
+
+- Use `flowchart TD` (top-down).
+- Nodes are areas/components (not individual functions); use short labels.
+- Edges show relationships introduced or changed by the diff (e.g. "calls", "extends", "persists to") — label the important ones.
+- Group with `subgraph` only when it clearly helps."#
+        }
+        super::diagrams::DIAGRAM_KIND_SUBSYSTEMS => {
+            r#"Build a **subsystem breakdown** of this diff: group the changed files by the subsystem/area they belong to, and show how the subsystems interact.
+
+- Use `flowchart LR` with one `subgraph` per subsystem (2–6 subgraphs).
+- Inside each subgraph, nodes are the key changed files/modules of that subsystem (not every file — the 3–6 most important per subsystem).
+- Edges between subgraphs/nodes show the interactions this diff introduces or changes."#
+        }
+        super::diagrams::DIAGRAM_KIND_FLOWS => {
+            r#"Build a **flow diagram** of this diff: the runtime flow(s) through the changed code for the main scenario the diff implements (e.g. a request path, a user action, a data pipeline).
+
+- Prefer `sequenceDiagram` when the flow crosses component boundaries (actors = modules/functions); use `flowchart TD` for branching logic.
+- Show the flow *after* the change; only include pre-change steps when they are essential context.
+- One diagram for the primary scenario; mention a fork/alt path inside the same diagram only if it is central."#
+        }
+        _ => {
+            r#"Build the diagram the user asked for in **Custom instructions** below. Pick the most fitting mermaid diagram type (`flowchart`, `sequenceDiagram`, `classDiagram`, `stateDiagram-v2`, `erDiagram`, …) for the request."#
+        }
+    };
+
+    let mut prompt = String::new();
+    prompt.push_str(
+        "You are preparing a **Mermaid diagram** of a code diff for a reviewer. A diff for scope `",
+    );
+    prompt.push_str(scope);
+    prompt.push_str("` is already captured at `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp`.\n\n## Steps\n1. The diff hash is `");
+    prompt.push_str(diff_hash);
+    prompt.push_str("` — SHA-256 of `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp`, computed by the harness. Save it as `diff_hash` in the output (do **not** run `sha256sum`).\n2. Read `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diff-tmp` (the full diff) into context. You may read referenced source files under the repo to understand surrounding structure, but the diagram is about **the change**.\n3. ");
+    prompt.push_str(task);
+    prompt.push_str("\n4. Write `");
+    prompt.push_str(&safe_output_dir);
+    prompt.push_str("/diagrams/");
+    prompt.push_str(output_file);
+    prompt.push_str(
+        r#"` (and nothing else — create the `diagrams` directory if needed) with this exact shape:
+
+```json
+{
+  "version": 1,
+  "diff_hash": "<sha256 from step 1>",
+  "created_at": "<ISO 8601>",
+  "kind": ""#,
+    );
+    prompt.push_str(kind);
+    prompt.push_str(
+        r#"",
+  "title": "<short diagram title>",
+  "prompt": "<the custom instructions, or empty string for presets>",
+  "mermaid": "<bare mermaid source — no ``` fences>"
+}
+```
+
+## Mermaid rules (the renderer rejects invalid source)
+- First line must be the diagram type (`flowchart TD`, `sequenceDiagram`, …). No title/frontmatter comment before it.
+- Quote any node label containing special characters: `A["calls foo()"]`, not `A[calls foo()]`.
+- Keep ids alphanumeric (`parser`, `store2`) — put display text in the quoted label.
+- No `click` handlers, links, or raw HTML in labels.
+- Aim for readability in a ~350px-wide panel: ≤ 15 nodes for flowcharts, ≤ 8 participants for sequence diagrams. Omit detail rather than shrink it.
+
+Do NOT modify `review.json`, `tour.json`, or any other file. Write only `diagrams/"#,
+    );
+    prompt.push_str(output_file);
+    prompt.push_str("`.");
+
+    if let Some(p) = custom_prompt.map(str::trim).filter(|s| !s.is_empty()) {
+        prompt.push_str("\n\n## Custom instructions (user-provided)\n");
+        prompt.push_str(p);
+    }
+
+    prompt
+}
+
 /// When `review-files.txt` exists, agents must limit analysis to those paths.
 pub fn file_scope_appendix(output_dir: &str) -> String {
     let safe_output_dir = sanitize_for_shell(output_dir)

--- a/crates/er-engine/src/ai/review.rs
+++ b/crates/er-engine/src/ai/review.rs
@@ -487,6 +487,8 @@ pub struct AiState {
     pub github_comments: Option<ErGitHubComments>,
     /// Fast branch triage (`.er/triage.json`) — routing verdict, not merged into review.
     pub triage: Option<super::triage::TriageReview>,
+    /// Mermaid diagrams of the diff (`diagrams/*.json`), newest preset state only.
+    pub diagrams: Vec<super::diagrams::ErDiagram>,
     /// Legacy feedback (kept for migration, not used for new comments)
     pub feedback: Option<ErFeedback>,
     /// Whether the loaded data matches the current diff
@@ -516,6 +518,7 @@ impl Default for AiState {
             notes: None,
             github_comments: None,
             triage: None,
+            diagrams: Vec::new(),
             feedback: None,
             is_stale: false,
             tour_stale: false,

--- a/crates/er-engine/src/app/mod.rs
+++ b/crates/er-engine/src/app/mod.rs
@@ -9,6 +9,7 @@ pub use card_ai_spawn::{plan_card_ai_invocation, run_card_ai_subprocess, CardAiI
 pub use crate::git::Worktree;
 pub use state::background::{
     debug_bg_enabled, BackgroundTask, BackgroundTaskSnapshot, BackgroundTaskTarget,
+    HostWriteDiagram,
 };
 pub use state::chrono_now;
 pub use state::github_sync::{fetch_comment_sync_data, CommentSyncContext, CommentSyncResult};

--- a/crates/er-engine/src/app/state/background.rs
+++ b/crates/er-engine/src/app/state/background.rs
@@ -132,10 +132,22 @@ pub(crate) struct PendingBackgroundTask {
     pub command_name: String,
     pub prompt: String,
     pub prepared_diff: bool,
+    /// When set, the agent runs read-only and this sidecar is written by the
+    /// host from stdout (diagram confinement against prompt injection).
+    pub host_write_diagram: Option<HostWriteDiagram>,
     /// Optional action-bound provider/model/effort selection. This is captured
     /// when a TUI action is queued so it cannot leak into later actions or be
     /// replaced by a changed global default before launch.
     pub ai_selection: Option<crate::config::AiSelection>,
+}
+
+/// Host-owned diagram write target — agent emits JSON; Easy Review persists it.
+#[derive(Debug, Clone)]
+pub struct HostWriteDiagram {
+    pub output_path: std::path::PathBuf,
+    pub kind: String,
+    pub diff_hash: String,
+    pub custom_prompt: Option<String>,
 }
 
 /// In-flight + recently finished background task channels. The `App` owns

--- a/crates/er-engine/src/app/state/background.rs
+++ b/crates/er-engine/src/app/state/background.rs
@@ -64,11 +64,15 @@ impl BackgroundTaskTarget {
 /// identical (e.g. a security pass and a professor pass running side by side).
 ///
 /// Accepts the raw `BackgroundTask::kind` string: `"review"`/`"general"`,
-/// `"expert:<id>"`, `"professor"`, `"triage"`, or `"tour"`.
+/// `"expert:<id>"`, `"professor"`, `"triage"`, `"tour"`, or `"diagram:<kind>"`.
 pub fn kind_label(kind: &str) -> String {
     match kind {
         "" | "review" | "general" => "Review".to_string(),
         "tour" => "Guide".to_string(),
+        other if other.starts_with("diagram:") => {
+            let sub = other.trim_start_matches("diagram:");
+            format!("Diagram ({})", crate::ai::diagram_kind_label(sub))
+        }
         other => {
             // expert:<id>, professor, and triage all resolve through the
             // shared finding-agent label map.
@@ -278,6 +282,8 @@ mod tests {
         assert_eq!(kind_label("triage"), "Triage");
         assert_eq!(kind_label("expert:security"), "Security");
         assert_eq!(kind_label("expert:performance"), "Performance");
+        assert_eq!(kind_label("diagram:mental-model"), "Diagram (Mental model)");
+        assert_eq!(kind_label("diagram:custom"), "Diagram (Custom)");
     }
 
     #[test]

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2550,6 +2550,7 @@ impl App {
             target,
             prompt,
             prepared_diff,
+            None,
         )
     }
 
@@ -2570,6 +2571,7 @@ impl App {
             target,
             prompt,
             prepared_diff,
+            None,
         )
     }
 
@@ -2580,18 +2582,26 @@ impl App {
         prompt: String,
         prepared_diff: bool,
     ) -> Result<()> {
-        self.spawn_background_agent_task("tour".to_string(), "tour", target, prompt, prepared_diff)
+        self.spawn_background_agent_task(
+            "tour".to_string(),
+            "tour",
+            target,
+            prompt,
+            prepared_diff,
+            None,
+        )
     }
 
-    /// Spawn diagram generation (`kind` = `diagram:<diagram-kind>`). Writes
-    /// `diagrams/<file>.json` only; per-preset kinds keep concurrent preset
-    /// runs from deduping against each other.
+    /// Spawn diagram generation (`kind` = `diagram:<diagram-kind>`). The agent
+    /// runs read-only and emits JSON; the harness atomically writes
+    /// `diagrams/<file>.json` only (prompt-injection write confinement).
     pub fn spawn_background_diagram(
         &mut self,
         diagram_kind: &str,
         target: super::background::BackgroundTaskTarget,
         prompt: String,
         prepared_diff: bool,
+        host_write: super::background::HostWriteDiagram,
     ) -> Result<()> {
         self.spawn_background_agent_task(
             crate::ai::diagram_task_kind(diagram_kind),
@@ -2599,6 +2609,7 @@ impl App {
             target,
             prompt,
             prepared_diff,
+            Some(host_write),
         )
     }
 
@@ -2615,6 +2626,7 @@ impl App {
             target,
             prompt,
             prepared_diff,
+            None,
         )
     }
 
@@ -2631,6 +2643,7 @@ impl App {
             target,
             prompt,
             prepared_diff,
+            None,
         )
     }
 
@@ -2652,6 +2665,7 @@ impl App {
         target: super::background::BackgroundTaskTarget,
         prompt: String,
         prepared_diff: bool,
+        host_write_diagram: Option<super::background::HostWriteDiagram>,
     ) -> Result<()> {
         use super::background::{BackgroundTask, PendingBackgroundTask};
 
@@ -2680,6 +2694,7 @@ impl App {
                 command_name: command_name.to_string(),
                 prompt,
                 prepared_diff,
+                host_write_diagram,
                 // Snapshot at enqueue so a mid-queue palette change cannot retarget
                 // an already-queued job.
                 ai_selection: Some(self.pending_ai_selection_override.clone().unwrap_or_else(
@@ -2720,6 +2735,7 @@ impl App {
             command_name,
             prompt,
             prepared_diff,
+            host_write_diagram,
             ai_selection,
         } = pending;
         let command_name = command_name.as_str();
@@ -2824,11 +2840,21 @@ impl App {
             &mut config_args,
             Some(target.er_dir.as_str()),
         );
-        let opencode_env = crate::config::apply_opencode_spawn(
-            family,
-            &mut config_args,
-            Some(target.er_dir.as_str()),
-        );
+        // Diagrams: host writes the sidecar — deny agent edit tools. Still allow
+        // reading the managed bucket (diff-tmp) via external_directory allow.
+        let opencode_env = if host_write_diagram.is_some() {
+            crate::config::apply_opencode_readonly_storage_spawn(
+                family,
+                &mut config_args,
+                Some(target.er_dir.as_str()),
+            )
+        } else {
+            crate::config::apply_opencode_spawn(
+                family,
+                &mut config_args,
+                Some(target.er_dir.as_str()),
+            )
+        };
 
         std::fs::create_dir_all(&target.er_dir)?;
 
@@ -2884,7 +2910,17 @@ impl App {
                 }
 
                 if is_claude_compatible {
-                    let allowed: &[&str] = if prepared_diff {
+                    let allowed: &[&str] = if host_write_diagram.is_some() {
+                        // Read-only: harness persists the diagram JSON from stdout.
+                        &[
+                            "Read",
+                            "Bash(grep *)",
+                            "Bash(rg *)",
+                            "Bash(git grep*)",
+                            "Bash(git show*)",
+                            "Bash(git log*)",
+                        ]
+                    } else if prepared_diff {
                         &[
                             "Read",
                             "Write",
@@ -3057,6 +3093,21 @@ impl App {
                         );
                     }
                     anyhow::bail!("{command_name_fail} failed: {stderr_snip}");
+                }
+                // Host-owned diagram write: agent had no Write/Edit; persist
+                // only the validated diagrams/<id>.json from stdout.
+                if let Some(hw) = &host_write_diagram {
+                    crate::ai::persist_diagram_from_agent_stdout(
+                        &stdout_lines.join("\n"),
+                        is_stream_json,
+                        &hw.kind,
+                        &hw.diff_hash,
+                        hw.custom_prompt.as_deref(),
+                        &hw.output_path,
+                    )
+                    .with_context(|| {
+                        format!("{command_name_fail}: failed to persist diagram sidecar")
+                    })?;
                 }
                 // Selected-file reviews overwrite sidecars with a subset —
                 // merge back into the pre-scoped snapshot when present.

--- a/crates/er-engine/src/app/state/comments.rs
+++ b/crates/er-engine/src/app/state/comments.rs
@@ -2583,6 +2583,25 @@ impl App {
         self.spawn_background_agent_task("tour".to_string(), "tour", target, prompt, prepared_diff)
     }
 
+    /// Spawn diagram generation (`kind` = `diagram:<diagram-kind>`). Writes
+    /// `diagrams/<file>.json` only; per-preset kinds keep concurrent preset
+    /// runs from deduping against each other.
+    pub fn spawn_background_diagram(
+        &mut self,
+        diagram_kind: &str,
+        target: super::background::BackgroundTaskTarget,
+        prompt: String,
+        prepared_diff: bool,
+    ) -> Result<()> {
+        self.spawn_background_agent_task(
+            crate::ai::diagram_task_kind(diagram_kind),
+            "diagram",
+            target,
+            prompt,
+            prepared_diff,
+        )
+    }
+
     /// Spawn the Professor learning agent (`kind` = `professor`).
     pub fn spawn_background_professor_review(
         &mut self,

--- a/crates/er-engine/src/config.rs
+++ b/crates/er-engine/src/config.rs
@@ -933,6 +933,51 @@ pub fn opencode_readonly_permission_env() -> (String, String) {
     ("OPENCODE_PERMISSION".to_string(), value)
 }
 
+/// Ensure `--auto` and return a read-only `OPENCODE_PERMISSION` that can still
+/// *read* a managed review bucket (for `diff-tmp`) but cannot edit anything.
+///
+/// Used by diagram generation: the host writes the sidecar from agent stdout.
+pub fn apply_opencode_readonly_storage_spawn(
+    family: CliFamily,
+    args: &mut Vec<String>,
+    storage_dir: Option<&str>,
+) -> Option<(String, String)> {
+    if family != CliFamily::OpenCode {
+        return None;
+    }
+    ensure_opencode_auto(args);
+    opencode_readonly_storage_permission_env(storage_dir)
+}
+
+/// OpenCode permission: deny all edits; allow reading only `storage_dir`.
+pub fn opencode_readonly_storage_permission_env(
+    storage_dir: Option<&str>,
+) -> Option<(String, String)> {
+    let directory = storage_dir.map(str::trim).filter(|dir| !dir.is_empty())?;
+    let normalized = directory
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    let pattern = format!("{normalized}/**");
+    let mut external = serde_json::Map::new();
+    external.insert("*".into(), serde_json::json!("deny"));
+    external.insert(pattern, serde_json::json!("allow"));
+    let value = serde_json::json!({
+        "edit": "deny",
+        "bash": {
+            "*": "deny",
+            "grep *": "allow",
+            "rg *": "allow",
+            "git grep*": "allow",
+            "git show*": "allow",
+            "git log*": "allow",
+        },
+        "external_directory": serde_json::Value::Object(external),
+    })
+    .to_string();
+    Some(("OPENCODE_PERMISSION".to_string(), value))
+}
+
 /// Ensure `--auto` and return storage permission env for OpenCode artifact spawns.
 ///
 /// Non-OpenCode commands are left unchanged and return `None`. When OpenCode is
@@ -2802,6 +2847,28 @@ mod tests {
         assert_eq!(parsed["edit"], "deny");
         assert_eq!(parsed["external_directory"]["*"], "deny");
         assert!(apply_opencode_readonly_spawn(CliFamily::Claude, &mut args).is_none());
+    }
+
+    #[test]
+    fn apply_opencode_readonly_storage_spawn_allows_bucket_read_denies_edit() {
+        let mut args = vec!["run".to_string(), "{prompt}".to_string()];
+        let env = apply_opencode_readonly_storage_spawn(
+            CliFamily::OpenCode,
+            &mut args,
+            Some("/managed/review"),
+        )
+        .expect("env");
+        assert!(args.iter().any(|a| a == "--auto"));
+        let parsed: serde_json::Value = serde_json::from_str(&env.1).unwrap();
+        assert_eq!(parsed["edit"], "deny");
+        assert_eq!(parsed["external_directory"]["*"], "deny");
+        assert_eq!(parsed["external_directory"]["/managed/review/**"], "allow");
+        assert!(apply_opencode_readonly_storage_spawn(
+            CliFamily::Claude,
+            &mut args,
+            Some("/managed/review")
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/er-engine/src/diagram_upload.rs
+++ b/crates/er-engine/src/diagram_upload.rs
@@ -1,0 +1,316 @@
+//! Prepare/list/upload PR Mermaid diagrams for MCP clients.
+//!
+//! Parallel to [`crate::sidecar_upload`] (triage/review/tour), but diagrams
+//! don't fit [`crate::sidecar_upload::SidecarKind`]'s fixed-filename-per-kind
+//! model: presets overwrite in place (`<kind>.json`) while `custom` diagrams
+//! accumulate under timestamped ids, so a bucket can hold any number of
+//! `diagrams/*.json` files. This module owns that variable-id upload path;
+//! [`crate::ai::diagrams`] owns the sidecar shape and validation itself.
+//!
+//! Flow: [`prepare_diagram_kit`] writes shared `diff-tmp` + a prompt for one
+//! kind; the MCP client (the reviewing agent itself — no subprocess spawn)
+//! authors the diagram JSON; [`upload_diagram`] validates and stores it.
+
+use crate::ai::diagrams::{
+    diagram_output_file, diagram_sidecar_path, is_safe_diagram_id, is_valid_diagram_kind,
+    persist_diagram_json, DIAGRAM_KIND_CUSTOM,
+};
+use crate::ai::prompts::build_diagram_prompt_mcp;
+use crate::ai::{compute_diff_hash, load_diagrams, prepared_diff::diff_tmp_hash, ErDiagram};
+use crate::github::owner_repo_storage_slug;
+use crate::sidecar_upload::prepare_pr_diff_tmp;
+use crate::storage::resolve_managed_root_for_pr_bucket;
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Bucket + diff + prompt for one diagram kind (no agent spawn).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreparedDiagramKit {
+    pub owner: String,
+    pub repo: String,
+    pub pr: u64,
+    pub er_dir: String,
+    pub diff_tmp_path: String,
+    /// SHA-256 hex of `diff-tmp` — embed this as `diff_hash` in the diagram JSON.
+    pub diff_hash: String,
+    pub kind: String,
+    /// Filename to upload as (`diagrams/<output_file>`). Presets are stable
+    /// (`<kind>.json`); `custom` is a fresh timestamped id each prepare call.
+    pub output_file: String,
+    pub prompt: String,
+    pub instructions: String,
+}
+
+/// Fetch the PR diff into managed storage and return a prompt for one diagram kind.
+pub fn prepare_diagram_kit(
+    owner: &str,
+    repo: &str,
+    pr: u64,
+    kind: &str,
+    custom_prompt: Option<&str>,
+    ignore_globs: &[String],
+) -> Result<PreparedDiagramKit> {
+    if !is_valid_diagram_kind(kind) {
+        bail!("unknown diagram kind '{kind}'; expected mental-model|subsystems|flows|custom");
+    }
+    let custom_prompt = custom_prompt.map(str::trim).filter(|s| !s.is_empty());
+    if kind == DIAGRAM_KIND_CUSTOM && custom_prompt.is_none() {
+        bail!("kind=custom requires a non-empty prompt");
+    }
+
+    let (er_dir, diff_tmp_path) = prepare_pr_diff_tmp(owner, repo, pr, ignore_globs)?;
+    let diff = std::fs::read_to_string(&diff_tmp_path)
+        .with_context(|| format!("read prepared diff {diff_tmp_path}"))?;
+    let diff_hash = compute_diff_hash(&diff);
+    let output_file = diagram_output_file(kind);
+
+    let prompt = build_diagram_prompt_mcp("PR diff", &er_dir, &diff_hash, kind, custom_prompt);
+
+    Ok(PreparedDiagramKit {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        pr,
+        er_dir,
+        diff_tmp_path,
+        diff_hash: diff_hash.clone(),
+        kind: kind.to_string(),
+        output_file: output_file.clone(),
+        prompt,
+        instructions: format!(
+            "Read the prepared diff at diff_tmp_path (do not re-fetch). Embed diff_hash={diff_hash} \
+             in the diagram JSON, then call pr_diagram with action=upload, the same kind, and \
+             files={{\"{output_file}\": \"<diagram JSON>\"}}."
+        ),
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadDiagramResult {
+    pub er_dir: String,
+    pub id: String,
+    pub kind: String,
+    pub diff_hash: String,
+}
+
+/// Filename (minus `.json`) must match the kind's naming convention: presets
+/// upload as exactly `<kind>.json`; `custom` uploads accumulate under
+/// `custom-*` ids so they never clobber a preset or each other.
+fn validate_output_id(kind: &str, id: &str) -> Result<()> {
+    if !is_safe_diagram_id(id) {
+        bail!("invalid diagram id '{id}'");
+    }
+    if kind == DIAGRAM_KIND_CUSTOM {
+        if !id.starts_with("custom-") {
+            bail!("custom diagrams must upload as 'custom-<id>.json' (got '{id}.json')");
+        }
+    } else if id != kind {
+        bail!("{kind} diagram must upload as '{kind}.json' (got '{id}.json')");
+    }
+    Ok(())
+}
+
+fn resolve_er_dir(owner: &str, repo: &str, pr: u64) -> String {
+    let slug = owner_repo_storage_slug(owner, repo);
+    resolve_managed_root_for_pr_bucket(&slug, pr).er_dir()
+}
+
+/// Resolve the PR bucket (optionally refresh `diff-tmp`), validate the
+/// diagram JSON against the current diff hash, and atomically write it.
+#[allow(clippy::too_many_arguments)]
+pub fn upload_diagram(
+    owner: &str,
+    repo: &str,
+    pr: u64,
+    kind: &str,
+    file_name: &str,
+    content: &str,
+    custom_prompt: Option<&str>,
+    refresh_diff: bool,
+) -> Result<UploadDiagramResult> {
+    if !is_valid_diagram_kind(kind) {
+        bail!("unknown diagram kind '{kind}'; expected mental-model|subsystems|flows|custom");
+    }
+    let id = file_name.trim().strip_suffix(".json").ok_or_else(|| {
+        anyhow::anyhow!("diagram file must be named '<id>.json' (got '{file_name}')")
+    })?;
+    validate_output_id(kind, id)?;
+
+    let er_dir = if refresh_diff {
+        prepare_pr_diff_tmp(owner, repo, pr, &[])?.0
+    } else {
+        let er_dir = resolve_er_dir(owner, repo, pr);
+        let diff_path = Path::new(&er_dir).join("diff-tmp");
+        if !diff_path.exists() {
+            prepare_pr_diff_tmp(owner, repo, pr, &[])?.0
+        } else {
+            er_dir
+        }
+    };
+    let diff_path = Path::new(&er_dir).join("diff-tmp");
+    let diff = std::fs::read_to_string(&diff_path)
+        .with_context(|| format!("read {}", diff_path.display()))?;
+    let expected_hash = compute_diff_hash(&diff);
+
+    let output_path = diagram_sidecar_path(&er_dir, file_name)
+        .ok_or_else(|| anyhow::anyhow!("invalid diagram output file: {file_name}"))?;
+
+    persist_diagram_json(content, kind, &expected_hash, custom_prompt, &output_path)
+        .with_context(|| format!("diagram upload rejected (expected diff_hash={expected_hash})"))?;
+
+    Ok(UploadDiagramResult {
+        er_dir,
+        id: id.to_string(),
+        kind: kind.to_string(),
+        diff_hash: expected_hash,
+    })
+}
+
+/// List existing `diagrams/*.json` for a PR bucket, marking staleness against
+/// the last prepared `diff-tmp` (or unconditionally stale if none exists yet).
+pub fn list_diagrams(owner: &str, repo: &str, pr: u64) -> (String, Vec<ErDiagram>) {
+    let er_dir = resolve_er_dir(owner, repo, pr);
+    let current_hash = diff_tmp_hash(&er_dir).unwrap_or_default();
+    let diagrams = load_diagrams(&er_dir, &current_hash);
+    (er_dir, diagrams)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::STORAGE_TEST_ENV_LOCK;
+
+    fn with_storage_root<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = STORAGE_TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let root = tempfile::tempdir().unwrap();
+        std::env::set_var("ER_STORAGE_ROOT", root.path());
+        let out = f();
+        std::env::remove_var("ER_STORAGE_ROOT");
+        out
+    }
+
+    fn write_diff_tmp(er_dir: &str, diff: &str) -> String {
+        std::fs::create_dir_all(er_dir).unwrap();
+        std::fs::write(format!("{er_dir}/diff-tmp"), diff).unwrap();
+        let hash = compute_diff_hash(diff);
+        std::fs::write(format!("{er_dir}/.diff-tmp.sha256"), &hash).unwrap();
+        hash
+    }
+
+    #[test]
+    fn validate_output_id_enforces_naming_convention() {
+        assert!(validate_output_id("flows", "flows").is_ok());
+        assert!(validate_output_id("flows", "mental-model").is_err());
+        assert!(validate_output_id("custom", "custom-1700000000000").is_ok());
+        assert!(validate_output_id("custom", "flows").is_err());
+        assert!(validate_output_id("flows", "../escape").is_err());
+    }
+
+    #[test]
+    fn prepare_rejects_custom_without_prompt() {
+        with_storage_root(|| {
+            let err = prepare_diagram_kit("acme", "widgets", 1, "custom", None, &[]).unwrap_err();
+            assert!(err.to_string().contains("requires a non-empty prompt"));
+        });
+    }
+
+    #[test]
+    fn upload_writes_preset_diagram_and_pins_hash() {
+        with_storage_root(|| {
+            let er_dir = resolve_er_dir("acme", "widgets", 5);
+            let diff = "diff --git a/x b/x\n+hello\n";
+            let hash = write_diff_tmp(&er_dir, diff);
+
+            let body = r#"{"version":1,"diff_hash":"stale","kind":"subsystems","title":"T","prompt":"","mermaid":"flowchart TD\n  A-->B"}"#;
+            let result = upload_diagram(
+                "acme",
+                "widgets",
+                5,
+                "flows",
+                "flows.json",
+                body,
+                None,
+                false,
+            )
+            .unwrap();
+            assert_eq!(result.id, "flows");
+            assert_eq!(result.kind, "flows");
+            assert_eq!(result.diff_hash, hash);
+
+            let (_, diagrams) = list_diagrams("acme", "widgets", 5);
+            assert_eq!(diagrams.len(), 1);
+            assert_eq!(diagrams[0].kind, "flows");
+            assert!(!diagrams[0].stale);
+        });
+    }
+
+    #[test]
+    fn upload_rejects_wrong_filename_for_kind() {
+        with_storage_root(|| {
+            let er_dir = resolve_er_dir("acme", "widgets", 6);
+            write_diff_tmp(&er_dir, "diff --git a/x b/x\n+hi\n");
+            let err = upload_diagram(
+                "acme",
+                "widgets",
+                6,
+                "flows",
+                "mental-model.json",
+                "{}",
+                None,
+                false,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("must upload as 'flows.json'"));
+        });
+    }
+
+    #[test]
+    fn upload_custom_pins_prompt_and_accumulates() {
+        with_storage_root(|| {
+            let er_dir = resolve_er_dir("acme", "widgets", 7);
+            let hash = write_diff_tmp(&er_dir, "diff --git a/x b/x\n+hi\n");
+            let body = format!(
+                r#"{{"version":1,"diff_hash":"{hash}","kind":"custom","title":"T","prompt":"ignored","mermaid":"flowchart TD\n  A-->B"}}"#
+            );
+            upload_diagram(
+                "acme",
+                "widgets",
+                7,
+                "custom",
+                "custom-1.json",
+                &body,
+                Some("what the user asked"),
+                false,
+            )
+            .unwrap();
+            upload_diagram(
+                "acme",
+                "widgets",
+                7,
+                "custom",
+                "custom-2.json",
+                &body,
+                Some("a different ask"),
+                false,
+            )
+            .unwrap();
+
+            let (_, diagrams) = list_diagrams("acme", "widgets", 7);
+            assert_eq!(diagrams.len(), 2);
+            assert!(diagrams.iter().all(|d| d.kind == "custom"));
+            let prompts: Vec<&str> = diagrams.iter().map(|d| d.prompt.as_str()).collect();
+            assert!(prompts.contains(&"what the user asked"));
+            assert!(prompts.contains(&"a different ask"));
+        });
+    }
+
+    #[test]
+    fn list_diagrams_on_empty_bucket_is_empty() {
+        with_storage_root(|| {
+            let (_, diagrams) = list_diagrams("acme", "widgets", 99);
+            assert!(diagrams.is_empty());
+        });
+    }
+}

--- a/crates/er-engine/src/lib.rs
+++ b/crates/er-engine/src/lib.rs
@@ -12,6 +12,7 @@ pub use config::{
 };
 pub mod agent_runtime;
 pub mod dev_log;
+pub mod diagram_upload;
 pub mod env_path;
 #[cfg(feature = "ui")]
 pub mod export;

--- a/crates/er-mcp/README.md
+++ b/crates/er-mcp/README.md
@@ -3,7 +3,7 @@
 Stdio [Model Context Protocol](https://modelcontextprotocol.io) server (MCP **2026-07-28**).
 Thin REST API over `er-engine` — use **skills** for workflows.
 
-## MCP tools (11)
+## MCP tools (12)
 
 | Tool | Purpose |
 |------|---------|
@@ -14,6 +14,7 @@ Thin REST API over `er-engine` — use **skills** for workflows.
 | `pr_guide` | Prepare + upload guided tour (`tour.json`) |
 | `pr_prepare` | Fetch diff, write `diff-tmp`, return `diff_hash` + specs |
 | `pr_upload` | Validate + write triage/review/tour sidecars |
+| `pr_diagram` | List / prepare / upload Mermaid diagrams (`diagrams/<id>.json`) |
 | `pr_summarize` | Read triage/review/tour summary from managed storage |
 | `pr_feedback_get` | Questions, notes, AI findings |
 | `pr_feedback_reply` | Reply (`type`: question \| note \| finding) |
@@ -69,6 +70,19 @@ pr_summarize → { "ref": "…" }
 Guided tours use **`pr_guide`** (not `pr_prepare` / `pr_upload`). See `er-guide` skill.
 
 Review uploads need all four: `review.json`, `order.json`, `checklist.json`, `summary.md`.
+
+Diagrams (`kind`: `mental-model` | `subsystems` | `flows` | `custom`):
+
+```text
+pr_diagram   → { "ref": "…", "action": "list" }
+pr_diagram   → { "ref": "…", "action": "prepare", "kind": "flows" }
+# …author the diagram JSON at kit.output_file…
+pr_diagram   → { "ref": "…", "action": "upload", "kind": "flows", "files": { "flows.json": "..." } }
+```
+
+`custom` diagrams need `prompt` on both `prepare` and `upload`, and accumulate under
+timestamped ids (`custom-<ms>.json`) instead of overwriting each other. Presets
+(`mental-model` / `subsystems` / `flows`) always upload as `<kind>.json`.
 
 ## `prs_query` reference
 

--- a/crates/er-mcp/src/server.rs
+++ b/crates/er-mcp/src/server.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use er_engine::diagram_upload::{list_diagrams, prepare_diagram_kit, upload_diagram};
 use er_engine::git::ProdDiffStats;
 use er_engine::github::{
     gh_pr_checks_state_remote, gh_pr_list_queue, gh_pr_prod_diff_stats,
@@ -136,6 +137,29 @@ pub struct PrGuideArgs {
 pub struct PrSummarizeArgs {
     #[serde(flatten)]
     pub target: PrRefFields,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PrDiagramArgs {
+    #[serde(flatten)]
+    pub target: PrRefFields,
+    /// `list` (default) fetches existing diagrams; `prepare` fetches diff + prompt for
+    /// one kind; `upload` writes the diagram JSON.
+    #[serde(default)]
+    pub action: Option<String>,
+    /// Required for `prepare`/`upload`: `mental-model` | `subsystems` | `flows` | `custom`.
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// For `kind=custom`: the diagram instructions (required on `prepare`; pinned onto
+    /// the sidecar on `upload`, overriding whatever `prompt` the uploaded JSON carries).
+    #[serde(default)]
+    pub prompt: Option<String>,
+    /// Required for `upload`: exactly one entry, `{ "<output_file>": "<diagram JSON>" }`
+    /// using the filename from `action=prepare`'s `kit.output_file`.
+    #[serde(default)]
+    pub files: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub refresh_diff: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -855,6 +879,104 @@ impl ErMcp {
         }))
     }
 
+    #[tool(
+        description = "List, prepare, or upload Mermaid diagrams for a PR (kind: mental-model|subsystems|flows|custom). action=list (default) reads diagrams/*.json; action=prepare fetches diff + prompt for one kind; action=upload writes the diagram JSON."
+    )]
+    async fn pr_diagram(
+        &self,
+        Parameters(args): Parameters<PrDiagramArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let action = args
+            .action
+            .as_deref()
+            .unwrap_or("list")
+            .to_ascii_lowercase();
+        let pr = resolve_target(&args.target)?;
+        let owner = pr.owner.clone();
+        let name = pr.repo.clone();
+        let number = pr.number;
+
+        match action.as_str() {
+            "list" => {
+                let (er_dir, diagrams) =
+                    tokio::task::spawn_blocking(move || list_diagrams(&owner, &name, number))
+                        .await
+                        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                text_json(&json!({
+                    "project": pr.project_name,
+                    "repo": format!("{}/{}", pr.owner, pr.repo),
+                    "number": pr.number,
+                    "bucket_path": pr.bucket_path,
+                    "er_dir": er_dir,
+                    "diagrams": diagrams,
+                }))
+            }
+            "prepare" => {
+                let kind = args
+                    .kind
+                    .filter(|k| !k.trim().is_empty())
+                    .ok_or_else(|| tool_err("prepare requires kind"))?;
+                let prompt = args.prompt.clone();
+                let kit = tokio::task::spawn_blocking(move || {
+                    prepare_diagram_kit(&owner, &name, number, &kind, prompt.as_deref(), &[])
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?;
+
+                text_json(&json!({
+                    "project": pr.project_name,
+                    "repo": format!("{}/{}", pr.owner, pr.repo),
+                    "number": pr.number,
+                    "bucket_path": pr.bucket_path,
+                    "kit": kit,
+                }))
+            }
+            "upload" => {
+                let kind = args
+                    .kind
+                    .filter(|k| !k.trim().is_empty())
+                    .ok_or_else(|| tool_err("upload requires kind"))?;
+                let files = args.files.filter(|f| !f.is_empty()).ok_or_else(|| {
+                    tool_err("upload requires files: { \"<output_file>\": \"...\" }")
+                })?;
+                if files.len() != 1 {
+                    return Err(tool_err(
+                        "upload accepts exactly one file entry (the kit.output_file from prepare)",
+                    ));
+                }
+                let (file_name, content) = files.into_iter().next().expect("checked len == 1");
+                let custom_prompt = args.prompt.clone();
+                let refresh_diff = args.refresh_diff.unwrap_or(false);
+
+                let result = tokio::task::spawn_blocking(move || {
+                    upload_diagram(
+                        &owner,
+                        &name,
+                        number,
+                        &kind,
+                        &file_name,
+                        &content,
+                        custom_prompt.as_deref(),
+                        refresh_diff,
+                    )
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+                .map_err(|e| tool_err(e.to_string()))?;
+
+                text_json(&json!({
+                    "project": pr.project_name,
+                    "repo": format!("{}/{}", pr.owner, pr.repo),
+                    "number": pr.number,
+                    "bucket_path": pr.bucket_path,
+                    "uploaded": result,
+                }))
+            }
+            _ => Err(tool_err("action must be list, prepare, or upload")),
+        }
+    }
+
     #[tool(description = "Read review questions, notes, and AI findings for a PR.")]
     async fn pr_feedback_get(
         &self,
@@ -1129,6 +1251,7 @@ impl ServerHandler for ErMcp {
                 "Easy Review MCP — REST-style PR API. Resolve refs with pr_resolve. \
                  Query queues with prs_query. Review: pr_prepare → pr_upload. \
                  Guided tour: pr_guide (prepare → upload tour.json). \
+                 Diagrams: pr_diagram (list | prepare → upload diagram JSON). \
                  Feedback: pr_feedback_get / pr_feedback_reply. Saved: pr_saved. \
                  Skills: er-review, er-guide, er-queue, er-low-hanging-fruit, er-get-feedback, er-respond, er-saved.",
             )
@@ -1151,5 +1274,23 @@ mod tests {
             ProtocolVersion::V_2026_07_28
         );
         assert!(server.get_info().capabilities.tools.is_some());
+    }
+
+    #[test]
+    fn registers_pr_diagram_tool() {
+        let server = ErMcp::new();
+        let tools = server.tool_router.list_all();
+        let diagram_tool = tools
+            .iter()
+            .find(|t| t.name == "pr_diagram")
+            .expect("pr_diagram tool registered");
+        let schema = &diagram_tool.input_schema;
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("input schema has properties");
+        for field in ["action", "kind", "prompt", "files", "refresh_diff"] {
+            assert!(props.contains_key(field), "missing field: {field}");
+        }
     }
 }

--- a/desktop-ui/bun.lock
+++ b/desktop-ui/bun.lock
@@ -11,6 +11,7 @@
         "@tauri-apps/plugin-clipboard-manager": "^2",
         "@tauri-apps/plugin-log": "^2.8.0",
         "@xterm/xterm": "^5.5.0",
+        "mermaid": "^11.16.1",
         "shiki": "^3",
         "svelte": "^5",
       },
@@ -32,11 +33,17 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -88,6 +95,10 @@
 
     "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -97,6 +108,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
 
@@ -226,9 +239,73 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -241,6 +318,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -286,7 +365,85 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -302,6 +459,8 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -312,7 +471,11 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -328,13 +491,21 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -348,7 +519,13 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -376,13 +553,19 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -408,6 +591,10 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -417,6 +604,10 @@
     "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
     "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
@@ -442,11 +633,19 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -468,6 +667,8 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "svelte": ["svelte@5.55.5", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.4", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw=="],
 
     "svelte-check": ["svelte-check@4.4.8", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w=="],
@@ -479,6 +680,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
@@ -509,6 +712,8 @@
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -544,10 +749,24 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/desktop-ui/package.json
+++ b/desktop-ui/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/plugin-clipboard-manager": "^2",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@xterm/xterm": "^5.5.0",
+    "mermaid": "^11.16.1",
     "shiki": "^3",
     "svelte": "^5"
   },

--- a/desktop-ui/src/App.svelte
+++ b/desktop-ui/src/App.svelte
@@ -25,6 +25,7 @@
   import Terminal from "$lib/components/Terminal.svelte";
   import { terminal } from "$lib/stores/terminal.svelte";
   import { rightRail } from "$lib/stores/rightRail.svelte";
+  import { rightPanelTab, type RightPanelTab } from "$lib/stores/rightPanelTab.svelte";
   import BrowserView from "$lib/components/BrowserView.svelte";
   import AgentOutputView from "$lib/components/AgentOutputView.svelte";
   import ExportReviewView from "$lib/components/ExportReviewView.svelte";
@@ -73,11 +74,9 @@
   let rightPanelWidth = $state(RIGHT_PANEL_DEFAULT);
   let resizingRightPanel = $state(false);
 
-  function expandRightPanelToTab(tab: "branch" | "review" | "notes") {
+  function expandRightPanelToTab(tab: RightPanelTab) {
     rightRail.expand();
-    try {
-      localStorage.setItem("rightPanelActiveTab", tab);
-    } catch { /* ignore */ }
+    rightPanelTab.set(tab);
   }
 
   function clampRightPanelWidth(w: number): number {

--- a/desktop-ui/src/lib/components/CollapsedRightRail.svelte
+++ b/desktop-ui/src/lib/components/CollapsedRightRail.svelte
@@ -2,10 +2,11 @@
   import type { AiSnapshot } from "$lib/types";
   import { app } from "$lib/stores/app.svelte";
   import { totalReviewFindings, ALL_REVIEWERS } from "$lib/aiReviewAgents";
+  import type { RightPanelTab } from "$lib/stores/rightPanelTab.svelte";
 
   interface Props {
     ai: AiSnapshot | null;
-    onExpand: (tab: "branch" | "review" | "notes") => void;
+    onExpand: (tab: RightPanelTab) => void;
   }
 
   const { ai, onExpand }: Props = $props();
@@ -115,6 +116,22 @@
     </svg>
     {#if questionCount > 0}
       <span class="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 flex items-center justify-center text-[8px] font-bold rounded-full bg-question/20 text-question border-2 border-surface">{questionCount}</span>
+    {/if}
+  </button>
+
+  <!-- Context (diagrams) atom -->
+  <button
+    type="button"
+    title="Context — expand rail"
+    onclick={() => onExpand("context")}
+    class="relative w-8 h-8 rounded-lg flex items-center justify-center hover:bg-hover transition-colors"
+  >
+    <!-- flowchart -->
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-fg-3">
+      <rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/><path d="M10 6.5h5.5a2 2 0 0 1 2 2V14"/>
+    </svg>
+    {#if (ai?.diagrams?.length ?? 0) > 0}
+      <span class="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 px-0.5 flex items-center justify-center text-[8px] font-bold rounded-full bg-accent/20 text-accent border-2 border-surface">{ai?.diagrams?.length}</span>
     {/if}
   </button>
 

--- a/desktop-ui/src/lib/components/CommandPalette.svelte
+++ b/desktop-ui/src/lib/components/CommandPalette.svelte
@@ -4,6 +4,8 @@
   import { browser } from "$lib/stores/browser.svelte";
   import { terminal } from "$lib/stores/terminal.svelte";
   import { commandPalette } from "$lib/stores/commandPalette.svelte";
+  import { rightRail } from "$lib/stores/rightRail.svelte";
+  import { rightPanelTab } from "$lib/stores/rightPanelTab.svelte";
   import { openPrUrlModal } from "$lib/stores/prUrlModal.svelte";
   import { arena } from "$lib/stores/arena.svelte";
   import { diffNav } from "$lib/stores/diffNav.svelte";
@@ -169,6 +171,20 @@
         group: "AI" as const,
         kbd: "g",
         run: guard(() => { void dismissAndRun(() => app.cmd("generate_tour")); }),
+      },
+      {
+        id: "ai-diagrams",
+        label: "Diagrams",
+        description: reviewScope
+          ? "Generate mermaid diagrams of this diff (mental model, subsystems, flows)"
+          : "Not available in this view",
+        group: "AI" as const,
+        kbd: "d",
+        run: guard(() => {
+          closeKeepSubmenu();
+          rightRail.expand();
+          rightPanelTab.set("context");
+        }),
       },
       {
         id: "ai-validate",

--- a/desktop-ui/src/lib/components/DiagramsCard.svelte
+++ b/desktop-ui/src/lib/components/DiagramsCard.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+  import type { AiSnapshot, DiagramSnapshot } from "$lib/types";
+  import { app } from "$lib/stores/app.svelte";
+  import { copyToClipboard } from "$lib/clipboard";
+  import Card from "./ui/Card.svelte";
+  import ModalShell from "./ui/ModalShell.svelte";
+  import MermaidDiagram from "./MermaidDiagram.svelte";
+
+  interface Props {
+    ai: AiSnapshot;
+  }
+
+  const { ai }: Props = $props();
+
+  // ── Presets (mirror `diagram_presets()` in crates/er-engine/src/ai/diagrams.rs) ──
+  const PRESETS = [
+    {
+      kind: "mental-model",
+      label: "Mental model",
+      description: "High-level map of the areas this diff touches and how they relate",
+    },
+    {
+      kind: "subsystems",
+      label: "Subsystems",
+      description: "Changed files grouped by subsystem, with interactions",
+    },
+    {
+      kind: "flows",
+      label: "Flows",
+      description: "Runtime flow through the changed code for the main scenarios",
+    },
+  ] as const;
+
+  const diagrams = $derived(ai.diagrams ?? []);
+
+  // A diagram task's kind is `diagram:<kind>`; correlate running/queued tasks
+  // with the preset buttons so each shows its own spinner.
+  const diagramTasks = $derived(
+    (app.snapshot?.background_tasks ?? []).filter(
+      (t) => t.kind.startsWith("diagram:") && (t.status === "running" || t.status === "queued"),
+    ),
+  );
+
+  function taskFor(kind: string) {
+    return diagramTasks.find((t) => t.kind === `diagram:${kind}`);
+  }
+
+  let customPrompt = $state("");
+  let customOpen = $state(false);
+  let expandedId = $state<string | null>(null);
+  let confirmDeleteId = $state<string | null>(null);
+
+  const expandedDiagram = $derived(diagrams.find((d) => d.id === expandedId) ?? null);
+
+  function generate(kind: string, prompt?: string) {
+    void app.cmd("generate_diagram", { kind, custom_prompt: prompt ?? null });
+  }
+
+  function generateCustom() {
+    const p = customPrompt.trim();
+    if (!p) return;
+    generate("custom", p);
+    customPrompt = "";
+    customOpen = false;
+  }
+
+  function regenerate(d: DiagramSnapshot) {
+    generate(d.kind, d.kind === "custom" ? d.prompt : undefined);
+  }
+
+  async function copyMermaid(d: DiagramSnapshot) {
+    await copyToClipboard(d.mermaid);
+    app.showToast("success", `Copied mermaid source for "${d.title || d.kind}"`);
+  }
+
+  function removeDiagram(d: DiagramSnapshot) {
+    if (confirmDeleteId !== d.id) {
+      confirmDeleteId = d.id;
+      return;
+    }
+    confirmDeleteId = null;
+    void app.cmd("delete_diagram", { id: d.id });
+  }
+
+  function kindLabel(kind: string): string {
+    return PRESETS.find((p) => p.kind === kind)?.label ?? "Custom";
+  }
+
+  function formatCreated(iso: string): string {
+    if (!iso) return "";
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+</script>
+
+<!-- ── Generate ──────────────────────────────────────────────────────────── -->
+<Card>
+  <p class="text-[11px] font-semibold text-fg mb-1">Diagrams</p>
+  <p class="text-[10px] text-muted leading-relaxed mb-3">
+    AI-generated mermaid diagrams of the current diff. Saved per branch/PR in
+    your local review storage — never pushed.
+  </p>
+  <div class="space-y-1.5">
+    {#each PRESETS as preset (preset.kind)}
+      {@const task = taskFor(preset.kind)}
+      <button
+        type="button"
+        onclick={() => generate(preset.kind)}
+        disabled={!!task}
+        class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg border border-hairline text-left transition-colors hover:bg-hover hover:border-border disabled:opacity-60 disabled:cursor-default"
+      >
+        {#if task}
+          <svg class="animate-spin shrink-0 text-accent" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+          </svg>
+        {:else}
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-accent">
+            <rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/><path d="M10 6.5h5.5a2 2 0 0 1 2 2V14"/>
+          </svg>
+        {/if}
+        <span class="flex-1 min-w-0">
+          <span class="block text-[11px] font-medium text-fg">
+            {preset.label}
+            {#if task}
+              <span class="ml-1 text-[9px] font-normal text-fg-3">
+                {task.status === "queued" ? "queued" : "generating…"}
+              </span>
+            {/if}
+          </span>
+          <span class="block text-[10px] text-fg-3 leading-snug">{preset.description}</span>
+        </span>
+      </button>
+    {/each}
+
+    <!-- Custom prompt -->
+    {#if customOpen}
+      <div class="rounded-lg border border-border bg-surface p-2.5 space-y-2">
+        <textarea
+          bind:value={customPrompt}
+          rows="3"
+          placeholder="e.g. Sequence diagram of the auth token refresh path"
+          class="w-full bg-transparent text-[11px] text-fg placeholder:text-muted resize-y outline-none"
+          onkeydown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              generateCustom();
+            }
+          }}
+        ></textarea>
+        <div class="flex items-center justify-end gap-1.5">
+          <button
+            type="button"
+            onclick={() => { customOpen = false; }}
+            class="px-2 py-1 text-[10px] rounded border border-hairline text-fg-3 hover:text-fg-2 hover:bg-hover transition-colors"
+          >Cancel</button>
+          <button
+            type="button"
+            onclick={generateCustom}
+            disabled={!customPrompt.trim() || !!taskFor("custom")}
+            class="px-2 py-1 text-[10px] font-medium rounded bg-accent text-on-accent hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-default"
+          >Generate (⌘⏎)</button>
+        </div>
+      </div>
+    {:else}
+      <button
+        type="button"
+        onclick={() => { customOpen = true; }}
+        class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg border border-dashed border-hairline text-left transition-colors hover:bg-hover hover:border-border"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-fg-3">
+          <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+        </svg>
+        <span class="flex-1 min-w-0">
+          <span class="block text-[11px] font-medium text-fg-2">Custom diagram…</span>
+          <span class="block text-[10px] text-fg-3 leading-snug">Describe the diagram you want</span>
+        </span>
+      </button>
+    {/if}
+  </div>
+</Card>
+
+<!-- ── Generated diagrams ────────────────────────────────────────────────── -->
+{#if diagrams.length > 0}
+  <div class="space-y-3">
+    {#each diagrams as d (d.id)}
+      {@const task = taskFor(d.kind)}
+      <Card class="p-3">
+        <div class="flex items-start gap-2 mb-2">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/15 text-accent">
+                {kindLabel(d.kind)}
+              </span>
+              {#if !d.fresh}
+                <span
+                  class="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-risk-med/15 text-risk-med"
+                  title="Generated for an older diff — regenerate to refresh"
+                >stale</span>
+              {/if}
+            </div>
+            <p class="text-[11px] font-medium text-fg mt-1 leading-snug break-words">
+              {d.title || kindLabel(d.kind)}
+            </p>
+            {#if d.created_at}
+              <p class="text-[9px] text-muted mt-0.5">{formatCreated(d.created_at)}</p>
+            {/if}
+            {#if d.kind === "custom" && d.prompt}
+              <p class="text-[10px] text-fg-3 mt-1 italic leading-snug break-words">"{d.prompt}"</p>
+            {/if}
+          </div>
+          <!-- Row actions -->
+          <div class="flex items-center gap-0.5 shrink-0">
+            <button
+              type="button"
+              onclick={() => regenerate(d)}
+              disabled={!!task}
+              title="Regenerate this diagram"
+              class="p-1.5 rounded text-fg-3 hover:bg-hover hover:text-fg-2 transition-colors disabled:opacity-50"
+            >
+              {#if task}
+                <svg class="animate-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+                </svg>
+              {:else}
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+                </svg>
+              {/if}
+            </button>
+            <button
+              type="button"
+              onclick={() => void copyMermaid(d)}
+              title="Copy mermaid source"
+              class="p-1.5 rounded text-fg-3 hover:bg-hover hover:text-fg-2 transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+            </button>
+            <button
+              type="button"
+              onclick={() => removeDiagram(d)}
+              title={confirmDeleteId === d.id ? "Click again to confirm delete" : "Delete diagram"}
+              class="p-1.5 rounded transition-colors {confirmDeleteId === d.id ? 'text-del-fg bg-del-bg' : 'text-fg-3 hover:bg-hover hover:text-del-fg'}"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Click to expand -->
+        <button
+          type="button"
+          onclick={() => { expandedId = d.id; }}
+          title="Expand diagram"
+          class="block w-full rounded-lg border border-hairline bg-surface p-2 cursor-zoom-in hover:border-border transition-colors"
+        >
+          <MermaidDiagram source={d.mermaid} class="max-h-64 pointer-events-none" />
+        </button>
+      </Card>
+    {/each}
+  </div>
+{/if}
+
+<!-- ── Expanded diagram modal ────────────────────────────────────────────── -->
+<ModalShell
+  open={expandedDiagram !== null}
+  ariaLabel={expandedDiagram?.title ?? "Diagram"}
+  onClose={() => { expandedId = null; }}
+  backdropClass="fixed inset-0 z-50 bg-bg/60 p-6"
+  panelClass="fixed left-1/2 top-1/2 z-[51] w-[min(92vw,1100px)] max-h-[85vh] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-surface shadow-2xl outline-none flex flex-col"
+>
+  {#if expandedDiagram}
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-hairline shrink-0">
+      <span class="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/15 text-accent">
+        {kindLabel(expandedDiagram.kind)}
+      </span>
+      <p class="flex-1 min-w-0 text-[12px] font-medium text-fg truncate">
+        {expandedDiagram.title || kindLabel(expandedDiagram.kind)}
+      </p>
+      {#if !expandedDiagram.fresh}
+        <span class="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-risk-med/15 text-risk-med">stale</span>
+      {/if}
+      <button
+        type="button"
+        onclick={() => { if (expandedDiagram) void copyMermaid(expandedDiagram); }}
+        class="px-2 py-1 text-[10px] rounded border border-hairline text-fg-3 hover:text-fg-2 hover:bg-hover transition-colors"
+      >Copy source</button>
+      <button
+        type="button"
+        onclick={() => { expandedId = null; }}
+        aria-label="Close"
+        class="p-1 rounded text-fg-3 hover:text-fg hover:bg-hover transition-colors"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+      </button>
+    </div>
+    <div class="flex-1 overflow-auto p-6">
+      <MermaidDiagram source={expandedDiagram.mermaid} />
+    </div>
+  {/if}
+</ModalShell>

--- a/desktop-ui/src/lib/components/DiagramsCard.svelte
+++ b/desktop-ui/src/lib/components/DiagramsCard.svelte
@@ -12,26 +12,8 @@
 
   const { ai }: Props = $props();
 
-  // ── Presets (mirror `diagram_presets()` in crates/er-engine/src/ai/diagrams.rs) ──
-  const PRESETS = [
-    {
-      kind: "mental-model",
-      label: "Mental model",
-      description: "High-level map of the areas this diff touches and how they relate",
-    },
-    {
-      kind: "subsystems",
-      label: "Subsystems",
-      description: "Changed files grouped by subsystem, with interactions",
-    },
-    {
-      kind: "flows",
-      label: "Flows",
-      description: "Runtime flow through the changed code for the main scenarios",
-    },
-  ] as const;
-
-  const diagrams = $derived(ai.diagrams ?? []);
+  const presets = $derived(ai.diagram_presets);
+  const diagrams = $derived(ai.diagrams);
 
   // A diagram task's kind is `diagram:<kind>`; correlate running/queued tasks
   // with the preset buttons so each shows its own spinner.
@@ -83,7 +65,7 @@
   }
 
   function kindLabel(kind: string): string {
-    return PRESETS.find((p) => p.kind === kind)?.label ?? "Custom";
+    return presets.find((p) => p.kind === kind)?.label ?? "Custom";
   }
 
   function formatCreated(iso: string): string {
@@ -107,7 +89,7 @@
     your local review storage — never pushed.
   </p>
   <div class="space-y-1.5">
-    {#each PRESETS as preset (preset.kind)}
+    {#each presets as preset (preset.kind)}
       {@const task = taskFor(preset.kind)}
       <button
         type="button"

--- a/desktop-ui/src/lib/components/MermaidDiagram.svelte
+++ b/desktop-ui/src/lib/components/MermaidDiagram.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { app } from "$lib/stores/app.svelte";
+  import { themeByName } from "$lib/themes";
+  import { renderMermaid } from "$lib/mermaidClient";
+
+  interface Props {
+    /** Bare mermaid source. */
+    source: string;
+    /** Extra classes on the wrapper (e.g. max-height for inline previews). */
+    class?: string;
+  }
+
+  const { source, class: className = "" }: Props = $props();
+
+  let svg = $state<string | null>(null);
+  let error = $state<string | null>(null);
+
+  // Re-render when the source or the active theme changes. Rendering is async
+  // and cached by `theme::source` in the client, so remounts and theme
+  // switches back to a previously-seen combination are free.
+  $effect(() => {
+    const theme = themeByName(app.snapshot?.theme);
+    const src = source;
+    let cancelled = false;
+    svg = null;
+    error = null;
+    renderMermaid(src, theme)
+      .then((rendered) => {
+        if (!cancelled) svg = rendered;
+      })
+      .catch((e) => {
+        if (!cancelled) error = e instanceof Error ? e.message : String(e);
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+<div class="mermaid-diagram overflow-auto {className}">
+  {#if error}
+    <div class="p-3 rounded border border-del-fg/30 bg-del-bg">
+      <p class="text-[11px] font-medium text-del-fg">Diagram failed to render</p>
+      <p class="text-[10px] text-fg-3 mt-1 break-words">{error}</p>
+    </div>
+  {:else if svg}
+    <!-- SVG is produced by mermaid with securityLevel "strict" (no scripts/links). -->
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html svg}
+  {:else}
+    <div class="flex items-center justify-center py-8 text-fg-3">
+      <svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+      </svg>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .mermaid-diagram :global(svg) {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+  }
+</style>

--- a/desktop-ui/src/lib/components/RightPanel.svelte
+++ b/desktop-ui/src/lib/components/RightPanel.svelte
@@ -13,7 +13,9 @@
   import CommentsCard from "./CommentsCard.svelte";
   import UiAnnotationsCard from "./UiAnnotationsCard.svelte";
   import AgentOutputCard from "./AgentOutputCard.svelte";
+  import DiagramsCard from "./DiagramsCard.svelte";
   import InlineThread from "./InlineThread.svelte";
+  import { rightPanelTab, type RightPanelTab } from "$lib/stores/rightPanelTab.svelte";
 
   interface Props {
     ai: AiSnapshot | null;
@@ -33,26 +35,14 @@
     onCollapseToggle,
   }: Props = $props();
 
-  // ── Tab state (persisted to localStorage) ──────────────────────────────────
-  const TAB_STORAGE_KEY = "rightPanelActiveTab";
-
-  type Tab = "branch" | "review" | "notes";
-
-  function readStoredTab(): Tab {
-    try {
-      const raw = localStorage.getItem(TAB_STORAGE_KEY);
-      if (raw === "branch" || raw === "review" || raw === "notes") return raw;
-    } catch { /* ignore */ }
-    return "branch";
-  }
-
-  let activeTab = $state<Tab>(readStoredTab());
+  // ── Tab state (shared store, persisted to localStorage) ───────────────────
+  // The store lets the command palette and collapsed rail switch the tab even
+  // while the panel is already mounted.
+  type Tab = RightPanelTab;
+  const activeTab = $derived(rightPanelTab.active);
 
   function setTab(t: Tab) {
-    activeTab = t;
-    try {
-      localStorage.setItem(TAB_STORAGE_KEY, t);
-    } catch { /* ignore */ }
+    rightPanelTab.set(t);
   }
 
   // ── Derived counts for tab badges ──────────────────────────────────────────
@@ -127,10 +117,13 @@
     visibleCommentThreads(ai?.threads, app.commentVisibility).length
   );
 
+  const diagramCount = $derived(ai?.diagrams?.length ?? 0);
+
   const tabs: TabDef[] = $derived([
     { id: "branch", label: "Branch", badge: commentCount > 0 ? commentCount : null },
     { id: "review", label: "Review", badge: totalFindings > 0 ? totalFindings : null },
     { id: "notes",  label: "Notes",  badge: noteCount + questionCount > 0 ? noteCount + questionCount : null },
+    { id: "context", label: "Context", badge: diagramCount > 0 ? diagramCount : null },
   ]);
 
   // ── Per-tab export ───────────────────────────────────────────────────────────
@@ -169,6 +162,10 @@
         return { ...NO_SECTIONS, includeComments: true };
       case "review":
         return { ...NO_SECTIONS, includeFindings: true };
+      case "context":
+        // Handled client-side in copyTabToClipboard (mermaid fences, not the
+        // export_review sections).
+        return NO_SECTIONS;
       case "notes":
         switch (notesSubTab) {
           case "notes":
@@ -193,7 +190,13 @@
     copying = true;
     const label = exportLabel();
     try {
-      const body = await invoke<string>("export_review", { opts: exportOptsForTab(activeTab) });
+      // The Context tab has no `export_review` section — build its markdown
+      // (title + mermaid fence per diagram) client-side.
+      const body = activeTab === "context"
+        ? (ai?.diagrams ?? [])
+            .map((d) => `## ${d.title || d.kind}\n\n\`\`\`mermaid\n${d.mermaid}\n\`\`\``)
+            .join("\n\n")
+        : await invoke<string>("export_review", { opts: exportOptsForTab(activeTab) });
       if (!body.trim()) {
         app.showToast("info", `Nothing to export from the ${label} tab`);
         return;
@@ -246,6 +249,11 @@
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
             class={isActive ? "text-accent" : "text-fg-3"}>
             <path d="M12 2l2.4 7.2H22l-6.2 4.5 2.4 7.2L12 17l-6.2 3.9 2.4-7.2L2 9.2h7.6z"/>
+          </svg>
+        {:else if tab.id === "context"}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            class={isActive ? "text-accent" : "text-fg-3"}>
+            <rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/><path d="M10 6.5h5.5a2 2 0 0 1 2 2V14"/>
           </svg>
         {:else}
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -379,6 +387,14 @@
             <UiAnnotationsCard />
           {/if}
         </div>
+      </div>
+
+    <!-- Context tab (mermaid diagrams of the diff) -->
+    {:else if activeTab === "context"}
+      <div class="p-4 space-y-4 pb-8">
+        {#if ai}
+          <DiagramsCard {ai} />
+        {/if}
       </div>
     {/if}
   </div>

--- a/desktop-ui/src/lib/mermaidClient.ts
+++ b/desktop-ui/src/lib/mermaidClient.ts
@@ -1,0 +1,109 @@
+/**
+ * Lazy-loaded mermaid renderer with a small SVG cache.
+ *
+ * Mermaid is a heavy dependency (~2 MB), so it is loaded on first use via
+ * dynamic import and configured with `securityLevel: "strict"` (diagram source
+ * is AI-generated — no click handlers, links, or raw HTML). Renders are cached
+ * by `theme::source` so re-polls and modal open/close don't re-render.
+ */
+
+import type { MermaidConfig } from "mermaid";
+import type { AppTheme } from "./themes";
+
+type Mermaid = typeof import("mermaid").default;
+
+let mermaidPromise: Promise<Mermaid> | null = null;
+let initializedTheme: string | null = null;
+let renderSeq = 0;
+
+const CACHE_LIMIT = 40;
+const svgCache = new Map<string, string>();
+
+function cacheSet(key: string, svg: string) {
+  if (svgCache.has(key)) svgCache.delete(key);
+  svgCache.set(key, svg);
+  while (svgCache.size > CACHE_LIMIT) {
+    const oldest = svgCache.keys().next().value;
+    if (oldest === undefined) break;
+    svgCache.delete(oldest);
+  }
+}
+
+async function getMermaid(): Promise<Mermaid> {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((m) => m.default);
+  }
+  return mermaidPromise;
+}
+
+/** Mermaid `themeVariables` derived from an app theme (pure — exported for tests). */
+export function mermaidThemeVariables(t: AppTheme): MermaidConfig["themeVariables"] {
+  return {
+    background: t.surface,
+    primaryColor: t.panel,
+    primaryTextColor: t.textBright,
+    primaryBorderColor: t.border,
+    lineColor: t.textMuted,
+    secondaryColor: t.panel,
+    tertiaryColor: t.surface,
+    textColor: t.textBright,
+    mainBkg: t.panel,
+    nodeBorder: t.border,
+    clusterBkg: "transparent",
+    clusterBorder: t.border,
+    edgeLabelBackground: t.surface,
+    actorBkg: t.panel,
+    actorBorder: t.border,
+    actorTextColor: t.textBright,
+    actorLineColor: t.textMuted,
+    signalColor: t.textMuted,
+    signalTextColor: t.textBright,
+    labelBoxBkgColor: t.surface,
+    labelBoxBorderColor: t.border,
+    labelTextColor: t.textBright,
+    loopTextColor: t.textBright,
+    noteBkgColor: t.panel,
+    noteBorderColor: t.border,
+    noteTextColor: t.text,
+    activationBorderColor: t.accent,
+    sequenceNumberColor: t.onAccent,
+  };
+}
+
+/** (Re-)initialize mermaid for the given app theme. Idempotent per theme name. */
+async function ensureInitialized(theme: AppTheme): Promise<Mermaid> {
+  const mermaid = await getMermaid();
+  if (initializedTheme === theme.name) return mermaid;
+
+  const config: MermaidConfig = {
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "base",
+    // Mermaid injects an error graphic into the DOM on parse failure by
+    // default; the component renders its own error state instead.
+    suppressErrorRendering: true,
+    fontFamily: "inherit",
+    flowchart: { htmlLabels: false, curve: "basis" },
+    themeVariables: mermaidThemeVariables(theme),
+  };
+  mermaid.initialize(config);
+  initializedTheme = theme.name;
+  return mermaid;
+}
+
+/**
+ * Render mermaid source to an SVG string, themed to the given app theme.
+ * Throws on parse errors — callers show their own error state.
+ */
+export async function renderMermaid(source: string, theme: AppTheme): Promise<string> {
+  const cacheKey = `${theme.name}::${source}`;
+  const cached = svgCache.get(cacheKey);
+  if (cached) return cached;
+
+  const mermaid = await ensureInitialized(theme);
+  // mermaid.render needs a unique id per call; it appends temp nodes to the
+  // document and removes them itself.
+  const { svg } = await mermaid.render(`er-mmd-${renderSeq++}`, source);
+  cacheSet(cacheKey, svg);
+  return svg;
+}

--- a/desktop-ui/src/lib/stores/rightPanelTab.svelte.ts
+++ b/desktop-ui/src/lib/stores/rightPanelTab.svelte.ts
@@ -1,0 +1,46 @@
+// Single source of truth for the right panel's active tab. Lives in a store
+// (not component state) so the command palette and the collapsed rail can
+// switch tabs even while the panel is already expanded — a plain localStorage
+// write wouldn't reach a mounted RightPanel.
+
+const STORAGE_KEY = "rightPanelActiveTab";
+
+export type RightPanelTab = "branch" | "review" | "notes" | "context";
+
+const VALID: readonly string[] = ["branch", "review", "notes", "context"];
+
+function loadInitial(): RightPanelTab {
+  if (typeof localStorage === "undefined") return "branch";
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw && VALID.includes(raw)) return raw as RightPanelTab;
+  } catch {
+    /* ignore */
+  }
+  return "branch";
+}
+
+function persist(v: RightPanelTab) {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, v);
+  } catch {
+    /* ignore quota / privacy-mode errors */
+  }
+}
+
+function createRightPanelTabStore() {
+  let active = $state<RightPanelTab>(loadInitial());
+
+  return {
+    get active() {
+      return active;
+    },
+    set(v: RightPanelTab) {
+      active = v;
+      persist(v);
+    },
+  };
+}
+
+export const rightPanelTab = createRightPanelTabStore();

--- a/desktop-ui/src/lib/stories/BrowserView.stories.ts
+++ b/desktop-ui/src/lib/stories/BrowserView.stories.ts
@@ -66,6 +66,7 @@ function setupAnnotations(items: UiAnnotation[], annotateMode = false) {
       has_review_json: false,
       eligible_comment_count: 0,
       triage: null,
+      diagrams: [],
     },
     pr: null,
     panels: { left: true, tree: true, right: true },

--- a/desktop-ui/src/lib/stories/BrowserView.stories.ts
+++ b/desktop-ui/src/lib/stories/BrowserView.stories.ts
@@ -3,6 +3,7 @@ import BrowserView from "$lib/components/BrowserView.svelte";
 import { browser } from "$lib/stores/browser.svelte";
 import { app } from "$lib/stores/app.svelte";
 import type { UiAnnotation } from "$lib/types";
+import { diagramPresetsFixture } from "./fixtures";
 
 // Minimal HTML loaded into the iframe so the stories render something visible
 // without depending on a running dev server.
@@ -67,6 +68,7 @@ function setupAnnotations(items: UiAnnotation[], annotateMode = false) {
       eligible_comment_count: 0,
       triage: null,
       diagrams: [],
+      diagram_presets: diagramPresetsFixture,
     },
     pr: null,
     panels: { left: true, tree: true, right: true },

--- a/desktop-ui/src/lib/stories/MainLayoutPlayground.svelte
+++ b/desktop-ui/src/lib/stories/MainLayoutPlayground.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { app } from "$lib/stores/app.svelte";
   import { terminal } from "$lib/stores/terminal.svelte";
+  import type { RightPanelTab } from "$lib/stores/rightPanelTab.svelte";
   import TabStrip from "$lib/components/TabStrip.svelte";
   import BranchContextBar from "$lib/components/BranchContextBar.svelte";
   import LeftSidebar from "$lib/components/LeftSidebar.svelte";
@@ -112,7 +113,7 @@
     // no-op in playground — rightRail state is driven by Storybook args
   }
 
-  function expandRightPanelToTab(_tab: "branch" | "review" | "notes") {
+  function expandRightPanelToTab(_tab: RightPanelTab) {
     // no-op in playground — use Storybook Controls to change rightRail
   }
 

--- a/desktop-ui/src/lib/stories/fixtures.ts
+++ b/desktop-ui/src/lib/stories/fixtures.ts
@@ -218,6 +218,27 @@ export const filePageTest: FileSnapshot = {
 
 // ─── AI snapshots ───────────────────────────────────────────────────────────
 
+/** Mirrors `diagram_presets()` in er-engine for Storybook (no live snapshot).
+ *  Production UI reads `ai.diagram_presets` from the snapshot wire contract;
+ *  fixtures can't import the Rust catalog, so keep this list aligned manually. */
+export const diagramPresetsFixture = [
+  {
+    kind: "mental-model",
+    label: "Mental model",
+    description: "High-level map of the areas this diff touches and how they relate",
+  },
+  {
+    kind: "subsystems",
+    label: "Subsystems",
+    description: "Changed files grouped by subsystem, with interactions",
+  },
+  {
+    kind: "flows",
+    label: "Flows",
+    description: "Runtime flow through the changed code for the main scenarios",
+  },
+];
+
 export const aiWithFindings: AiSnapshot = {
   fresh: true,
   stale_reason: null,
@@ -311,6 +332,7 @@ export const aiWithFindings: AiSnapshot = {
       created_at: "2026-08-11T09:00:00Z",
     },
   ],
+  diagram_presets: diagramPresetsFixture,
 };
 
 export const aiEmpty: AiSnapshot = {
@@ -333,6 +355,7 @@ export const aiEmpty: AiSnapshot = {
   eligible_comment_count: 0,
   triage: null,
   diagrams: [],
+  diagram_presets: diagramPresetsFixture,
 };
 
 function professorFinding(id: string, file: string, line: number, title: string): AiSnapshot["findings"][0] {
@@ -387,6 +410,7 @@ export const aiProfessorOnly: AiSnapshot = {
   eligible_comment_count: 0,
   triage: null,
   diagrams: [],
+  diagram_presets: diagramPresetsFixture,
 };
 
 /** General + Professor + Security for multi-agent dropdown. */

--- a/desktop-ui/src/lib/stories/fixtures.ts
+++ b/desktop-ui/src/lib/stories/fixtures.ts
@@ -291,6 +291,26 @@ export const aiWithFindings: AiSnapshot = {
   has_review_json: true,
   eligible_comment_count: 0,
   triage: null,
+  diagrams: [
+    {
+      id: "mental-model",
+      kind: "mental-model",
+      title: "Variant warning copy flow",
+      prompt: "",
+      mermaid: "flowchart TD\n  checkout[\"Checkout page\"]\n  copy[\"variant-warning-copy.ts\"]\n  resolution[\"experiment-template-resolution.ts\"]\n  checkout -->|\"renders warnings\"| copy\n  copy -->|\"resolves template\"| resolution",
+      fresh: true,
+      created_at: "2026-08-11T10:00:00Z",
+    },
+    {
+      id: "flows",
+      kind: "flows",
+      title: "Warning resolution flow",
+      prompt: "",
+      mermaid: "sequenceDiagram\n  participant UI as Checkout\n  participant Lib as WarningCopy\n  UI->>Lib: getWarning(variant)\n  Lib-->>UI: message",
+      fresh: false,
+      created_at: "2026-08-11T09:00:00Z",
+    },
+  ],
 };
 
 export const aiEmpty: AiSnapshot = {
@@ -312,6 +332,7 @@ export const aiEmpty: AiSnapshot = {
   has_review_json: false,
   eligible_comment_count: 0,
   triage: null,
+  diagrams: [],
 };
 
 function professorFinding(id: string, file: string, line: number, title: string): AiSnapshot["findings"][0] {
@@ -365,6 +386,7 @@ export const aiProfessorOnly: AiSnapshot = {
   has_review_json: true,
   eligible_comment_count: 0,
   triage: null,
+  diagrams: [],
 };
 
 /** General + Professor + Security for multi-agent dropdown. */

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -192,6 +192,13 @@ export interface TriageSnapshot {
   domains: string[];
 }
 
+export interface DiagramPresetSnapshot {
+  /** "mental-model" | "subsystems" | "flows" */
+  kind: string;
+  label: string;
+  description: string;
+}
+
 export interface DiagramSnapshot {
   /** File-stem id (`diagrams/<id>.json`) — delete/regenerate target. */
   id: string;
@@ -231,6 +238,8 @@ export interface AiSnapshot {
   triage: TriageSnapshot | null;
   /** Mermaid diagrams of the diff (`diagrams/*.json`), for the Context tab. */
   diagrams: DiagramSnapshot[];
+  /** Built-in generate presets from the engine catalog (never hand-rolled in UI). */
+  diagram_presets: DiagramPresetSnapshot[];
 }
 
 export interface PrSnapshot {

--- a/desktop-ui/src/lib/types.ts
+++ b/desktop-ui/src/lib/types.ts
@@ -192,6 +192,21 @@ export interface TriageSnapshot {
   domains: string[];
 }
 
+export interface DiagramSnapshot {
+  /** File-stem id (`diagrams/<id>.json`) — delete/regenerate target. */
+  id: string;
+  /** "mental-model" | "subsystems" | "flows" | "custom" */
+  kind: string;
+  title: string;
+  /** User prompt for custom diagrams (empty for presets). */
+  prompt: string;
+  /** Bare mermaid source. */
+  mermaid: string;
+  /** True when the diagram's diff hash matches the current diff. */
+  fresh: boolean;
+  created_at: string;
+}
+
 export interface AiSnapshot {
   fresh: boolean;
   stale_reason: string | null;
@@ -214,6 +229,8 @@ export interface AiSnapshot {
   /** Top-level GitHub comments eligible for batch validate (!resolved, !outdated). */
   eligible_comment_count: number;
   triage: TriageSnapshot | null;
+  /** Mermaid diagrams of the diff (`diagrams/*.json`), for the Context tab. */
+  diagrams: DiagramSnapshot[];
 }
 
 export interface PrSnapshot {

--- a/docs/guide/mcp.html
+++ b/docs/guide/mcp.html
@@ -208,6 +208,7 @@ args = ["-y", "easy-review-mcp"]</code></pre>
         <tr><td>Production-only size</td><td><code>pr_stats</code></td></tr>
         <tr><td>Guided tour</td><td><code>pr_guide</code> (prepare → upload <code>tour.json</code>)</td></tr>
         <tr><td>Full AI review / triage</td><td><code>pr_prepare</code> → <code>pr_upload</code> → <code>pr_summarize</code></td></tr>
+        <tr><td>Mermaid diagrams</td><td><code>pr_diagram</code> (list | prepare → upload diagram JSON)</td></tr>
         <tr><td>PR feedback threads</td><td><code>pr_feedback_get</code> / <code>pr_feedback_reply</code></td></tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Add a **Diagram** AI command with presets (Mental model, Subsystems, Flows) plus custom prompts; results persist as `diagrams/*.json` in managed per-view storage.
- New right-panel **Context** tab renders Mermaid diagrams (inline + modal), with Command Palette entry (`d`) and themed lazy Mermaid client.
- Wire the preset catalog through `AiSnapshot.diagram_presets` so the UI stays in sync with the engine.

## Test plan
- [ ] Open Desktop on a branch/PR with a non-empty diff; open right panel → **Context**
- [ ] Generate each preset (Mental model / Subsystems / Flows); confirm background task pills and diagram cards appear
- [ ] Expand a diagram into the modal; copy Mermaid source; delete and regenerate
- [ ] Submit a custom prompt; confirm a new timestamped diagram accumulates
- [ ] Change the diff (or switch views) and confirm stale badge when hashes diverge
- [ ] Command Palette → Diagrams (`d`) opens Context; collapsed right rail badge shows diagram count
- [ ] `cargo test -p er-engine` and `cd desktop-ui && bun run check && bun test src`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 382e677c40c026d9cbfbbff2a961945874436a30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->