### PR TITLE
docs: sync desktop AI hub shortcuts and document Context tab

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -60,7 +60,7 @@ args = ["--print", "-p", "{prompt}"]    # Arguments ({prompt} is replaced)
 
 ### `[ai_hub]`
 
-Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, Cursor, and OpenCode. Desktop Settings persists the selected default immediately; the AI action palette keeps mid-session picks session-only. The TUI persists defaults when you save General settings.
+Optional runtime provider/model presets for the AI Hub. When present, AI Hub actions can switch between providers such as Claude, Codex, Cursor, and OpenCode. Desktop Settings persists the selected default immediately; the ⌘K command palette keeps mid-session picks session-only. The TUI persists defaults when you save General settings.
 
 ```toml
 [ai_hub]

--- a/docs/guide/ai-review.html
+++ b/docs/guide/ai-review.html
@@ -27,7 +27,8 @@
     <h2 id="ai-hub">Running a review: the AI Hub</h2>
     <p>
       Both apps have a built-in <strong>AI Hub</strong> that spawns the review agents for you — no second terminal
-      required. Open it with <kbd>a</kbd> in the terminal app or <kbd>Cmd</kbd>+<kbd>A</kbd> in the desktop app, then
+      required. Open it with <kbd>a</kbd> in the terminal app or <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> in the
+      desktop app, then
       choose an action: a full review, a single expert, the professor, a fast triage, answering your questions, or a
       summary. The Hub runs your AI tool as a subprocess and writes the same sidecar artifacts described below, which
       then render inline against the diff.

--- a/docs/guide/desktop-features.html
+++ b/docs/guide/desktop-features.html
@@ -89,11 +89,27 @@
 
     <h2>AI Hub: providers, models, reviewers</h2>
     <p>
-      The command palette (<kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong>) is the desktop's front door to AI. From it you can run a review,
-      launch the arena, choose a <strong>provider</strong> (Claude, Codex, Cursor), pick a specific <strong>model</strong>,
-      select which <strong>reviewer kinds</strong> to run, and reach export, the browser, and settings. Running reviews
-      surface as background tasks with cancellation; results land in the Review tab, filterable by severity or by agent.
-      The provider and model catalog comes from your <a href="configuration.html#ai-hub">AI Hub configuration</a>.
+      The command palette (<kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong>) is the desktop's front door to AI. Nested
+      menus group reviews, triage, professor, tour, diagrams, validation, and model selection. From it you can run a
+      review, launch the arena, choose a <strong>provider</strong> (Claude, Codex, Cursor), pick a specific
+      <strong>model</strong>, select which <strong>reviewer kinds</strong> to run, and reach export, the browser, and
+      settings. Running reviews surface as background tasks with cancellation; results land in the Review tab, filterable
+      by severity or by agent. The provider and model catalog comes from your
+      <a href="configuration.html#ai-hub">AI Hub configuration</a>.
+    </p>
+
+    <h2>Context tab: Mermaid diagrams</h2>
+    <p>
+      The right panel's <strong>Context</strong> tab generates and renders AI-authored Mermaid diagrams of the current
+      diff. Built-in presets cover a <strong>mental model</strong> (areas touched and how they relate),
+      <strong>subsystems</strong> (changed files grouped with interactions), and <strong>flows</strong> (runtime paths
+      through the changed code). A <strong>custom</strong> prompt covers anything else. Open the tab from the panel rail,
+      or jump there with <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Diagrams</strong>.
+    </p>
+    <p>
+      Diagrams are stored locally per branch/PR view bucket (<code>diagrams/*.json</code> — see
+      <a href="storage.html">Review Storage</a>) and never pushed. Regenerate or delete from the card; copy the raw
+      Mermaid source to paste elsewhere. When the diff changes, stale diagrams dim until you regenerate.
     </p>
 
     <h2>Inline threads &amp; findings</h2>

--- a/docs/guide/desktop.html
+++ b/docs/guide/desktop.html
@@ -95,13 +95,13 @@
         </div>
         <div class="bottom">
           <span><b>⌘K</b> commands</span><span class="sep">·</span>
-          <span><b>⌘A</b> AI hub</span><span class="sep">·</span>
+          <span><b>⌘A</b> select all</span><span class="sep">·</span>
           <span><b>⌘F</b> find usages</span><span class="sep">·</span>
           <span><b>d</b> split ↔ unified</span><span class="sep">·</span>
           <span><b>⌘T</b> terminal drawer</span>
         </div>
       </div>
-      <figcaption>The desktop app — persistent tabs, a branch context bar with a Local&nbsp;↔&nbsp;PR toggle, a side-by-side split diff with intra-line <span style="color:var(--green)">word-diff</span> highlighting, inline AI threads with “Ask AI” / “promote to GitHub”, and a three-tab right panel (Branch · Review · Notes).</figcaption>
+      <figcaption>The desktop app — persistent tabs, a branch context bar with a Local&nbsp;↔&nbsp;PR toggle, a side-by-side split diff with intra-line <span style="color:var(--green)">word-diff</span> highlighting, inline AI threads with “Ask AI” / “promote to GitHub”, and a four-tab right panel (Branch · Review · Notes · Context).</figcaption>
     </figure>
 
     <table>
@@ -111,20 +111,21 @@
         <tr><td><strong>Branch context bar</strong></td><td>Current branch, base comparison, PR number, change summary, and a Local&nbsp;Branch ↔ PR&nbsp;Diff toggle.</td></tr>
         <tr><td><strong>Left sidebar</strong></td><td>Collapsible file tree with search, plus a project / branch / PR picker for switching context.</td></tr>
         <tr><td><strong>Diff view</strong> (center)</td><td>Unified or split diff with inline threads, AI findings, and intra-line word-diff highlighting.</td></tr>
-        <tr><td><strong>Right panel</strong></td><td>Three tabs — Branch (git/PR status), Review (AI findings, summary, arena history), and Notes (questions &amp; GitHub comments).</td></tr>
+        <tr><td><strong>Right panel</strong></td><td>Four tabs — Branch (git/PR status), Review (AI findings, summary, arena history), Notes (questions &amp; GitHub comments), and Context (Mermaid diagrams of the diff).</td></tr>
         <tr><td><strong>Browser</strong> (optional)</td><td>An embedded webview for docs, design systems, or APIs, with an annotation mode.</td></tr>
         <tr><td><strong>Terminal drawer</strong> (bottom)</td><td>A resizable embedded shell for running commands without leaving the app.</td></tr>
       </tbody>
     </table>
 
     <h2>Command surfaces</h2>
-    <p>Two palettes make everything reachable without hunting through menus:</p>
+    <p>Everything is reachable from the <strong>command palette</strong> (<kbd>Cmd</kbd>+<kbd>K</kbd>):</p>
     <ul>
-      <li><strong>Command palette</strong> (<kbd>Cmd</kbd>+<kbd>K</kbd>) — a searchable list of actions, navigation, and
-      files in the current diff.</li>
-      <li><strong>AI action palette / AI Hub</strong> (<kbd>Cmd</kbd>+<kbd>A</kbd>) — run a review, launch the arena,
-      pick a provider and model, choose specialized reviewers, export, and more.</li>
+      <li><strong>Top level</strong> — navigation, PR actions, settings, export, and files in the current diff.</li>
+      <li><strong>AI submenu</strong> — run a review, launch the arena, triage, professor, generate a tour or diagrams,
+      pick a provider and model, choose specialized reviewers, validate findings, and more. Letter shortcuts and arrow
+      keys work inside nested menus.</li>
     </ul>
+    <p><kbd>Cmd</kbd>+<kbd>A</kbd> is native select-all again (including in the embedded browser).</p>
 
     <h2>What the desktop adds over the terminal</h2>
     <table>
@@ -139,6 +140,7 @@
         <tr><td>Persistent, drag-to-reorder tabs</td><td>Yes</td><td>Session tabs</td></tr>
         <tr><td>Reference “find usages” popover</td><td>Yes</td><td>—</td></tr>
         <tr><td>Export review to markdown</td><td>Preview + copy/save</td><td>—</td></tr>
+        <tr><td>Mermaid diagrams (Context tab)</td><td>Yes</td><td>—</td></tr>
         <tr><td>Keyboard-driven, zero-dependency, instant start</td><td>—</td><td>Yes</td></tr>
       </tbody>
     </table>
@@ -149,8 +151,9 @@
       The desktop app supports the same live loop as the terminal: watch mode keeps the diff current while an
       assistant edits, stages, and commits. The embedded <strong>terminal drawer</strong> means the assistant can run
       <em>inside</em> the app — open Claude Code in the drawer, review its changes in the diff above, and drop
-      questions or notes inline as they come up. Run reviews from the AI Hub (<kbd>Cmd</kbd>+<kbd>A</kbd>); findings,
-      triage, and the guided tour land in the Review panel and the Guide tab automatically.
+      questions or notes inline as they come up. Run reviews from the command palette (<kbd>Cmd</kbd>+<kbd>K</kbd> →
+      <strong>AI</strong>); findings, triage, guided tour, and Mermaid diagrams land in the Review, Guide, and Context
+      panels automatically.
     </p>
 
     <h2>Running it</h2>

--- a/docs/guide/quick-start.html
+++ b/docs/guide/quick-start.html
@@ -75,7 +75,8 @@
 
     <h2>6. Add AI analysis (optional)</h2>
     <p>This is where <code>er</code> earns its name. The quickest way is the built-in <strong>AI Hub</strong>: press
-    <kbd>a</kbd> to open it (<kbd>Cmd</kbd>+<kbd>A</kbd> in the desktop app) and run a review. <code>er</code> spawns your
+    <kbd>a</kbd> to open it (<kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> in the desktop app) and run a review.
+    <code>er</code> spawns your
     AI tool for you — Claude Code by default, if the <code>claude</code> CLI is on your <code>PATH</code> — so you do not
     need a second terminal.</p>
     <ol>

--- a/docs/guide/skills.html
+++ b/docs/guide/skills.html
@@ -12,9 +12,10 @@
     <p class="eyebrow">Core Concepts</p>
     <h1>AI Hub Actions</h1>
     <p class="lead">
-      Open the AI Hub — press <kbd>a</kbd> in the TUI or <kbd>Cmd+A</kbd> (macOS) / <kbd>Ctrl+A</kbd> (Windows/Linux)
-      in the desktop app — to run any of these actions. Each writes sidecar files that <code>er</code> reads and
-      renders inline. The Hub is the primary way to trigger AI work; no external tool or command is needed.
+      Open the AI Hub — press <kbd>a</kbd> in the TUI or <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> (macOS) /
+      <kbd>Ctrl</kbd>+<kbd>K</kbd> → <strong>AI</strong> (Windows/Linux) in the desktop app — to run any of these
+      actions. Each writes sidecar files that <code>er</code> reads and renders inline. The Hub is the primary way to
+      trigger AI work; no external tool or command is needed.
     </p>
 
     <h2>The standard loop</h2>
@@ -77,7 +78,7 @@
       <thead><tr><th>App</th><th>Invocation</th></tr></thead>
       <tbody>
         <tr><td>TUI</td><td>Press <kbd>a</kbd> → select <strong>Review work</strong></td></tr>
-        <tr><td>Desktop</td><td>Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → select <strong>Run review</strong></td></tr>
+        <tr><td>Desktop</td><td>Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Run review</strong></td></tr>
       </tbody>
     </table>
     <p>
@@ -95,7 +96,7 @@
       <div>
         <p>
           <strong>TUI:</strong> Press <kbd>a</kbd> → <strong>Specialized review</strong> → a sub-menu lists all 8 experts; select one to run it.<br>
-          <strong>Desktop:</strong> Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → <strong>Run reviewers…</strong> → a
+          <strong>Desktop:</strong> Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Run reviewers…</strong> → a
           <strong>Choose reviewers</strong> multi-select appears (General + 8 experts + Professor); toggle with
           <kbd>Space</kbd> and confirm with <strong>Run N reviewer(s)</strong>. You can run multiple in one go.
         </p>
@@ -120,7 +121,7 @@
       <thead><tr><th>App</th><th>Invocation</th></tr></thead>
       <tbody>
         <tr><td>TUI</td><td>Press <kbd>a</kbd> → <strong>Triage branch</strong></td></tr>
-        <tr><td>Desktop</td><td>Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → <strong>Triage branch</strong></td></tr>
+        <tr><td>Desktop</td><td>Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Triage branch</strong></td></tr>
       </tbody>
     </table>
     <p>
@@ -133,7 +134,7 @@
       <thead><tr><th>App</th><th>Invocation</th></tr></thead>
       <tbody>
         <tr><td>TUI</td><td>Press <kbd>a</kbd> → <strong>Professor</strong></td></tr>
-        <tr><td>Desktop</td><td>Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → <strong>Professor</strong> (opens an optional focus-prompt modal before running)</td></tr>
+        <tr><td>Desktop</td><td>Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Professor</strong> (opens an optional focus-prompt modal before running)</td></tr>
       </tbody>
     </table>
     <p>
@@ -149,7 +150,7 @@
         <p>
           <strong>TUI only:</strong> Press <kbd>a</kbd> → <strong>Generate summary</strong> to regenerate
           <code>summary.md</code> as a standalone action.<br>
-          <strong>Desktop:</strong> There is no standalone "Generate summary" action in the AI Actions palette.
+          <strong>Desktop:</strong> There is no standalone "Generate summary" action in the ⌘K AI menu.
           <code>summary.md</code> is produced automatically as part of <strong>Run review</strong>.
         </p>
       </div>
@@ -174,7 +175,7 @@
       <thead><tr><th>App</th><th>Invocation</th></tr></thead>
       <tbody>
         <tr><td>TUI</td><td>Press <kbd>a</kbd> → <strong>Validate review</strong></td></tr>
-        <tr><td>Desktop</td><td>Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → <strong>Validate / re-anchor</strong></td></tr>
+        <tr><td>Desktop</td><td>Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Validate / re-anchor</strong></td></tr>
       </tbody>
     </table>
     <p>
@@ -187,7 +188,7 @@
       <span class="ico">◆</span>
       <div>
         <p>
-          <strong>Desktop only:</strong> Press <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd> → <strong>Generate tour</strong>
+          <strong>Desktop only:</strong> Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Generate tour</strong>
           (or <strong>Regenerate tour</strong> if one already exists). A "Re-run guide" button also appears in the
           Guide tab when the tour is stale. Writes <code>tour.json</code>.<br>
           <strong>TUI:</strong> The TUI can navigate an existing tour in Guide / Tour mode, but it cannot
@@ -196,12 +197,26 @@
       </div>
     </div>
 
+    <h3>Generate diagrams</h3>
+    <table>
+      <thead><tr><th>App</th><th>Invocation</th></tr></thead>
+      <tbody>
+        <tr><td>Desktop</td><td>Press <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> → <strong>Diagrams</strong> (opens the Context tab), then pick a preset or enter a custom prompt</td></tr>
+      </tbody>
+    </table>
+    <p>
+      AI-generated Mermaid diagrams of the current diff: mental model, subsystems, flows, or a custom description.
+      Writes <code>diagrams/*.json</code> (presets overwrite in place; custom diagrams accumulate). Rendered in the
+      right panel's <strong>Context</strong> tab. See
+      <a href="desktop-features.html">Desktop Features → Context tab</a>.
+    </p>
+
     <h3>Arena (multi-reviewer consensus)</h3>
     <div class="callout note">
       <span class="ico">◆</span>
       <div>
         <p>
-          <strong>Desktop only — and not in the AI Actions palette.</strong> The Arena lives in the
+          <strong>Desktop only — and not in the ⌘K AI menu.</strong> The Arena lives in the
           <strong>Review panel</strong> Arena card: use <strong>Run as Arena</strong> or
           <strong>Promote to Arena</strong> there.<br>
           <strong>TUI:</strong> Arena is not available in the TUI.
@@ -252,7 +267,7 @@
       sidecar (matching the current diff hash) into the in-memory review, and every finding carries an <strong>agent
       pill</strong> — <code>General</code>, <code>Security</code>, <code>Professor</code>, and so on — so you can tell at a
       glance which agent raised it. The desktop app makes this a first-class flow: use <strong>Run reviewers…</strong>
-      in the AI Actions palette to select and launch multiple reviewers at once, or use the
+      in the ⌘K AI menu to select and launch multiple reviewers at once, or use the
       <a href="desktop-features.html#arena">review arena</a> for adversarial multi-model consensus.
     </p>
 

--- a/docs/guide/storage.html
+++ b/docs/guide/storage.html
@@ -65,6 +65,7 @@
         <tr><td><code>professor.json</code></td><td>AI Hub: Professor</td><td>Teaching / learning insights</td></tr>
         <tr><td><code>experts/*.json</code></td><td>AI Hub: Specialized review</td><td>Domain-specific expert findings</td></tr>
         <tr><td><code>tour.json</code></td><td>AI Hub: Generate tour (desktop)</td><td>Guided-tour pillars and file order</td></tr>
+        <tr><td><code>diagrams/*.json</code></td><td>AI Hub: Diagrams (desktop Context tab)</td><td>Mermaid diagrams of the diff (mental model, subsystems, flows, or custom)</td></tr>
         <tr><td><code>questions.json</code></td><td><code>er</code> (<kbd>q</kbd>)</td><td>Personal review questions</td></tr>
         <tr><td><code>notes.json</code></td><td><code>er</code> (draft type cycled with <kbd>Ctrl</kbd>+<kbd>t</kbd>)</td><td>Local actionable notes for agent hand-off</td></tr>
         <tr><td><code>github-comments.json</code></td><td><code>er</code> (<kbd>c</kbd>)</td><td>GitHub PR comments</td></tr>
@@ -92,7 +93,8 @@
     <div class="callout note">
       <span class="ico">◆</span>
       <div><p>With default managed storage, run reviews through <code>er</code>'s built-in AI Hub (TUI: <kbd>a</kbd> /
-      Desktop: <kbd>Cmd+A</kbd>). Use <code>ER_REPO_LOCAL=1</code> only when an external tool writes directly into
+      Desktop: <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong>). Use <code>ER_REPO_LOCAL=1</code> only when an external
+      tool writes directly into
       <code>.er/</code> and you want <code>er</code> to read from the same location.</p></div>
     </div>
 

--- a/docs/guide/troubleshooting.html
+++ b/docs/guide/troubleshooting.html
@@ -29,8 +29,9 @@
     <ul>
       <li><strong>Check where the artifacts went.</strong> By default <code>er</code> reads from managed storage, not the
       repo's <code>.er/</code>. External tools may write to <code>.er/</code> in the repo
-      instead. To bridge the gap: run reviews via the AI Hub (<kbd>a</kbd> in the TUI, <kbd>Cmd+A</kbd> / <kbd>Ctrl+A</kbd>
-      in the desktop), or launch <code>er</code> with <code>ER_REPO_LOCAL=1</code> to read the repo directory directly.
+      instead. To bridge the gap: run reviews via the AI Hub (<kbd>a</kbd> in the TUI,
+      <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> in the desktop), or launch <code>er</code> with
+      <code>ER_REPO_LOCAL=1</code> to read the repo directory directly.
       See <a href="storage.html">Review Storage</a>.</li>
       <li><strong>Check freshness.</strong> If the diff changed after the review ran, the data is dimmed as
       <em>stale</em>. Re-run the relevant action from the AI Hub.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1062,7 +1062,7 @@
           <span class="font-mono text-xs text-orange uppercase tracking-widest">AI review</span>
           <h2 class="text-3xl sm:text-4xl font-body font-500 mt-3 mb-5 leading-tight">AI reads the diff<br>so you don't have<br>to guess</h2>
           <p class="text-text-dim leading-relaxed mb-6">
-            Open the AI Hub — press <span class="keycap">a</span> in the TUI or <kbd class="keycap">Cmd+A</kbd> in the desktop app — and run a review (<strong class="text-text">Review work</strong> in the TUI, <strong class="text-text">Run review</strong> on desktop). Risk ratings and hunk-level findings appear inline — toggle the findings layer with <span class="keycap">A</span>, and cycle the side panel with <span class="keycap">p</span> for the summary and risk breakdown. To get answers to your private questions without a full review, open the Hub and choose <strong class="text-text">Answer questions</strong> (TUI only; questions are managed in the Notes panel in the desktop app).
+            Open the AI Hub — press <span class="keycap">a</span> in the TUI or <kbd class="keycap">Cmd+K</kbd> → <strong class="text-text">AI</strong> in the desktop app — and run a review (<strong class="text-text">Review work</strong> in the TUI, <strong class="text-text">Run review</strong> on desktop). Risk ratings and hunk-level findings appear inline — toggle the findings layer with <span class="keycap">A</span>, and cycle the side panel with <span class="keycap">p</span> for the summary and risk breakdown. To get answers to your private questions without a full review, open the Hub and choose <strong class="text-text">Answer questions</strong> (TUI only; questions are managed in the Notes panel in the desktop app).
           </p>
           <ul class="space-y-3 text-sm text-text-dim mb-7">
             <li class="flex gap-3">
@@ -1437,13 +1437,13 @@
         <div class="timeline-step" style="transition-delay: 400ms;">
           <div class="timeline-node key"><span class="font-mono text-xs text-accent font-bold">3</span></div>
           <h3 class="font-body font-500 text-base mb-1">Run a review from the AI Hub</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">a</span> (TUI) or <kbd class="keycap">Cmd+A</kbd> (desktop) to open the AI Hub, then run a review (<strong class="text-text">Review work</strong> / <strong class="text-text">Run review</strong>). Risk ratings, hunk-level findings, and a review checklist appear inline. Toggle the findings layer with <span class="keycap">A</span> and cycle the side panel with <span class="keycap">p</span> to dial how much AI context is shown.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">a</span> (TUI) or <kbd class="keycap">Cmd+K</kbd> → <strong class="text-text">AI</strong> (desktop) to open the AI Hub, then run a review (<strong class="text-text">Review work</strong> / <strong class="text-text">Run review</strong>). Risk ratings, hunk-level findings, and a review checklist appear inline. Toggle the findings layer with <span class="keycap">A</span> and cycle the side panel with <span class="keycap">p</span> to dial how much AI context is shown.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 600ms;">
           <div class="timeline-node"><span class="font-mono text-xs text-text-muted">4</span></div>
           <h3 class="font-body font-500 text-base mb-1">Comment and iterate</h3>
-          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Cycle with <span class="keycap">p</span> to a side panel for the AI summary and PR overview alongside your diff. Re-run the review from the AI Hub (<span class="keycap">a</span> → <strong class="text-text">Review work</strong> in the TUI, or <kbd class="keycap">Cmd+A</kbd> → <strong class="text-text">Run review</strong> in the desktop app) — the AI reads your questions and updates its analysis.</p>
+          <p class="text-text-dim text-sm leading-relaxed">Press <span class="keycap">c</span> for GitHub comments or <span class="keycap">q</span> for private questions on any line. Cycle with <span class="keycap">p</span> to a side panel for the AI summary and PR overview alongside your diff. Re-run the review from the AI Hub (<span class="keycap">a</span> → <strong class="text-text">Review work</strong> in the TUI, or <kbd class="keycap">Cmd+K</kbd> → <strong class="text-text">AI</strong> → <strong class="text-text">Run review</strong> in the desktop app) — the AI reads your questions and updates its analysis.</p>
         </div>
 
         <div class="timeline-step" style="transition-delay: 800ms;">

--- a/docs/release-notes/remove-external-skills-use-ai-hub.md
+++ b/docs/release-notes/remove-external-skills-use-ai-hub.md
@@ -6,7 +6,7 @@ Easy Review no longer ships the external `/er-*` Claude Code skills. Both apps a
 the same review agents internally through the **AI Hub**, so the docs now send users there
 instead of telling them to type slash commands in a separate Claude Code pane:
 
-- **Open the AI Hub** with <kbd>a</kbd> in the terminal app or <kbd>Cmd</kbd>+<kbd>A</kbd> in
+- **Open the AI Hub** with <kbd>a</kbd> in the terminal app or <kbd>Cmd</kbd>+<kbd>K</kbd> → <strong>AI</strong> in
   the desktop app, then run a review, a specialized (expert) review, triage, or the professor.
 - **Removed** all 21 `/er-*` skill directories under `skills/`, `skills/README.md`, and the
   18 `.claude/commands/*.md` symlinks that exposed them as slash commands.


### PR DESCRIPTION
## Summary
- Rebased `update-docs` onto `main` (was stale at v0.4.10).
- Replaced stale desktop `Cmd+A` AI Hub references with `Cmd+K` → **AI** across the guide, landing page, and config reference (matches v0.4.10 nested command palette).
- Documented the **Context** tab and Mermaid diagram presets (`diagrams/*.json` storage, ⌘K → AI → Diagrams).

## Test plan
- [ ] Spot-check `docs/guide/desktop.html`, `desktop-features.html`, and `skills.html` in a browser
- [ ] Confirm no remaining `Cmd+A` AI Hub references in `docs/` (except select-all mentions)


Made with [Cursor](https://cursor.com)