### PR TITLE
feat(desktop): drag to reorder sidebar repositories

### DIFF
--- a/crates/er-desktop/agent.md
+++ b/crates/er-desktop/agent.md
@@ -8,7 +8,7 @@
 - `src/snapshot.rs`: Rust wire contract for `desktop-ui/src/lib/types.ts`.
 - `src/main.rs`: Tauri setup, browser proxy/content script, background loops, command registration.
 - `src/tabs.rs`: persisted desktop tab descriptors and tab reconstruction (`tabs.json` under the platform config dir).
-- `src/projects.rs`: persisted project list, tracked branches, tracked/dismissed PRs.
+- `src/projects.rs`: persisted project list (Vec order is the sidebar order), tracked branches, tracked/dismissed PRs. `reorder_projects` rewrites that Vec.
 - `src/pr_cache.rs`: GitHub PR list fetching/caching helpers.
 - `src/export.rs`: pure Markdown renderer for comments, questions, findings, and UI annotations.
 - `src/er_storage.rs`: re-exports `er_engine::storage` (managed review storage under app data).

--- a/crates/er-desktop/permissions/app-commands.toml
+++ b/crates/er-desktop/permissions/app-commands.toml
@@ -128,6 +128,7 @@ commands.allow = [
   "remove_tracked_branch",
   "list_available_branches",
   "delete_project",
+  "reorder_projects",
   "open_project_branch",
   "new_tab",
   "close_tab",

--- a/crates/er-desktop/src/commands.rs
+++ b/crates/er-desktop/src/commands.rs
@@ -7529,6 +7529,18 @@ pub fn delete_project(project_id: String, state: State<AppState>) -> Result<AppS
 }
 
 #[tauri::command]
+#[allow(non_snake_case)]
+pub fn reorder_projects(
+    fromIdx: usize,
+    toIdx: usize,
+    state: State<AppState>,
+) -> Result<AppSnapshot, String> {
+    projects::reorder_projects(fromIdx, toIdx).map_err(|e| e.to_string())?;
+    state.desktop_revision.fetch_add(1, Ordering::Relaxed);
+    snap!(state)
+}
+
+#[tauri::command]
 pub fn open_project_branch(
     project_id: String,
     branch: String,

--- a/crates/er-desktop/src/main.rs
+++ b/crates/er-desktop/src/main.rs
@@ -1936,6 +1936,7 @@ fn main() {
             commands::remove_tracked_branch,
             commands::list_available_branches,
             commands::delete_project,
+            commands::reorder_projects,
             commands::open_project_branch,
             commands::new_tab,
             commands::close_tab,

--- a/crates/er-desktop/src/projects.rs
+++ b/crates/er-desktop/src/projects.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProjectsFile {
@@ -213,6 +214,26 @@ pub fn delete_project(project_id: &str) -> anyhow::Result<()> {
     save(&file)
 }
 
+/// Move the project at `from` to index `to`. Out-of-bounds or `from == to`
+/// are silent no-ops. Persisted order is the sidebar display order.
+pub fn reorder_projects(from: usize, to: usize) -> anyhow::Result<()> {
+    let mut file = load();
+    if reorder_projects_in_file(&mut file, from, to) {
+        save(&file)?;
+    }
+    Ok(())
+}
+
+fn reorder_projects_in_file(file: &mut ProjectsFile, from: usize, to: usize) -> bool {
+    let len = file.projects.len();
+    if from >= len || to >= len || from == to {
+        return false;
+    }
+    let project = file.projects.remove(from);
+    file.projects.insert(to, project);
+    true
+}
+
 pub fn save_pr(project_id: &str, pr_number: u64, title: &str) -> anyhow::Result<()> {
     let mut file = load();
     let proj = file
@@ -257,12 +278,20 @@ pub fn config_path() -> PathBuf {
 use std::sync::Mutex;
 
 static PROJECTS_LOAD_CACHE: Mutex<Option<(std::time::SystemTime, ProjectsFile)>> = Mutex::new(None);
+static PROJECTS_CONTENT_GEN: AtomicU64 = AtomicU64::new(0);
 
 /// Drop the in-process parse cache so the next [`load`] re-reads from disk.
 pub fn invalidate_load_cache() {
     if let Ok(mut guard) = PROJECTS_LOAD_CACHE.lock() {
         *guard = None;
     }
+}
+
+/// Monotonic generation bumped on every successful [`save`]. Snapshot caching
+/// keys off this so in-process reorders are visible even when filesystem mtime
+/// resolution would otherwise keep the old cache entry.
+pub fn content_generation() -> u64 {
+    PROJECTS_CONTENT_GEN.load(Ordering::Relaxed)
 }
 
 pub fn load() -> ProjectsFile {
@@ -298,6 +327,7 @@ pub fn save(file: &ProjectsFile) -> anyhow::Result<()> {
     let path = config_path();
     crate::persist::save_json_atomic(&path, file)?;
     invalidate_load_cache();
+    PROJECTS_CONTENT_GEN.fetch_add(1, Ordering::Relaxed);
     Ok(())
 }
 
@@ -996,5 +1026,52 @@ mod tests {
         // Idempotent — duplicate refs do not add rows.
         assert!(!sync_project_refs_in_file(&mut file, &refs));
         assert_eq!(file.projects.len(), 3);
+    }
+
+    fn ids(file: &ProjectsFile) -> Vec<&str> {
+        file.projects.iter().map(|p| p.id.as_str()).collect()
+    }
+
+    #[test]
+    fn reorder_projects_moves_first_to_last() {
+        let mut file = ProjectsFile {
+            projects: vec![
+                local_project("alpha", None),
+                local_project("beta", None),
+                local_project("gamma", None),
+            ],
+            active_id: None,
+        };
+
+        assert!(reorder_projects_in_file(&mut file, 0, 2));
+        assert_eq!(ids(&file), vec!["beta", "gamma", "alpha"]);
+    }
+
+    #[test]
+    fn reorder_projects_moves_last_to_first() {
+        let mut file = ProjectsFile {
+            projects: vec![
+                local_project("alpha", None),
+                local_project("beta", None),
+                local_project("gamma", None),
+            ],
+            active_id: None,
+        };
+
+        assert!(reorder_projects_in_file(&mut file, 2, 0));
+        assert_eq!(ids(&file), vec!["gamma", "alpha", "beta"]);
+    }
+
+    #[test]
+    fn reorder_projects_noop_when_from_equals_to_or_out_of_bounds() {
+        let mut file = ProjectsFile {
+            projects: vec![local_project("alpha", None), local_project("beta", None)],
+            active_id: None,
+        };
+
+        assert!(!reorder_projects_in_file(&mut file, 0, 0));
+        assert!(!reorder_projects_in_file(&mut file, 2, 0));
+        assert!(!reorder_projects_in_file(&mut file, 0, 2));
+        assert_eq!(ids(&file), vec!["alpha", "beta"]);
     }
 }

--- a/crates/er-desktop/src/snapshot.rs
+++ b/crates/er-desktop/src/snapshot.rs
@@ -2839,6 +2839,7 @@ fn build_projects(
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ProjectsCacheKey {
     projects_mtime_ns: u128,
+    projects_gen: u64,
     pr_cache_fingerprint: u64,
     meta_cache_fingerprint: u64,
     active_root: String,
@@ -2910,6 +2911,7 @@ fn build_projects_cache_key(
 
     ProjectsCacheKey {
         projects_mtime_ns,
+        projects_gen: projects::content_generation(),
         pr_cache_fingerprint,
         meta_cache_fingerprint,
         active_root: tab.repo_root.clone(),
@@ -4363,6 +4365,35 @@ mod tests {
         assert!(projects[0].recently_merged.is_empty());
         assert_eq!(projects[0].recent_prs.len(), 1);
         assert_eq!(projects[0].recent_prs[0].title, "Remote PR title");
+    }
+
+    #[test]
+    fn projects_snapshot_preserves_file_order() {
+        let tab = TabState::new_for_test(vec![]);
+        let record = |id: &str| projects::ProjectRecord {
+            id: id.to_string(),
+            name: id.to_string(),
+            root_path: format!("/tmp/{id}"),
+            remote: None,
+            dismissed_prs: Vec::new(),
+            tracked_prs: Vec::new(),
+            tracked_branches: Vec::new(),
+            dismissed_branches: Vec::new(),
+            recent_prs: Vec::new(),
+            saved_prs: Vec::new(),
+            auto_triage: false,
+            auto_triage_own_prs: false,
+            auto_triage_when: "new-and-push".to_string(),
+            auto_triage_max_diff_kb: 0,
+            review_ignore_globs: Vec::new(),
+        };
+        let file = projects::ProjectsFile {
+            projects: vec![record("zeta"), record("alpha")],
+            active_id: None,
+        };
+        let snaps = build_projects_from_file(&file, &tab, None, None, None, None);
+        let ids: Vec<&str> = snaps.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec!["zeta", "alpha"]);
     }
 
     #[test]

--- a/desktop-ui/src/lib/components/LeftSidebar.svelte
+++ b/desktop-ui/src/lib/components/LeftSidebar.svelte
@@ -6,6 +6,7 @@
   import type { BackgroundTaskSnapshot, InboxItemSnapshot, ProjectSnapshot, PrInfo } from "$lib/types";
   import { invoke } from "@tauri-apps/api/core";
   import { tick } from "svelte";
+  import { destIndexAfterRemove, dropSlot } from "$lib/listReorder";
 
   interface PinnedItem {
     id: string;
@@ -132,8 +133,15 @@
   let pendingDeleteProjectId = $state<string | null>(null);
   let pendingDeleteTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Project-row drag reorder. `dragFrom` is the source index in `projects`
+  // (search disables drag so filtered indices match persisted order). `dropAt`
+  // is the insertion gap (0..projects.length).
+  let dragFrom = $state<number | null>(null);
+  let dropAt = $state<number | null>(null);
+
   const sidebarSearchNeedle = $derived(sidebarSearch.trim().toLowerCase());
   const searchActive = $derived(sidebarSearchNeedle.length > 0);
+  const canReorder = $derived(!searchActive && projects.length > 1);
   const matchesSearch = (v: string): boolean => v.toLowerCase().includes(sidebarSearchNeedle);
   const filteredProjects = $derived(
     !sidebarSearchNeedle
@@ -427,6 +435,53 @@
 
   function toggleProject(p: ProjectSnapshot) {
     expandedProject = expandedProject === p.id ? null : p.id;
+  }
+
+  function handleProjectDragStart(e: DragEvent, idx: number) {
+    if (!canReorder) {
+      e.preventDefault();
+      return;
+    }
+    const target = e.target as HTMLElement | null;
+    if (target?.closest("[data-no-project-drag]")) {
+      e.preventDefault();
+      return;
+    }
+    dragFrom = idx;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(idx));
+    }
+  }
+
+  function dropSlotFor(e: DragEvent, idx: number, el: HTMLElement): number {
+    const rect = el.getBoundingClientRect();
+    return dropSlot(e.clientY, rect.top, rect.height, idx);
+  }
+
+  function handleProjectDragOver(e: DragEvent, idx: number) {
+    if (dragFrom === null) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    dropAt = dropSlotFor(e, idx, e.currentTarget as HTMLElement);
+  }
+
+  function handleProjectDrop(e: DragEvent, idx: number) {
+    if (dragFrom === null) return;
+    e.preventDefault();
+    const slot = dropSlotFor(e, idx, e.currentTarget as HTMLElement);
+    const toIdx = destIndexAfterRemove(dragFrom, slot);
+    const fromIdx = dragFrom;
+    dragFrom = null;
+    dropAt = null;
+    if (toIdx !== fromIdx) {
+      app.cmd("reorder_projects", { fromIdx, toIdx });
+    }
+  }
+
+  function handleProjectDragEnd() {
+    dragFrom = null;
+    dropAt = null;
   }
 
   async function deleteProject(project: ProjectSnapshot) {
@@ -1207,16 +1262,28 @@
     </div>
     <div class="space-y-0.5">
       {#if filteredProjects.length > 0}
-        {#each filteredProjects as project (project.id)}
+        {#each filteredProjects as project, i (project.id)}
           {@const badge = projectBadge(project)}
           {@const open = isProjectOpen(project)}
           <!-- Project header row: chevron + folder + name + badge + 3-dot menu -->
-          <div class="group relative">
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="group relative {dragFrom === i ? 'opacity-50' : ''}"
+            ondragover={(e) => handleProjectDragOver(e, i)}
+            ondrop={(e) => handleProjectDrop(e, i)}
+          >
+            {#if dragFrom !== null && dropAt === i}
+              <div class="absolute -top-px left-2 right-2 h-0.5 bg-accent rounded-full z-10" aria-hidden="true"></div>
+            {/if}
             <div class="flex items-center">
               <button
                 type="button"
+                draggable={canReorder}
                 onclick={() => toggleProject(project)}
-                class="flex-1 flex items-center gap-1.5 px-2 py-1.5 rounded-md hover:bg-hover text-[12px] text-left {project.is_active ? 'text-fg-2' : 'text-fg-3'} min-w-0"
+                ondragstart={(e) => handleProjectDragStart(e, i)}
+                ondragend={handleProjectDragEnd}
+                title={canReorder ? "Drag to reorder" : undefined}
+                class="flex-1 flex items-center gap-1.5 px-2 py-1.5 rounded-md hover:bg-hover text-[12px] text-left {project.is_active ? 'text-fg-2' : 'text-fg-3'} min-w-0 {canReorder ? 'cursor-grab active:cursor-grabbing' : ''}"
               >
                 <!-- Chevron caret: down when expanded, right when collapsed — 10px fg-muted -->
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="shrink-0 text-muted transition-transform {open ? '' : '-rotate-90'}">
@@ -1234,6 +1301,7 @@
               <!-- 3-dot more menu button — revealed on row hover -->
               <button
                 type="button"
+                data-no-project-drag
                 onclick={(e) => openProjectMenu(project.id, e)}
                 title="More options"
                 aria-label="More options for {project.name}"
@@ -1575,6 +1643,9 @@
             </div>
           {/if}
         {/each}
+        {#if dragFrom !== null && dropAt !== null && dropAt >= filteredProjects.length}
+          <div class="h-0.5 bg-accent rounded-full mx-2" aria-hidden="true"></div>
+        {/if}
       {:else if projects.length > 0 && sidebarSearchNeedle}
         <div class="px-2 py-2 text-[12px] text-muted">No matching projects, branches, or PRs.</div>
       {:else}

--- a/desktop-ui/src/lib/components/agent.md
+++ b/desktop-ui/src/lib/components/agent.md
@@ -6,7 +6,7 @@ This directory contains Desktop feature components. Most components are thin vie
 
 - `TabStrip.svelte`: open tab list, select/close/reorder tabs, panel toggles (left/tree/right). Backend commands: `new_tab`, `select_tab`, `close_tab`, `reorder_tabs`.
 - `BranchContextBar.svelte`: active branch chip, base label, copy branch/path actions (row below tab strip).
-- `LeftSidebar.svelte`: projects, tracked branches, PR buckets, refresh/dismiss/track actions.
+- `LeftSidebar.svelte`: projects, tracked branches, PR buckets, refresh/dismiss/track actions, drag-reorder projects (`reorder_projects`).
 - `BranchCard.svelte`: active branch/PR summary, GitHub status, checks/reviews, watcher state, GitHub refresh.
 - `FileTree.svelte`: file index, reviewed toggles, continuous diff jump-to-file behavior; optional `pickerMode` with checkboxes for multi-select (used by `AiReviewFilesModal`).
 - `DiffView.svelte`: continuous diff rendering, split/unified modes, windowed file bodies, inline findings/threads, diff selection and composers.

--- a/desktop-ui/src/lib/listReorder.test.ts
+++ b/desktop-ui/src/lib/listReorder.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { destIndexAfterRemove, dropSlot } from "./listReorder";
+
+describe("dropSlot", () => {
+  it("returns the item index when the pointer is in the first half", () => {
+    // Item 1 occupies [100, 140); midpoint 120.
+    expect(dropSlot(110, 100, 40, 1)).toBe(1);
+  });
+
+  it("returns the next gap when the pointer is in the second half", () => {
+    expect(dropSlot(130, 100, 40, 1)).toBe(2);
+  });
+});
+
+describe("destIndexAfterRemove", () => {
+  it("moves the first item to the end of a three-item list", () => {
+    // Drop after the last item: slot 3, from 0 → dest 2.
+    expect(destIndexAfterRemove(0, 3)).toBe(2);
+  });
+
+  it("moves the last item to the front", () => {
+    expect(destIndexAfterRemove(2, 0)).toBe(0);
+  });
+
+  it("is a no-op when dropping on the source (before or after its midpoint)", () => {
+    expect(destIndexAfterRemove(1, 1)).toBe(1);
+    expect(destIndexAfterRemove(1, 2)).toBe(1);
+  });
+});

--- a/desktop-ui/src/lib/listReorder.ts
+++ b/desktop-ui/src/lib/listReorder.ts
@@ -1,0 +1,23 @@
+/**
+ * Insertion-slot math for HTML5 list reorder (tabs, sidebar projects).
+ *
+ * `dropSlot` is the gap index in `0..=len` (before item 0 … after the last
+ * item). Removing `from` before inserting means a slot past the source maps
+ * to `slot - 1` as the destination index.
+ */
+
+/** Gap to insert at, from pointer position along the list axis. */
+export function dropSlot(
+  clientPos: number,
+  start: number,
+  size: number,
+  idx: number,
+): number {
+  const after = clientPos > start + size / 2;
+  return after ? idx + 1 : idx;
+}
+
+/** Destination index after removing `from`, given a drop `slot` (`0..=len`). */
+export function destIndexAfterRemove(from: number, slot: number): number {
+  return slot > from ? slot - 1 : slot;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drag a project in the left sidebar to change its order. The new order is written to `projects.json` and restored on the next launch.

## What changed

- **Sidebar.** Project rows are draggable when there are two or more projects and the sidebar search is empty. A drop marker shows the insertion point; the 3-dot menu is excluded from the drag handle.
- **Persistence.** `reorder_projects` moves the matching `ProjectRecord` in the on-disk list. Snapshot caching keys off a save generation so a reorder is visible even when filesystem mtime would not change.
- **Display contract.** `build_projects_from_file` already emits projects in file order; a test now locks that in.

## Tests

- `cargo test -p er-desktop --lib -- reorder_projects projects_snapshot_preserves_file_order`
- `bun test src/lib/listReorder.test.ts` (drop-slot / dest-index math)
- `bun run check` (0 errors)

Drag is disabled while searching so filtered indices cannot write the wrong persisted order. New projects still append at the end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4763bcc-1323-47e7-9dd7-5c6f72e72288?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4763bcc-1323-47e7-9dd7-5c6f72e72288&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

